### PR TITLE
fix: require wallet signature for patron register/revoke

### DIFF
--- a/web/src/app/api/talos/[id]/patrons/route.ts
+++ b/web/src/app/api/talos/[id]/patrons/route.ts
@@ -2,7 +2,8 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPatrons } from "@/db/schema";
 import { and, desc, eq } from "drizzle-orm";
-import { getAccountInfo } from "@/lib/stellar";
+import { getAccountInfo, verifyStellarSignature } from "@/lib/stellar";
+import { becomePatronSchema, revokePatronSchema, parseBody } from "@/lib/schemas";
 
 // GET /api/talos/:id/patrons — List patrons for a TALOS
 export async function GET(
@@ -36,6 +37,8 @@ export async function GET(
 }
 
 // POST /api/talos/:id/patrons — Register as patron (requires min Pulse holding)
+// Caller must sign a message containing both the TALOS id and the literal
+// "register-patron" with their Stellar wallet, proving control of the key.
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -43,21 +46,30 @@ export async function POST(
   try {
     const { id } = await params;
 
-    const body = await request.json();
-    const { stellarPublicKey, pulseAmount } = body;
+    const parsed = await parseBody(request, becomePatronSchema);
+    if (parsed.error) return parsed.error;
 
-    if (!stellarPublicKey) {
+    const { stellarPublicKey, pulseAmount, signature, message } = parsed.data;
+
+    // Bind the signature to this TALOS and this action to prevent replay
+    // across TALOSes and across the register/revoke endpoints.
+    if (!message.includes(id) || !message.includes("register-patron")) {
       return Response.json(
-        { error: "stellarPublicKey is required" },
+        {
+          error:
+            "Signature message must contain the TALOS id and the action 'register-patron'",
+        },
         { status: 400 }
       );
     }
 
-    if (pulseAmount == null || typeof pulseAmount !== "number" || pulseAmount <= 0) {
-      return Response.json(
-        { error: "pulseAmount must be a positive number" },
-        { status: 400 }
-      );
+    const sigOk = await verifyStellarSignature(
+      stellarPublicKey,
+      message,
+      signature
+    );
+    if (!sigOk) {
+      return Response.json({ error: "Invalid signature" }, { status: 403 });
     }
 
     const talos = await db
@@ -158,6 +170,8 @@ export async function POST(
 }
 
 // DELETE /api/talos/:id/patrons — Withdraw patron status
+// Caller must sign a message containing both the TALOS id and the literal
+// "revoke-patron" with their Stellar wallet, proving control of the key.
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -165,14 +179,28 @@ export async function DELETE(
   try {
     const { id } = await params;
 
-    const body = await request.json();
-    const { stellarPublicKey } = body;
+    const parsed = await parseBody(request, revokePatronSchema);
+    if (parsed.error) return parsed.error;
 
-    if (!stellarPublicKey) {
+    const { stellarPublicKey, signature, message } = parsed.data;
+
+    if (!message.includes(id) || !message.includes("revoke-patron")) {
       return Response.json(
-        { error: "stellarPublicKey is required" },
+        {
+          error:
+            "Signature message must contain the TALOS id and the action 'revoke-patron'",
+        },
         { status: 400 }
       );
+    }
+
+    const sigOk = await verifyStellarSignature(
+      stellarPublicKey,
+      message,
+      signature
+    );
+    if (!sigOk) {
+      return Response.json({ error: "Invalid signature" }, { status: 403 });
     }
 
     const patron = await db

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -81,6 +81,14 @@ export const transferSchema = z.object({
 export const becomePatronSchema = z.object({
   stellarPublicKey: z.string().min(1),
   pulseAmount: z.number().positive(),
+  signature: z.string().min(1),
+  message: z.string().min(1),
+});
+
+export const revokePatronSchema = z.object({
+  stellarPublicKey: z.string().min(1),
+  signature: z.string().min(1),
+  message: z.string().min(1),
 });
 
 // --- Commerce Service ---

--- a/web/src/lib/stellar.ts
+++ b/web/src/lib/stellar.ts
@@ -237,6 +237,28 @@ export async function recordApprovalOnChain(
 }
 
 /**
+ * Verify an ED25519 signature was produced by the private key corresponding
+ * to `publicKey`. `signature` is base64-encoded; `message` is the UTF-8 text
+ * the wallet signed. Returns false on any error (invalid key, bad base64, etc).
+ */
+export async function verifyStellarSignature(
+  publicKey: string,
+  message: string,
+  signature: string,
+): Promise<boolean> {
+  try {
+    const { Keypair } = await import("@stellar/stellar-sdk");
+    const keypair = Keypair.fromPublicKey(publicKey);
+    return keypair.verify(
+      Buffer.from(message, "utf8"),
+      Buffer.from(signature, "base64"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if a Stellar account exists on the network.
  */
 export async function getAccountInfo(


### PR DESCRIPTION
CLOSE #49 
## Summary

Patron registration `(POST /api/talos/[id]/patrons)` and revocation `(DELETE /api/talos/[id]/patrons)` previously accepted a bare `stellarPublicKey` in the request body and wrote to the database without any proof the caller controlled the corresponding private key.

This allowed two unauthenticated attacks:

Impersonation: anyone could register any Stellar key as a Patron, provided that key had a USDC balance.
Griefing: anyone could revoke another user's active Patron status by sending a DELETE with their public key.
This PR adds wallet-ownership proof via a Stellar ED25519 signature, gating both endpoints behind cryptographic verification before any DB modification.

## Changes
web/src/lib/stellar.ts — new `verifyStellarSignature(publicKey, message, signature) helper using Keypair.fromPublicKey(...).verify(...)`. Base64 signature, UTF-8 message. Returns false on any error (invalid key, malformed base64, bad signature).
web/src/lib/schemas.ts — extended `becomePatronSchema` with `signature` and `message` fields; added `revokePatronSchema` for `DELETE`. Both fields are required (Zod-enforced → `400` if missing).
web/src/app/api/talos/[id]/patrons/route.ts — POST and DELETE now:
Parse + validate the body via `parseBody` + Zod.
Require the signed message to contain both the TALOS id and an action keyword `(register-patron` for POST, `revoke-patron` for `DELETE`) — prevents replay across TALOSes and across endpoints.
Call `verifyStellarSignature(...)` and return `403 Invalid signature` on failure.
Only then touch the database.

## Client contract
Clients must sign a UTF-8 message containing both the TALOS id and the action keyword, then send the base64-encoded signature.

Register example


```rs
POST /api/talos/<id>/patrons
{
  "stellarPublicKey": "G...",
  "pulseAmount": 1000,
  "message": "talos:register-patron:<id>:<nonce>",
  "signature": "<base64-ed25519>"
}
```


Revoke example


```rs
DELETE /api/talos/<id>/patrons
{
  "stellarPublicKey": "G...",
  "message": "talos:revoke-patron:<id>:<nonce>",
  "signature": "<base64-ed25519>"
}
```
The exact message format is up to the client as long as both substrings are present.

## Acceptance criteria
 - Require a signed message and signature from the wallet in the request body.
 - Verify the signature against the target `stellarPublicKey` using Stellar SDK.
 - Prevent unauthorized database modifications.

 ## Test plan
 POST /api/talos/:id/patrons without signature or message → 400 Validation failed.
 POST with a signature from a different keypair than stellarPublicKey → 403 Invalid signature.
 POST with a valid signature but a message missing the TALOS id or register-patron keyword → 400.
 POST with a valid signature signing a different TALOS id → 400 (replay across TALOSes blocked).
 POST with a valid register-patron signature reused on DELETE → 400 (replay across endpoints blocked).
 POST with a correctly signed message → 201 (or 200 on re-activation) and DB row created/updated.
 DELETE mirroring the four signature failure cases above.
 DELETE with a correctly signed revoke-patron message → 200 and status set to revoked.
