### PR TITLE
Add contributor guide and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a reproducible problem in Talos Protocol
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the problem and the user-visible impact.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should happen?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- Area: web / agent / contracts / docs
+- Browser or runtime:
+- Node version:
+- Python version:
+- Rust version:
+- Network: Stellar testnet / local / other
+
+## Logs or Screenshots
+
+Paste relevant logs, screenshots, or transaction links. Remove secrets and private keys.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user or contributor problem should this solve?
+
+## Proposed Solution
+
+Describe the change you want to see.
+
+## Alternatives Considered
+
+List any other approaches you considered.
+
+## Affected Areas
+
+- [ ] Web app
+- [ ] Agent runtime
+- [ ] Soroban contracts
+- [ ] Documentation
+- [ ] Deployment or infrastructure
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Additional Context
+
+Add mockups, examples, links, or implementation notes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+-
+
+## Related Issue
+
+Closes #
+
+## Test Plan
+
+- [ ] `pnpm lint`
+- [ ] `pnpm --dir web test:e2e`
+- [ ] `cd packages/prime-agent && uv run pytest`
+- [ ] `cd contracts && cargo test`
+- [ ] Screenshots or recording attached for UI changes
+- [ ] Not applicable checks are explained below
+
+## Notes
+
+-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+contracts/** @enliven17
+web/src/lib/stellar* @enliven17
+web/src/lib/auth.ts @enliven17
+packages/prime-agent/src/talos_agent/payments/** @enliven17

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Talos Protocol
+
+Thanks for helping improve Talos Protocol. This monorepo contains a Next.js web app, a Python agent runtime, and Soroban contracts, so most changes only need the setup for the subproject they touch.
+
+## Prerequisites
+
+- Node.js 20 or newer
+- pnpm 9 or newer
+- Python 3.11 or newer
+- uv for Python dependency management
+- Rust stable with the `wasm32-unknown-unknown` target
+- Soroban CLI configured for Stellar testnet contract work
+
+## Clone and Install
+
+```bash
+git clone https://github.com/enliven17/talos-stellar.git
+cd talos-stellar
+pnpm install
+```
+
+The web app keeps its environment example in `web/.env.example`. Copy it before running local web or API routes:
+
+```bash
+cp web/.env.example web/.env.local
+```
+
+Agent runtime secrets are loaded from `packages/prime-agent/.env`. Create that file locally when working on the agent service, and do not commit real keys or API tokens.
+
+## Web App
+
+The web app lives in `web/` and contains the Next.js frontend plus API routes.
+
+```bash
+pnpm install
+pnpm dev
+pnpm lint
+pnpm --dir web test:e2e
+```
+
+For database work, use the web package scripts:
+
+```bash
+pnpm web:db:push
+pnpm web:db:seed
+```
+
+## Agent Runtime
+
+The Prime Agent service lives in `packages/prime-agent/`.
+
+```bash
+cd packages/prime-agent
+uv sync --extra dev
+uv run talos-agent start
+uv run pytest
+```
+
+Use this setup for changes under `packages/prime-agent/src/talos_agent/`, including browser automation, scheduler, tool registry, and payment logic.
+
+## Soroban Contracts
+
+The contracts live in `contracts/`.
+
+```bash
+cd contracts
+cargo test
+cargo build --target wasm32-unknown-unknown --release
+```
+
+Use the package scripts when you want the named contract commands:
+
+```bash
+pnpm --dir contracts test
+pnpm --dir contracts build:registry
+pnpm --dir contracts build:name-service
+```
+
+Deploy commands target Stellar testnet and require a configured Soroban account:
+
+```bash
+pnpm --dir contracts deploy:testnet
+pnpm --dir contracts deploy:name-service:testnet
+```
+
+## Pull Request Checklist
+
+Before opening a PR:
+
+- Link the related issue with `Closes #N` or `Fixes #N`.
+- Keep the change focused on one issue.
+- Run the checks for every subproject you changed.
+- Include screenshots or screen recordings for UI changes.
+- Document any skipped checks with the reason.
+- Verify that no secrets, private keys, or local `.env` files are committed.
+
+The PR template in `.github/PULL_REQUEST_TEMPLATE.md` lists the same expectations so reviewers can triage changes quickly.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Autonomous agent corporations on Stellar. Agents register on-chain, sell services, earn USDC via x402 nanopayments, and operate without human intervention.
 
+New contributors should start with [CONTRIBUTING.md](CONTRIBUTING.md) for setup, test commands, and PR expectations.
+
 ## What it is
 
 Each **Talos** is an AI agent with its own Stellar wallet, service listing, and revenue stream. Agents discover each other, purchase services peer-to-peer, and report activity — all on Stellar testnet.


### PR DESCRIPTION
/claim #12

## Summary
- Add CONTRIBUTING.md with setup and test commands for the web app, prime-agent runtime, and Soroban contracts.
- Add a pull request template plus bug report and feature request issue templates.
- Add CODEOWNERS entries for the requested critical paths and link the contributor guide from README.md.

## Verification
- git diff --check
- Content check for required prerequisites, subproject commands, PR/issue templates, CODEOWNERS critical paths, and README contributor link.
- No runtime tests were run because this is a docs/config-only change.

Payout address (Binance Smart Chain / BSC-BEP20): 0xe80506A1431B3B4aAca8B260838481deBbdF75Ab