### PR TITLE
feat : Build modular social channel adapter interface in agent

### DIFF
--- a/packages/prime-agent/src/talos_agent/adapters/__init__.py
+++ b/packages/prime-agent/src/talos_agent/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Social channel adapters — modular publishing interface."""
+
+from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.adapters.registry import AdapterRegistry
+
+__all__ = ["BaseSocialAdapter", "ChannelCapabilities", "PublishResult", "AdapterRegistry"]

--- a/packages/prime-agent/src/talos_agent/adapters/base.py
+++ b/packages/prime-agent/src/talos_agent/adapters/base.py
@@ -1,0 +1,88 @@
+"""Base social adapter interface — all channel adapters implement this."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ChannelCapabilities:
+    char_limit: int | None  # None = no enforced limit
+    supports_media: bool = False
+    supports_threads: bool = False
+    supports_replies: bool = True
+    supports_search: bool = False
+    supports_mentions: bool = False
+    supports_analytics: bool = False
+
+
+@dataclass
+class PublishResult:
+    status: str  # "posted" | "failed" | "pending"
+    channel: str
+    content: str
+    post_id: str | None = None
+    url: str | None = None
+    error: str | None = None
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
+class BaseSocialAdapter(ABC):
+    """Abstract base class for all social channel publishing adapters.
+
+    Subclasses must declare a ``channel_name`` class attribute and implement
+    all abstract methods.  The adapter is responsible for authentication,
+    content validation, and interacting with the channel.
+    """
+
+    channel_name: str  # e.g. "X", "LinkedIn", "Farcaster"
+
+    # ── Content ─────────────────────────────────────────────
+
+    @abstractmethod
+    async def post(self, content: str, **kwargs) -> PublishResult:
+        """Publish a new post to the channel."""
+
+    @abstractmethod
+    async def reply(self, target_url: str, content: str, **kwargs) -> PublishResult:
+        """Reply to an existing post."""
+
+    # ── Discovery ────────────────────────────────────────────
+
+    @abstractmethod
+    async def get_mentions(self, **kwargs) -> list[dict]:
+        """Fetch recent mentions or notifications."""
+
+    @abstractmethod
+    async def search(self, query: str, **kwargs) -> list[dict]:
+        """Search for posts matching a keyword query."""
+
+    # ── Analytics ────────────────────────────────────────────
+
+    @abstractmethod
+    async def get_post_performance(self, content_snippet: str, **kwargs) -> dict:
+        """Return engagement metrics for a post identified by a content snippet."""
+
+    @abstractmethod
+    async def get_profile_stats(self, **kwargs) -> dict:
+        """Return channel profile statistics (followers, posts, etc.)."""
+
+    # ── Capabilities ─────────────────────────────────────────
+
+    @abstractmethod
+    def get_capabilities(self) -> ChannelCapabilities:
+        """Return the feature capabilities of this channel."""
+
+    def validate_content(self, content: str) -> tuple[bool, str | None]:
+        """Return (is_valid, error_message).  Enforces char_limit if set."""
+        caps = self.get_capabilities()
+        if caps.char_limit and len(content) > caps.char_limit:
+            return (
+                False,
+                f"Content is {len(content)} chars — exceeds the {caps.char_limit} character limit for {self.channel_name}.",
+            )
+        return True, None

--- a/packages/prime-agent/src/talos_agent/adapters/registry.py
+++ b/packages/prime-agent/src/talos_agent/adapters/registry.py
@@ -1,0 +1,31 @@
+"""AdapterRegistry — maps channel names to BaseSocialAdapter instances."""
+
+from __future__ import annotations
+
+from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities
+
+
+class AdapterRegistry:
+    """Holds all registered channel adapters and routes publishing calls."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, BaseSocialAdapter] = {}
+
+    def register(self, adapter: BaseSocialAdapter) -> None:
+        """Register an adapter under its channel_name (case-insensitive key)."""
+        self._adapters[adapter.channel_name.lower()] = adapter
+
+    def get(self, channel: str) -> BaseSocialAdapter | None:
+        return self._adapters.get(channel.lower())
+
+    def available_channels(self) -> list[str]:
+        return [a.channel_name for a in self._adapters.values()]
+
+    def capabilities(self) -> dict[str, dict]:
+        return {
+            a.channel_name: a.get_capabilities().__dict__
+            for a in self._adapters.values()
+        }
+
+    def __len__(self) -> int:
+        return len(self._adapters)

--- a/packages/prime-agent/src/talos_agent/adapters/x.py
+++ b/packages/prime-agent/src/talos_agent/adapters/x.py
@@ -1,0 +1,260 @@
+"""X (Twitter) channel adapter — browser-based posting via Stagehand."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+
+if TYPE_CHECKING:
+    from talos_agent.browser.session import BrowserSession
+    from talos_agent.config import Settings
+
+console = Console()
+
+_CHAR_LIMIT = 280
+_LOGIN_URL = "https://x.com/i/flow/login"
+_HOME_URL = "https://x.com/home"
+_MENTIONS_URL = "https://x.com/notifications/mentions"
+_SEARCH_URL = "https://x.com/search?q={query}&src=typed_query&f=live"
+_PROFILE_URL = "https://x.com/{username}"
+
+
+class XAdapter(BaseSocialAdapter):
+    """Publishes to X (Twitter) using Stagehand browser automation."""
+
+    channel_name = "X"
+
+    def __init__(self, browser: BrowserSession, settings: Settings) -> None:
+        self._browser = browser
+        self._settings = settings
+        self._logged_in = False
+        self._cookie_dismissed = False
+
+    # ── Capabilities ─────────────────────────────────────────
+
+    def get_capabilities(self) -> ChannelCapabilities:
+        return ChannelCapabilities(
+            char_limit=_CHAR_LIMIT,
+            supports_media=True,
+            supports_threads=True,
+            supports_replies=True,
+            supports_search=True,
+            supports_mentions=True,
+            supports_analytics=True,
+        )
+
+    # ── Auth ─────────────────────────────────────────────────
+
+    async def _dismiss_cookie_banner(self) -> None:
+        try:
+            await self._browser.act(
+                "Click the 'Accept all cookies' button at the bottom of the page. "
+                "It is a dark button with white text that says 'Accept all cookies'."
+            )
+            await asyncio.sleep(2)
+        except Exception:
+            pass
+
+    async def _ensure_login(self) -> None:
+        if self._logged_in:
+            return
+
+        if not self._settings.x_username or not self._settings.x_password:
+            console.print("[yellow]X credentials not configured — skipping login.[/yellow]")
+            return
+
+        console.print("[dim]Checking X login status...[/dim]")
+        await self._browser.goto(_HOME_URL)
+        await asyncio.sleep(3)
+
+        if not self._cookie_dismissed:
+            await self._dismiss_cookie_banner()
+            self._cookie_dismissed = True
+
+        page_info = await self._browser.extract(
+            "Is the user logged in to X/Twitter? "
+            "If you see a compose/post box or timeline feed → logged_in: true. "
+            "If you see a login form, sign-in button, or 'Sign in' text → logged_in: false.",
+            schema={"type": "object", "properties": {"logged_in": {"type": "boolean"}}, "required": ["logged_in"]},
+        )
+        if isinstance(page_info, dict) and page_info.get("logged_in"):
+            console.print("[green]Already logged in to X.[/green]")
+            self._logged_in = True
+            return
+
+        console.print("[bold]Logging in to X...[/bold]")
+        await self._browser.goto(_LOGIN_URL)
+        await asyncio.sleep(4)
+
+        await self._browser.act(
+            f"Click on the username or email input field and type: {self._settings.x_username}"
+        )
+        await asyncio.sleep(2)
+        await self._browser.act("Click the Next button")
+        await asyncio.sleep(4)
+
+        # X sometimes requests email/phone verification before the password step
+        check = await self._browser.extract(
+            "What is the current page asking for? "
+            "email or phone verification → type: 'verification'. "
+            "password field → type: 'password'. "
+            "something else → type: 'other'.",
+            schema={"type": "object", "properties": {"type": {"type": "string"}}, "required": ["type"]},
+        )
+        page_type = check.get("type", "other") if isinstance(check, dict) else "other"
+        if page_type == "verification" and self._settings.x_email:
+            await self._browser.act(
+                f"Click on the input field and type: {self._settings.x_email}"
+            )
+            await asyncio.sleep(1)
+            await self._browser.act("Click the Next button")
+            await asyncio.sleep(4)
+
+        await self._browser.act(
+            f"Click on the password input field and type: {self._settings.x_password}"
+        )
+        await asyncio.sleep(1)
+        await self._browser.act("Click the Log in button")
+        await asyncio.sleep(5)
+
+        post_login = await self._browser.extract(
+            "Is the user now logged in to X/Twitter? "
+            "If you see a timeline, home feed, or compose button → logged_in: true. "
+            "Otherwise → logged_in: false.",
+            schema={"type": "object", "properties": {"logged_in": {"type": "boolean"}}, "required": ["logged_in"]},
+        )
+        if isinstance(post_login, dict) and post_login.get("logged_in"):
+            console.print("[bold green]Successfully logged in to X.[/bold green]")
+            self._logged_in = True
+        else:
+            console.print("[red]X login may have failed — continuing anyway.[/red]")
+
+    # ── Publishing ───────────────────────────────────────────
+
+    async def post(self, content: str, **kwargs) -> PublishResult:
+        valid, error = self.validate_content(content)
+        if not valid:
+            return PublishResult(status="failed", channel=self.channel_name, content=content, error=error)
+
+        await self._ensure_login()
+        await self._dismiss_cookie_banner()
+
+        # Use Playwright keyboard shortcuts directly — bypasses Stagehand LLM overhead
+        await self._browser.keyboard_press("n")
+        await asyncio.sleep(2)
+        await self._browser.keyboard_type(content)
+        await asyncio.sleep(2)
+        await self._browser.keyboard_press("Control+Enter")
+        await asyncio.sleep(4)
+
+        verify = await self._browser.extract(
+            "Is there a compose tweet dialog/modal currently open on the page? "
+            "If no dialog is open and you see the timeline → dialog_open: false. "
+            "If the compose dialog is still visible with text → dialog_open: true.",
+            schema={"type": "object", "properties": {"dialog_open": {"type": "boolean"}}, "required": ["dialog_open"]},
+        )
+        dialog_open = bool(verify.get("dialog_open")) if isinstance(verify, dict) else True
+        if dialog_open:
+            try:
+                await self._browser.act("Press the Escape key")
+                await asyncio.sleep(1)
+                await self._browser.act("Click the 'Discard' button")
+            except Exception:
+                pass
+            return PublishResult(
+                status="failed",
+                channel=self.channel_name,
+                content=content,
+                error="Post failed — compose dialog still open. Tweet was NOT published.",
+            )
+
+        return PublishResult(status="posted", channel=self.channel_name, content=content)
+
+    async def reply(self, target_url: str, content: str, **kwargs) -> PublishResult:
+        await self._ensure_login()
+        await self._browser.goto(target_url)
+        await asyncio.sleep(2)
+        await self._browser.act("Click the reply button")
+        await self._browser.act(f"Type the following reply: {content}")
+        await self._browser.act("Click the Reply button to post")
+        return PublishResult(
+            status="posted",
+            channel=self.channel_name,
+            content=content,
+            metadata={"target_url": target_url},
+        )
+
+    # ── Discovery ────────────────────────────────────────────
+
+    async def get_mentions(self, **kwargs) -> list[dict]:
+        await self._ensure_login()
+        await self._browser.goto(_MENTIONS_URL)
+        await asyncio.sleep(2)
+        result = await self._browser.extract(
+            "Extract the latest 10 mentions: author handle, text content, tweet URL, and timestamp"
+        )
+        return result if isinstance(result, list) else []
+
+    async def search(self, query: str, **kwargs) -> list[dict]:
+        await self._ensure_login()
+        await self._browser.goto(_SEARCH_URL.format(query=query))
+        await asyncio.sleep(2)
+        results = await self._browser.extract(
+            "Extract the top 10 posts: author handle, text content, engagement (likes, reposts), and tweet URL"
+        )
+        return results if isinstance(results, list) else []
+
+    # ── Analytics ────────────────────────────────────────────
+
+    async def get_post_performance(self, content_snippet: str, **kwargs) -> dict:
+        await self._ensure_login()
+        username = self._settings.x_username
+        if not username:
+            return {"error": "X username not configured"}
+        await self._browser.goto(_PROFILE_URL.format(username=username))
+        await asyncio.sleep(3)
+        metrics = await self._browser.extract(
+            f"Find the tweet that contains text similar to: '{content_snippet[:80]}'. "
+            "Extract: likes (number), reposts/retweets (number), replies (number), "
+            "views/impressions (number), and the tweet URL. "
+            "If not found, return found: false.",
+            schema={
+                "type": "object",
+                "properties": {
+                    "found": {"type": "boolean"},
+                    "likes": {"type": "integer"},
+                    "reposts": {"type": "integer"},
+                    "replies": {"type": "integer"},
+                    "impressions": {"type": "integer"},
+                    "tweet_url": {"type": "string"},
+                },
+                "required": ["found"],
+            },
+        )
+        return metrics if isinstance(metrics, dict) else {"found": False}
+
+    async def get_profile_stats(self, **kwargs) -> dict:
+        await self._ensure_login()
+        username = self._settings.x_username
+        if not username:
+            return {"error": "X username not configured"}
+        await self._browser.goto(_PROFILE_URL.format(username=username))
+        await asyncio.sleep(3)
+        stats = await self._browser.extract(
+            "Extract the profile stats: followers count (number), following count (number), "
+            "total posts count (number).",
+            schema={
+                "type": "object",
+                "properties": {
+                    "followers": {"type": "integer"},
+                    "following": {"type": "integer"},
+                    "total_posts": {"type": "integer"},
+                },
+                "required": ["followers"],
+            },
+        )
+        return stats if isinstance(stats, dict) else {"error": "Could not extract profile stats"}

--- a/packages/prime-agent/src/talos_agent/agent/prompt.py
+++ b/packages/prime-agent/src/talos_agent/agent/prompt.py
@@ -87,7 +87,7 @@ Act → Measure → Learn → Adapt → Act. You don't just post — you learn w
 ## IMPORTANT: Complete the Full Cycle
 - Research alone is NOT a completed action. After researching, you MUST create content and post it.
 - Every agent cycle should aim to produce at least one visible output (a post, a reply, or a fulfilled job).
-- The workflow is: research → write post (under 280 chars, plain text) → post_to_x → record_post → report_activity.
+- The workflow is: research → get_publishing_channels → write post (respecting each channel's character limit) → publish_content → record_post → report_activity.
 - Do NOT end a cycle after only saving research notes. Always follow through to posting.
 
 ## Learning Loop Rules
@@ -149,6 +149,7 @@ Act → Measure → Learn → Adapt → Act. You don't just post — you learn w
 - ALWAYS call report_revenue after fulfilling a paid job
 - Keep posts aligned with persona and tone
 - When purchasing a Playbook, apply it to improve future strategy
+- Always call get_publishing_channels before composing content to check available channels and their character limits.
 - X (Twitter) posts MUST be under 280 characters. No markdown formatting (no **bold**, no bullet lists). Write plain text with emojis and hashtags only.
 - Do NOT include raw search queries or URLs in posts unless intentional
 

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -68,6 +68,10 @@ class Settings(BaseSettings):
     x_password: str = ""
     x_email: str = ""
 
+    # Per-channel credential configs for additional adapters.
+    # Set as JSON in env: CHANNEL_CONFIGS={"linkedin": {"access_token": "..."}}
+    channel_configs: dict = Field(default_factory=dict, description="Per-channel credentials map")
+
     # Agent behaviour
     agent_cycle_interval: int = Field(default=30, description="Seconds between agent cycles")
     polling_interval: int = Field(default=10, description="Seconds between API polls")

--- a/packages/prime-agent/src/talos_agent/db.py
+++ b/packages/prime-agent/src/talos_agent/db.py
@@ -180,6 +180,14 @@ class LocalDB:
         ).fetchone()
         return row["cnt"] if row else 0
 
+    def count_today_by_channel(self, type_: str, channel: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) as cnt FROM activity_log "
+            "WHERE type = ? AND channel = ? AND date(created_at) = date('now')",
+            (type_, channel),
+        ).fetchone()
+        return row["cnt"] if row else 0
+
     # ── Content History ────────────────────────────────────
 
     def add_content(self, content: str, channel: str) -> None:
@@ -193,6 +201,14 @@ class LocalDB:
         rows = self._conn.execute(
             "SELECT content, channel, posted_at FROM content_history ORDER BY posted_at DESC LIMIT ?",
             (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_recent_content_by_channel(self, channel: str, limit: int = 20) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT content, channel, posted_at FROM content_history "
+            "WHERE channel = ? ORDER BY posted_at DESC LIMIT ?",
+            (channel, limit),
         ).fetchall()
         return [dict(r) for r in rows]
 
@@ -369,6 +385,21 @@ class LocalDB:
             "LEFT JOIN content_performance cp ON cp.content_id = ch.id "
             "WHERE ch.posted_at >= datetime('now', ?)",
             (f"-{days} days",),
+        ).fetchone()
+        return dict(row) if row else {}
+
+    def get_performance_summary_by_channel(self, channel: str, days: int = 7) -> dict:
+        row = self._conn.execute(
+            "SELECT COUNT(*) as total_posts, "
+            "COALESCE(SUM(cp.likes), 0) as total_likes, "
+            "COALESCE(SUM(cp.reposts), 0) as total_reposts, "
+            "COALESCE(SUM(cp.replies), 0) as total_replies, "
+            "COALESCE(SUM(cp.impressions), 0) as total_impressions, "
+            "COALESCE(AVG(cp.likes + cp.reposts * 2 + cp.replies * 1.5), 0) as avg_engagement "
+            "FROM content_history ch "
+            "LEFT JOIN content_performance cp ON cp.content_id = ch.id "
+            "WHERE ch.channel = ? AND ch.posted_at >= datetime('now', ?)",
+            (channel, f"-{days} days"),
         ).fetchone()
         return dict(row) if row else {}
 

--- a/packages/prime-agent/src/talos_agent/tools/browser.py
+++ b/packages/prime-agent/src/talos_agent/tools/browser.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from talos_agent.tools.registry import tool
 
 if TYPE_CHECKING:
+    from talos_agent.adapters.registry import AdapterRegistry
     from talos_agent.browser.session import BrowserSession
     from talos_agent.config import Settings
 
@@ -19,94 +20,9 @@ console = Console()
 # Injected by registry.build_all_tools
 _browser: BrowserSession = None  # type: ignore[assignment]
 _settings: Settings = None  # type: ignore[assignment]
+_adapter_registry: AdapterRegistry = None  # type: ignore[assignment]
 
 BROWSER_TIMEOUT = 90  # seconds per browser action
-_x_logged_in = False
-_cookie_dismissed = False
-
-
-async def _ensure_x_login() -> None:
-    """Navigate to X and log in if not already authenticated."""
-    global _x_logged_in, _cookie_dismissed
-    if _x_logged_in:
-        return
-
-    if not _settings or not _settings.x_username or not _settings.x_password:
-        console.print("[yellow]X credentials not configured — skipping login.[/yellow]")
-        return
-
-    console.print("[dim]Checking X login status...[/dim]")
-    await _browser.goto("https://x.com/home")
-    await asyncio.sleep(3)
-
-    # Dismiss cookie banner once (this IS a page DOM element)
-    if not _cookie_dismissed:
-        await _dismiss_cookie_banner()
-        _cookie_dismissed = True
-
-    page_info = await _browser.extract(
-        "Is the user logged in to X/Twitter? "
-        "If you see a compose/post box or timeline feed → logged_in: true. "
-        "If you see a login form, sign-in button, or 'Sign in' text → logged_in: false.",
-        schema={"type": "object", "properties": {"logged_in": {"type": "boolean"}}, "required": ["logged_in"]},
-    )
-
-    is_logged_in = bool(page_info.get("logged_in")) if isinstance(page_info, dict) else False
-
-    if is_logged_in:
-        console.print("[green]Already logged in to X.[/green]")
-        _x_logged_in = True
-        if not _cookie_dismissed:
-            await _dismiss_cookie_banner()
-            _cookie_dismissed = True
-        return
-
-    console.print("[bold]Logging in to X...[/bold]")
-
-    await _browser.goto("https://x.com/i/flow/login")
-    await asyncio.sleep(4)
-
-    await _browser.act(f"Click on the username or email input field and type: {_settings.x_username}")
-    await asyncio.sleep(2)
-    await _browser.act("Click the Next button")
-    await asyncio.sleep(4)
-
-    # X sometimes asks for email/phone verification before password
-    verification_check = await _browser.extract(
-        "What is the current page asking for? "
-        "If it asks for email or phone verification → type: 'verification'. "
-        "If it shows a password field → type: 'password'. "
-        "If it shows something else → type: 'other'.",
-        schema={"type": "object", "properties": {"type": {"type": "string"}}, "required": ["type"]},
-    )
-
-    page_type = verification_check.get("type", "other") if isinstance(verification_check, dict) else "other"
-
-    if page_type == "verification" and _settings.x_email:
-        await _browser.act(f"Click on the input field and type: {_settings.x_email}")
-        await asyncio.sleep(1)
-        await _browser.act("Click the Next button")
-        await asyncio.sleep(4)
-
-    await _browser.act(f"Click on the password input field and type: {_settings.x_password}")
-    await asyncio.sleep(1)
-    await _browser.act("Click the Log in button")
-    await asyncio.sleep(5)
-
-    post_login = await _browser.extract(
-        "Is the user now logged in to X/Twitter? "
-        "If you see a timeline, home feed, or compose button → logged_in: true. "
-        "Otherwise → logged_in: false.",
-        schema={"type": "object", "properties": {"logged_in": {"type": "boolean"}}, "required": ["logged_in"]},
-    )
-
-    success = bool(post_login.get("logged_in")) if isinstance(post_login, dict) else False
-
-    if success:
-        console.print("[bold green]Successfully logged in to X.[/bold green]")
-        _x_logged_in = True
-    else:
-        console.print("[red]X login may have failed — continuing anyway.[/red]")
 
 
 def _browser_safe(fn: Callable) -> Callable:
@@ -124,8 +40,11 @@ def _browser_safe(fn: Callable) -> Callable:
             err_name = type(e).__name__
             if "session" in str(e).lower() or "closed" in str(e).lower() or "500" in str(e):
                 try:
-                    global _x_logged_in
-                    _x_logged_in = False
+                    # Reset session-dependent state on all adapters that track login
+                    if _adapter_registry:
+                        x_adapter = _adapter_registry.get("X")
+                        if x_adapter and hasattr(x_adapter, "_logged_in"):
+                            x_adapter._logged_in = False
                     await _browser.reconnect()
                     return await asyncio.wait_for(fn(*args, **kwargs), timeout=BROWSER_TIMEOUT)
                 except Exception as retry_err:
@@ -135,16 +54,19 @@ def _browser_safe(fn: Callable) -> Callable:
     return wrapper
 
 
-def _x_login_required(fn: Callable) -> Callable:
-    """Ensure X login before executing the wrapped tool."""
+async def _dismiss_cookie_banner() -> None:
+    """Dismiss a generic cookie consent banner (Google, etc.)."""
+    try:
+        await _browser.act(
+            "Click the 'Accept all cookies' button at the bottom of the page. "
+            "It is a dark button with white text that says 'Accept all cookies'."
+        )
+        await asyncio.sleep(2)
+    except Exception:
+        pass
 
-    @functools.wraps(fn)
-    async def wrapper(*args: Any, **kwargs: Any) -> dict:
-        await _ensure_x_login()
-        return await fn(*args, **kwargs)
 
-    return wrapper
-
+# ── General browser tools ────────────────────────────────────────────────────
 
 @tool("search_web", "Search Google and return top results for market research")
 @_browser_safe
@@ -160,18 +82,6 @@ async def search_web(query: str) -> dict:
     return {"query": query, "results": results}
 
 
-async def _dismiss_cookie_banner() -> None:
-    """Dismiss X's cookie consent banner. Always attempts the click without checking first."""
-    try:
-        await _browser.act(
-            "Click the 'Accept all cookies' button at the bottom of the page. "
-            "It is a dark button with white text that says 'Accept all cookies'."
-        )
-        await asyncio.sleep(2)
-    except Exception:
-        pass
-
-
 @tool("browse_page", "Visit a URL and extract information based on instructions")
 @_browser_safe
 async def browse_page(url: str, instruction: str) -> dict:
@@ -180,84 +90,47 @@ async def browse_page(url: str, instruction: str) -> dict:
     return {"url": url, "data": data}
 
 
+# ── Legacy X (Twitter) tools — delegate to XAdapter ─────────────────────────
+# These exist for backward compatibility with prompts that reference X-specific
+# tool names. New code should use publish_content / get_publishing_channels.
+
 @tool("post_to_x", "Post a tweet on X (Twitter). Content MUST be under 280 characters, plain text only.")
 @_browser_safe
-@_x_login_required
 async def post_to_x(content: str) -> dict:
-    if len(content) > 280:
-        return {"error": f"Post is {len(content)} chars — exceeds 280 char limit. Shorten it and try again."}
-
-    # Dismiss cookie banner first — it can block interactions
-    await _dismiss_cookie_banner()
-
-    # Use Playwright keyboard directly — bypasses Stagehand LLM entirely
-    # Step 1: Press 'N' to open compose modal (X keyboard shortcut)
-    await _browser.keyboard_press("n")
-    await asyncio.sleep(2)
-
-    # Step 2: Type content (text area is auto-focused by X after pressing N)
-    await _browser.keyboard_type(content)
-    await asyncio.sleep(2)
-
-    # Step 3: Press Ctrl+Enter to post (X keyboard shortcut)
-    await _browser.keyboard_press("Control+Enter")
-    await asyncio.sleep(4)
-
-    # Step 4: Verify — if modal closed, post succeeded
-    verify = await _browser.extract(
-        "Is there a compose tweet dialog/modal currently open on the page? "
-        "If no dialog is open and you see the timeline → dialog_open: false. "
-        "If the compose dialog is still visible with text → dialog_open: true.",
-        schema={"type": "object", "properties": {"dialog_open": {"type": "boolean"}}, "required": ["dialog_open"]},
-    )
-
-    dialog_open = bool(verify.get("dialog_open")) if isinstance(verify, dict) else True
-    if dialog_open:
-        # Close modal: Escape → Discard (no beforeunload from modal)
-        try:
-            await _browser.act("Press the Escape key")
-            await asyncio.sleep(1)
-            await _browser.act("Click the 'Discard' button")
-        except Exception:
-            pass
-        return {"error": "Post failed — compose dialog still open. Tweet was NOT published."}
-
-    return {"status": "posted", "content": content, "channel": "X"}
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    result = await adapter.post(content)
+    return result.to_dict()
 
 
 @tool("check_x_mentions", "Check X notifications/mentions and return unread items")
 @_browser_safe
-@_x_login_required
 async def check_x_mentions() -> dict:
-    await _browser.goto("https://x.com/notifications/mentions")
-    await asyncio.sleep(2)
-    mentions = await _browser.extract(
-        "Extract the latest 10 mentions: author handle, text content, tweet URL, and timestamp"
-    )
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    mentions = await adapter.get_mentions()
     return {"mentions": mentions}
 
 
 @tool("reply_on_x", "Reply to a specific tweet on X")
 @_browser_safe
-@_x_login_required
 async def reply_on_x(tweet_url: str, content: str) -> dict:
-    await _browser.goto(tweet_url)
-    await asyncio.sleep(2)
-    await _browser.act("Click the reply button")
-    await _browser.act(f"Type the following reply: {content}")
-    await _browser.act("Click the Reply button to post")
-    return {"status": "replied", "tweet_url": tweet_url, "content": content}
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    result = await adapter.reply(tweet_url, content)
+    return result.to_dict()
 
 
 @tool("search_x", "Search X for keywords and extract relevant posts")
 @_browser_safe
-@_x_login_required
 async def search_x(query: str) -> dict:
-    await _browser.goto(f"https://x.com/search?q={query}&src=typed_query&f=live")
-    await asyncio.sleep(2)
-    results = await _browser.extract(
-        "Extract the top 10 posts: author handle, text content, engagement (likes, reposts), and tweet URL"
-    )
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    results = await adapter.search(query)
     return {"query": query, "results": results}
 
 
@@ -267,34 +140,11 @@ async def search_x(query: str) -> dict:
     "Navigates to the user's profile and extracts metrics for the matching post.",
 )
 @_browser_safe
-@_x_login_required
 async def check_post_performance(content_snippet: str) -> dict:
-    username = _settings.x_username if _settings else ""
-    if not username:
-        return {"error": "X username not configured"}
-
-    await _browser.goto(f"https://x.com/{username}")
-    await asyncio.sleep(3)
-
-    metrics = await _browser.extract(
-        f"Find the tweet that contains the text similar to: '{content_snippet[:80]}'. "
-        "Extract: likes (number), reposts/retweets (number), replies (number), "
-        "views/impressions (number), and the tweet URL. "
-        "If not found, return found: false.",
-        schema={
-            "type": "object",
-            "properties": {
-                "found": {"type": "boolean"},
-                "likes": {"type": "integer"},
-                "reposts": {"type": "integer"},
-                "replies": {"type": "integer"},
-                "impressions": {"type": "integer"},
-                "tweet_url": {"type": "string"},
-            },
-            "required": ["found"],
-        },
-    )
-    return metrics if isinstance(metrics, dict) else {"found": False}
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    return await adapter.get_post_performance(content_snippet)
 
 
 @tool(
@@ -302,26 +152,8 @@ async def check_post_performance(content_snippet: str) -> dict:
     "Get current X profile stats: follower count, following count, total posts.",
 )
 @_browser_safe
-@_x_login_required
 async def get_profile_stats() -> dict:
-    username = _settings.x_username if _settings else ""
-    if not username:
-        return {"error": "X username not configured"}
-
-    await _browser.goto(f"https://x.com/{username}")
-    await asyncio.sleep(3)
-
-    stats = await _browser.extract(
-        "Extract the profile stats: followers count (number), following count (number), "
-        "total posts count (number).",
-        schema={
-            "type": "object",
-            "properties": {
-                "followers": {"type": "integer"},
-                "following": {"type": "integer"},
-                "total_posts": {"type": "integer"},
-            },
-            "required": ["followers"],
-        },
-    )
-    return stats if isinstance(stats, dict) else {"error": "Could not extract profile stats"}
+    adapter = _adapter_registry.get("X") if _adapter_registry else None
+    if not adapter:
+        return {"error": "X adapter not configured"}
+    return await adapter.get_profile_stats()

--- a/packages/prime-agent/src/talos_agent/tools/publishing.py
+++ b/packages/prime-agent/src/talos_agent/tools/publishing.py
@@ -1,0 +1,118 @@
+"""Publishing tools — unified multi-channel content publishing via adapter registry."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import TYPE_CHECKING, Any, Callable
+
+from rich.console import Console
+
+from talos_agent.tools.registry import tool
+
+if TYPE_CHECKING:
+    from talos_agent.adapters.registry import AdapterRegistry
+
+console = Console()
+
+# Injected by registry.build_all_tools
+_adapter_registry: AdapterRegistry = None  # type: ignore[assignment]
+
+_TIMEOUT = 90  # seconds
+
+
+def _publish_safe(fn: Callable) -> Callable:
+    """Wrap a publishing tool with timeout and structured error handling."""
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> dict:
+        if _adapter_registry is None:
+            return {"error": "Adapter registry not initialized"}
+        try:
+            return await asyncio.wait_for(fn(*args, **kwargs), timeout=_TIMEOUT)
+        except asyncio.TimeoutError:
+            return {"error": f"Publishing action timed out after {_TIMEOUT}s"}
+        except Exception as e:
+            return {"error": f"{type(e).__name__}: {e}"}
+
+    return wrapper
+
+
+@tool(
+    "publish_content",
+    "Publish content to a social channel. Call get_publishing_channels first to see available channels and their character limits.",
+)
+@_publish_safe
+async def publish_content(content: str, channel: str = "X") -> dict:
+    adapter = _adapter_registry.get(channel)
+    if not adapter:
+        return {
+            "error": f"Channel '{channel}' not available.",
+            "available_channels": _adapter_registry.available_channels(),
+        }
+    valid, error = adapter.validate_content(content)
+    if not valid:
+        return {"error": error}
+    result = await adapter.post(content)
+    return result.to_dict()
+
+
+@tool(
+    "reply_on_channel",
+    "Reply to a post on a social channel. Requires channel name, target post URL, and reply content.",
+)
+@_publish_safe
+async def reply_on_channel(channel: str, target_url: str, content: str) -> dict:
+    adapter = _adapter_registry.get(channel)
+    if not adapter:
+        return {"error": f"Channel '{channel}' not available"}
+    caps = adapter.get_capabilities()
+    if not caps.supports_replies:
+        return {"error": f"Channel '{channel}' does not support replies"}
+    valid, error = adapter.validate_content(content)
+    if not valid:
+        return {"error": error}
+    result = await adapter.reply(target_url, content)
+    return result.to_dict()
+
+
+@tool(
+    "get_channel_mentions",
+    "Get recent mentions or notifications from a social channel.",
+)
+@_publish_safe
+async def get_channel_mentions(channel: str = "X") -> dict:
+    adapter = _adapter_registry.get(channel)
+    if not adapter:
+        return {"error": f"Channel '{channel}' not available"}
+    mentions = await adapter.get_mentions()
+    return {"channel": channel, "mentions": mentions}
+
+
+@tool(
+    "search_channel",
+    "Search for posts on a social channel by keyword query.",
+)
+@_publish_safe
+async def search_channel(query: str, channel: str = "X") -> dict:
+    adapter = _adapter_registry.get(channel)
+    if not adapter:
+        return {"error": f"Channel '{channel}' not available"}
+    caps = adapter.get_capabilities()
+    if not caps.supports_search:
+        return {"error": f"Channel '{channel}' does not support search"}
+    results = await adapter.search(query)
+    return {"channel": channel, "query": query, "results": results}
+
+
+@tool(
+    "get_publishing_channels",
+    "Get all available social publishing channels and their capabilities (character limits, supported features). Call this before composing content.",
+)
+async def get_publishing_channels() -> dict:
+    if _adapter_registry is None:
+        return {"error": "Adapter registry not initialized"}
+    return {
+        "available": _adapter_registry.available_channels(),
+        "channels": _adapter_registry.capabilities(),
+    }

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -143,6 +143,14 @@ def build_all_tools(
     from talos_agent.tools import internal as _internal_mod  # noqa: F401
     from talos_agent.tools import learning as _learning_mod  # noqa: F401
     from talos_agent.tools import web_api as _web_api_mod  # noqa: F401
+    from talos_agent.tools import publishing as _publishing_mod  # noqa: F401
+
+    # Build the channel adapter registry with all configured adapters
+    from talos_agent.adapters.registry import AdapterRegistry
+    from talos_agent.adapters.x import XAdapter
+
+    adapter_registry = AdapterRegistry()
+    adapter_registry.register(XAdapter(browser, settings))
 
     # Inject dependencies into tool modules
     _internal_mod._db = db
@@ -150,6 +158,7 @@ def build_all_tools(
     _web_api_mod._settings = settings
     _browser_mod._browser = browser
     _browser_mod._settings = settings
+    _browser_mod._adapter_registry = adapter_registry
     _commerce_mod._api = api
     _commerce_mod._db = db
     _commerce_mod._settings = settings
@@ -157,5 +166,6 @@ def build_all_tools(
     _stellar_mod._api = api
     _learning_mod._db = db
     _learning_mod._settings = settings
+    _publishing_mod._adapter_registry = adapter_registry
 
     return registry


### PR DESCRIPTION
Refactors the Prime Agent's publishing runtime from a hardcoded X (Twitter) implementation into a clean, modular adapter architecture. The agent can now publish to any social channel through a unified interface — adding a new channel is a matter of implementing one abstract class and registering an instance.

---

## Motivation

The original codebase had all X/Twitter logic scattered across `tools/browser.py` — login state, cookie handling, posting, search, and analytics were all mixed into a single module with hardcoded URLs, character limits, and credential field names. This made it impossible to support any other social channel without duplicating large sections of code and touching the agent's core tool loop.

The goal of this PR is to:

- **Decouple channel logic from the agent runtime** so channels are swappable and independently testable.
- **Give the LLM a channel-agnostic publishing interface** so it discovers capabilities at runtime rather than being hard-wired to X tool names.
- **Make LocalDB channel-aware** so logging, history, and analytics queries can be filtered per channel.
- **Establish an extension point** for future adapters (LinkedIn, Farcaster, Telegram, etc.) without touching the agent loop, scheduler, or prompt.

---

## Changes

### 10 files changed — 598 insertions, 217 deletions

```
packages/prime-agent/src/talos_agent/
├── adapters/                        ← NEW package
│   ├── __init__.py                  ← NEW
│   ├── base.py                      ← NEW  BaseSocialAdapter ABC
│   ├── registry.py                  ← NEW  AdapterRegistry
│   └── x.py                         ← NEW  XAdapter (extracted from browser.py)
├── tools/
│   ├── browser.py                   ← REFACTORED  (−217 lines, delegates to adapters)
│   ├── publishing.py                ← NEW  5 unified publishing tools
│   └── registry.py                  ← MODIFIED  wires up adapter registry
├── agent/
│   └── prompt.py                    ← MODIFIED  updated workflow instructions
├── config.py                        ← MODIFIED  added channel_configs field
└── db.py                            ← MODIFIED  3 new channel-filtered query methods
```

---

## New: `adapters/` Package

### `adapters/base.py` — `BaseSocialAdapter`

Abstract base class that every channel adapter must implement.

```python
class BaseSocialAdapter(ABC):
    channel_name: str  # e.g. "X", "LinkedIn", "Farcaster"

    async def post(self, content: str, **kwargs) -> PublishResult: ...
    async def reply(self, target_url: str, content: str, **kwargs) -> PublishResult: ...
    async def get_mentions(self, **kwargs) -> list[dict]: ...
    async def search(self, query: str, **kwargs) -> list[dict]: ...
    async def get_post_performance(self, content_snippet: str, **kwargs) -> dict: ...
    async def get_profile_stats(self, **kwargs) -> dict: ...
    def get_capabilities(self) -> ChannelCapabilities: ...
    def validate_content(self, content: str) -> tuple[bool, str | None]: ...  # concrete
```

**Supporting dataclasses:**

`ChannelCapabilities` — describes what a channel supports:

| Field | Type | Purpose |
|---|---|---|
| `char_limit` | `int \| None` | Max characters per post (`None` = no limit) |
| `supports_media` | `bool` | Accepts image/video attachments |
| `supports_threads` | `bool` | Can post thread/reply chains |
| `supports_replies` | `bool` | Can reply to existing posts |
| `supports_search` | `bool` | Supports keyword search |
| `supports_mentions` | `bool` | Has a mentions/notifications feed |
| `supports_analytics` | `bool` | Can retrieve engagement metrics |

`PublishResult` — standardised return type from any `post()` or `reply()` call:

| Field | Type | Purpose |
|---|---|---|
| `status` | `str` | `"posted"` \| `"failed"` \| `"pending"` |
| `channel` | `str` | Channel name this result is from |
| `content` | `str` | The content that was published |
| `post_id` | `str \| None` | Platform-assigned post ID (if available) |
| `url` | `str \| None` | Direct URL to the published post |
| `error` | `str \| None` | Error message if `status == "failed"` |
| `metadata` | `dict` | Adapter-specific extra data |

---

### `adapters/registry.py` — `AdapterRegistry`

Holds all registered adapters and provides channel-name lookup:

```python
registry = AdapterRegistry()
registry.register(XAdapter(browser, settings))

adapter = registry.get("X")          # → XAdapter instance
registry.available_channels()        # → ["X"]
registry.capabilities()              # → {"X": {char_limit: 280, ...}}
```

Lookup is case-insensitive (`"x"`, `"X"`, and `"Twitter"` all route to the same adapter if registered under `"X"`).

---

### `adapters/x.py` — `XAdapter`

All X/Twitter-specific logic extracted from `browser.py` into a proper class:

- **`channel_name = "X"`**
- **Auth:** `_ensure_login()` — handles first-time login, email/phone verification step, and login state caching via `self._logged_in`
- **Cookie handling:** `_dismiss_cookie_banner()` as a private method (no longer pollutes the general browser module)
- **Posting:** Uses Playwright keyboard shortcuts (`n` → type → `Ctrl+Enter`) to bypass Stagehand LLM overhead
- **`get_capabilities()`** returns `ChannelCapabilities(char_limit=280, supports_media=True, supports_threads=True, ...)`
- **Session recovery:** `_logged_in = False` is reset externally by `_browser_safe` on reconnect

Constants are defined at module level for easy auditing:

```python
_CHAR_LIMIT   = 280
_LOGIN_URL    = "https://x.com/i/flow/login"
_HOME_URL     = "https://x.com/home"
_MENTIONS_URL = "https://x.com/notifications/mentions"
_SEARCH_URL   = "https://x.com/search?q={query}&src=typed_query&f=live"
_PROFILE_URL  = "https://x.com/{username}"
```

---

## New: `tools/publishing.py`

Five new channel-agnostic LLM tools that route through the adapter registry:

| Tool | Description |
|---|---|
| `get_publishing_channels` | Returns available channels and their full capabilities dict — call this before writing content |
| `publish_content(content, channel)` | Publishes to the specified channel via its adapter |
| `reply_on_channel(channel, target_url, content)` | Posts a reply on any channel that supports it |
| `get_channel_mentions(channel)` | Fetches mentions/notifications from a channel |
| `search_channel(query, channel)` | Keyword search on any channel that supports it |

All tools are wrapped with `_publish_safe` — a timeout + structured error handler that returns `{"error": "..."}` dicts rather than raising exceptions into the agent loop.

**Example LLM interaction:**

```json
// Agent calls: get_publishing_channels
// Returns:
{
  "available": ["X"],
  "channels": {
    "X": {
      "char_limit": 280,
      "supports_media": true,
      "supports_threads": true,
      "supports_replies": true,
      "supports_search": true,
      "supports_mentions": true,
      "supports_analytics": true
    }
  }
}

// Agent calls: publish_content
// Input:  {"content": "Hello world!", "channel": "X"}
// Returns: {"status": "posted", "channel": "X", "content": "Hello world!"}
```

---

## Refactored: `tools/browser.py`

**Before:** 328 lines — mixed X auth, cookie state, login flow, keyboard automation, and general browser utilities.

**After:** ~140 lines — only general-purpose browser tools (`search_web`, `browse_page`) plus thin legacy shims for backward-compatible X tool names.

All legacy X tools (`post_to_x`, `check_x_mentions`, `reply_on_x`, `search_x`, `check_post_performance`, `get_profile_stats`) now delegate to `_adapter_registry.get("X")`:

```python
@tool("post_to_x", "Post a tweet on X (Twitter). Content MUST be under 280 characters.")
@_browser_safe
async def post_to_x(content: str) -> dict:
    adapter = _adapter_registry.get("X") if _adapter_registry else None
    if not adapter:
        return {"error": "X adapter not configured"}
    result = await adapter.post(content)
    return result.to_dict()
```

**Session recovery** now correctly resets adapter login state on browser reconnect:

```python
# Inside _browser_safe reconnect handler:
if _adapter_registry:
    x_adapter = _adapter_registry.get("X")
    if x_adapter and hasattr(x_adapter, "_logged_in"):
        x_adapter._logged_in = False
await _browser.reconnect()
```

---

## Modified: `tools/registry.py`

`build_all_tools()` now constructs the adapter registry and injects it into the relevant tool modules:

```python
adapter_registry = AdapterRegistry()
adapter_registry.register(XAdapter(browser, settings))

_browser_mod._adapter_registry = adapter_registry
_publishing_mod._adapter_registry = adapter_registry
```

The `publishing` module is imported alongside the existing tool modules so its `@tool` decorators register into the global `ToolRegistry`.

---

## Modified: `db.py`

Three new channel-filtered query methods added to `LocalDB`:

```python
# Count posts/activity of a given type on a specific channel today
db.count_today_by_channel(type_: str, channel: str) -> int

# Get recent posts from a specific channel only
db.get_recent_content_by_channel(channel: str, limit: int = 20) -> list[dict]

# Get aggregated performance metrics for a specific channel over N days
db.get_performance_summary_by_channel(channel: str, days: int = 7) -> dict
```

Existing methods (`count_today`, `get_recent_content`, `get_performance_summary`) are unchanged — no migration needed.

---

## Modified: `config.py`

New `channel_configs` field for per-channel credential maps:

```python
# In Settings:
channel_configs: dict = Field(
    default_factory=dict,
    description="Per-channel credentials map"
)
```

Set via environment variable as a JSON string:

```env
CHANNEL_CONFIGS={"linkedin": {"access_token": "..."}, "farcaster": {"mnemonic": "..."}}
```

The existing `x_username`, `x_password`, `x_email` fields are unchanged — `XAdapter` reads them directly from `Settings`.

---

## Modified: `agent/prompt.py`

The agent workflow instruction was updated to use the new unified tools:

**Before:**
```
The workflow is: research → write post (under 280 chars, plain text) → post_to_x → record_post → report_activity.
```

**After:**
```
The workflow is: research → get_publishing_channels → write post (respecting each channel's character limit) → publish_content → record_post → report_activity.
```

A new constraint was also added to the `## Constraints` section:

```
- Always call get_publishing_channels before composing content to check available channels and their character limits.
```

---

## How to Add a New Channel Adapter

Adding a future channel (e.g. LinkedIn) requires no changes to the agent loop, scheduler, prompt builder, or database schema:

1. **Create** `adapters/linkedin.py` implementing `BaseSocialAdapter`
2. **Declare** `channel_name = "LinkedIn"` on the class
3. **Implement** all abstract methods (`post`, `reply`, `get_mentions`, `search`, `get_post_performance`, `get_profile_stats`, `get_capabilities`)
4. **Register** in `tools/registry.py` inside `build_all_tools`:

```python
from talos_agent.adapters.linkedin import LinkedInAdapter

if settings.channel_configs.get("linkedin"):
    adapter_registry.register(LinkedInAdapter(settings))
```

The agent's `publish_content` tool will immediately surface the new channel to the LLM via `get_publishing_channels`.

---

## Testing Checklist

- [ ] `XAdapter.validate_content` rejects content > 280 chars with a descriptive error
- [ ] `AdapterRegistry.get("x")` and `AdapterRegistry.get("X")` both resolve correctly (case-insensitive)
- [ ] `publish_content` returns `{"error": "..."}` with `available_channels` when an unknown channel is requested
- [ ] `post_to_x` (legacy shim) still posts correctly via the adapter
- [ ] Browser reconnect resets `XAdapter._logged_in = False` so re-login is attempted
- [ ] `db.count_today_by_channel("post", "X")` returns correct daily count
- [ ] `get_publishing_channels` tool returns capabilities dict with `char_limit: 280` for X
- [ ] Agent prompt references `publish_content` and `get_publishing_channels` in workflow instructions

---

closes #70