### PR TITLE
refactor(stellar): move operator address to env config

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -19,6 +19,12 @@ NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # View secret: stellar keys show operator
 STELLAR_OPERATOR_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+# Operator treasury public key (used for server-side authorization checks)
+STELLAR_OPERATOR_PUBLIC_KEY=GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL
+
+# Operator treasury public key (client-side variant exposed to the browser frontend)
+NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY=GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL
+
 # ─── Soroban Smart Contracts ─────────────────────────────
 # Run: cd contracts && ./deploy.sh testnet (returns contract IDs)
 NEXT_PUBLIC_TALOS_REGISTRY_CONTRACT=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,26 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables on Vercel
+
+When deploying this application on Vercel, make sure the following Stellar environment variables are properly configured in your Vercel Project Settings:
+
+### Server-Side Variables (Hidden from browser)
+* `STELLAR_OPERATOR_SECRET_KEY`: The operator treasury secret key (starts with `S`), used for signing transactions.
+* `STELLAR_OPERATOR_PUBLIC_KEY`: The operator treasury public key (starts with `G`), used for server-side auth validation.
+* `STELLAR_NETWORK`: Network to use (`testnet` or `mainnet`).
+* `STELLAR_HORIZON_URL`: URL of the Stellar Horizon server.
+* `STELLAR_RPC_URL`: URL of the Soroban RPC server.
+* `STELLAR_USDC_ISSUER`: USDC token issuer public key.
+
+### Client-Side Variables (Prefix `NEXT_PUBLIC_`, exposed to browser)
+* `NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY`: The operator treasury public key (starts with `G`).
+* `NEXT_PUBLIC_STELLAR_NETWORK`: Network to use (`testnet` or `mainnet`).
+* `NEXT_PUBLIC_STELLAR_RPC_URL`: URL of the Soroban RPC server.
+* `NEXT_PUBLIC_TALOS_REGISTRY_CONTRACT`: The registry Soroban contract ID.
+* `NEXT_PUBLIC_TALOS_NAME_SERVICE_CONTRACT`: The name service Soroban contract ID.
+* `NEXT_PUBLIC_STELLAR_WALLET_NETWORK`: Wallet network setting (e.g. `testnet`).
+* `NEXT_PUBLIC_TALOS_CREATION_XLM`: XLM required for Talos creation.
+* `NEXT_PUBLIC_STELLAR_USDC_ISSUER`: USDC token issuer public key.
+

--- a/web/src/app/agents/[id]/detail-client.tsx
+++ b/web/src/app/agents/[id]/detail-client.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useWallet } from "@/components/wallet-gate";
 import { AgentAvatar } from "@/components/agent-avatar";
+import { OPERATOR_PUBLIC_KEY, USDC_ISSUER as STELLAR_USDC_ISSUER } from "@/lib/stellar-config";
+
 
 interface ServiceInfo {
   name: string;
@@ -148,8 +150,8 @@ export function TalosDetailClient({ talos }: { talos: TalosDetail }) {
       const { Asset, TransactionBuilder, Operation, BASE_FEE, Horizon, Networks } = await import("@stellar/stellar-sdk");
       const HORIZON_URL = "https://horizon-testnet.stellar.org";
       const NETWORK_PASSPHRASE = Networks.TESTNET;
-      const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-      const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+      const USDC_ISSUER = STELLAR_USDC_ISSUER;
+      const OPERATOR = OPERATOR_PUBLIC_KEY;
       const recipient = talos.service.stellarPublicKey || talos.agentWalletAddress || OPERATOR;
 
       // Build payment TX — don't submit in browser; server will submit + verify
@@ -330,12 +332,12 @@ export function TalosDetailClient({ talos }: { talos: TalosDetail }) {
 
       const HORIZON_URL = "https://horizon-testnet.stellar.org";
       const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
-      const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+      const USDC_ISSUER = STELLAR_USDC_ISSUER;
 
       // Payment goes to agent treasury (agentWalletAddress) or operator
       const recipient =
         talos.agentWalletAddress ??
-        "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+        OPERATOR_PUBLIC_KEY;
 
       const server = new Horizon.Server(HORIZON_URL);
       const account = await server.loadAccount(address);

--- a/web/src/app/api/talos/[id]/jobs/route.ts
+++ b/web/src/app/api/talos/[id]/jobs/route.ts
@@ -3,6 +3,8 @@ import { db } from "@/db";
 import { tlsTalos, tlsCommerceServices, tlsCommerceJobs, tlsRevenues } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { fulfillInstant } from "@/lib/fulfillment";
+import { OPERATOR_PUBLIC_KEY, USDC_ISSUER } from "@/lib/stellar-config";
+
 
 /**
  * POST /api/talos/:id/jobs
@@ -26,8 +28,8 @@ async function submitAndVerifyPayment(
   const txHash = result.hash;
 
   // Verify at least one operation is a USDC payment to the expected recipient
-  const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-  const usdc = new Asset("USDC", USDC_ISSUER);
+  const USDC_ISSUER_VAL = USDC_ISSUER;
+  const usdc = new Asset("USDC", USDC_ISSUER_VAL);
   const ops = tx.operations as unknown as Array<{ type: string; asset?: { code: string; issuer: string }; destination?: string; amount?: string }>;
   const valid = ops.some(
     (op) =>
@@ -78,7 +80,7 @@ export async function POST(
     // Submit + verify payment if signedXdr provided; otherwise use legacy txHash
     let txHash: string;
     if (signedXdr) {
-      const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+      const OPERATOR = OPERATOR_PUBLIC_KEY;
       const recipient = service.stellarPublicKey ?? talos.agentWalletAddress ?? OPERATOR;
       try {
         ({ txHash } = await submitAndVerifyPayment(signedXdr, String(service.price), recipient));

--- a/web/src/app/api/talos/[id]/revenue/buyback/route.ts
+++ b/web/src/app/api/talos/[id]/revenue/buyback/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsRevenues } from "@/db/schema";
 import { and, eq, sum } from "drizzle-orm";
+import { OPERATOR_PUBLIC_KEY, USDC_ISSUER } from "@/lib/stellar-config";
+
 
 /**
  * POST /api/talos/:id/revenue/buyback
@@ -44,7 +46,7 @@ export async function POST(
     const talos = await db.query.tlsTalos.findFirst({ where: eq(tlsTalos.id, id) });
     if (!talos) return Response.json({ error: "TALOS not found" }, { status: 404 });
 
-    const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+    const OPERATOR = OPERATOR_PUBLIC_KEY;
     if (requesterPublicKey !== talos.creatorPublicKey && requesterPublicKey !== OPERATOR) {
       return Response.json({ error: "Only creator or operator can trigger buyback" }, { status: 403 });
     }
@@ -60,7 +62,7 @@ export async function POST(
     }
 
     const [mitosCode, mitosIssuer] = assetCode.split(":");
-    const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    const USDC_ISSUER_VAL = USDC_ISSUER;
 
     const {
       Keypair, Asset, TransactionBuilder, Operation, BASE_FEE, Networks, Horizon,
@@ -70,7 +72,7 @@ export async function POST(
     const server = new Horizon.Server("https://horizon-testnet.stellar.org");
     const account = await server.loadAccount(operatorKeypair.publicKey());
 
-    const usdc = new Asset("USDC", USDC_ISSUER);
+    const usdc = new Asset("USDC", USDC_ISSUER_VAL);
     const mitos = new Asset(mitosCode, mitosIssuer);
 
     // Build TX: send USDC to burn address (issuer) + burn Mitos (send to issuer)
@@ -150,7 +152,7 @@ export async function GET(
         const [mitosCode, mitosIssuer] = talos.stellarAssetCode.split(":");
         const { Horizon } = await import("@stellar/stellar-sdk");
         const server = new Horizon.Server("https://horizon-testnet.stellar.org");
-        const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+        const OPERATOR = OPERATOR_PUBLIC_KEY;
         const account = await server.loadAccount(OPERATOR);
         const balance = (account.balances as any[]).find(
           b => b.asset_code === mitosCode && b.asset_issuer === mitosIssuer,

--- a/web/src/app/api/talos/[id]/revenue/distribute/route.ts
+++ b/web/src/app/api/talos/[id]/revenue/distribute/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPatrons, tlsRevenues } from "@/db/schema";
 import { eq, and, sum } from "drizzle-orm";
+import { OPERATOR_PUBLIC_KEY, USDC_ISSUER } from "@/lib/stellar-config";
+
 
 /**
  * POST /api/talos/:id/revenue/distribute
@@ -31,7 +33,7 @@ export async function POST(
     if (!talos) return Response.json({ error: "TALOS not found" }, { status: 404 });
 
     // Only creator or operator can distribute
-    const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+    const OPERATOR = OPERATOR_PUBLIC_KEY;
     if (requesterPublicKey !== talos.creatorPublicKey && requesterPublicKey !== OPERATOR) {
       return Response.json({ error: "Only the creator or operator can trigger distribution" }, { status: 403 });
     }
@@ -75,8 +77,8 @@ export async function POST(
       Keypair, Asset, TransactionBuilder, Operation, BASE_FEE, Networks, Horizon,
     } = await import("@stellar/stellar-sdk");
 
-    const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-    const usdc = new Asset("USDC", USDC_ISSUER);
+    const USDC_ISSUER_VAL = USDC_ISSUER;
+    const usdc = new Asset("USDC", USDC_ISSUER_VAL);
     const operatorKeypair = Keypair.fromSecret(operatorSecret);
     const server = new Horizon.Server("https://horizon-testnet.stellar.org");
 

--- a/web/src/app/launch/page.tsx
+++ b/web/src/app/launch/page.tsx
@@ -11,6 +11,8 @@ import {
   TALOS_REGISTRY_CONTRACT_ID,
   TALOS_NAME_SERVICE_CONTRACT_ID,
 } from "@/lib/soroban";
+import { OPERATOR_PUBLIC_KEY } from "@/lib/stellar-config";
+
 
 const STEPS = [
   "Product",
@@ -165,7 +167,7 @@ function LaunchForm() {
         const registry = new Contract(TALOS_REGISTRY_CONTRACT_ID);
         const categoryCapitalized = form.category.charAt(0).toUpperCase() + form.category.slice(1);
 
-        const OPERATOR = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+        const OPERATOR = OPERATOR_PUBLIC_KEY;
 
         // Helper: build an ScMap entry (key as Symbol, value as ScVal)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web/src/lib/stellar-config.ts
+++ b/web/src/lib/stellar-config.ts
@@ -1,0 +1,34 @@
+const isProd = process.env.NODE_ENV === "production";
+const isClient = typeof window !== "undefined";
+const isNextBuild = process.env.NEXT_PHASE === "phase-production-build";
+
+const network =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK ??
+  process.env.STELLAR_NETWORK ??
+  "testnet";
+
+export const OPERATOR_PUBLIC_KEY = isClient
+  ? (process.env.NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY || "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL")
+  : (process.env.STELLAR_OPERATOR_PUBLIC_KEY ||
+     process.env.NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY ||
+     "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL");
+
+export const USDC_ISSUER =
+  process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER ??
+  process.env.STELLAR_USDC_ISSUER ??
+  (network === "mainnet"
+    ? "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+    : "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+
+// Throw at module load if a required env var is missing in production
+if (isProd && !isNextBuild) {
+  if (isClient) {
+    if (!process.env.NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY) {
+      throw new Error("Missing NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY in production client environment");
+    }
+  } else {
+    if (!process.env.STELLAR_OPERATOR_PUBLIC_KEY && !process.env.NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY) {
+      throw new Error("Missing STELLAR_OPERATOR_PUBLIC_KEY or NEXT_PUBLIC_STELLAR_OPERATOR_PUBLIC_KEY in production server environment");
+    }
+  }
+}

--- a/web/src/lib/stellar-x402.ts
+++ b/web/src/lib/stellar-x402.ts
@@ -8,6 +8,8 @@
  *   Mainnet: https://channels.openzeppelin.com/x402
  */
 
+import { USDC_ISSUER } from "./stellar-config";
+
 const X402_FACILITATOR_URL =
   process.env.X402_FACILITATOR_URL ??
   "https://channels.openzeppelin.com/x402/testnet";
@@ -92,9 +94,7 @@ export async function signX402Payment(
 
     const usdc = new Asset(
       payload.assetCode ?? "USDC",
-      process.env.STELLAR_NETWORK === "mainnet"
-        ? "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
-        : "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      USDC_ISSUER,
     );
 
     const tx = new TransactionBuilder(account, {

--- a/web/src/lib/stellar.ts
+++ b/web/src/lib/stellar.ts
@@ -6,6 +6,8 @@
  * They are held server-side in environment variables or a secret manager.
  */
 
+import { USDC_ISSUER } from "./stellar-config";
+
 const STELLAR_NETWORK = process.env.STELLAR_NETWORK ?? "testnet";
 const STELLAR_HORIZON_URL =
   process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
@@ -15,7 +17,7 @@ const USDC_ISSUER_TESTNET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZL
 const USDC_ISSUER_MAINNET = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 
 export function getUSDCIssuer(): string {
-  return STELLAR_NETWORK === "mainnet" ? USDC_ISSUER_MAINNET : USDC_ISSUER_TESTNET;
+  return USDC_ISSUER;
 }
 
 export function getNetworkPassphrase(): string {


### PR DESCRIPTION
##Summary 

This PR centralizes deployment-specific Stellar configuration by removing hardcoded operator treasury and audited USDC issuer addresses from the codebase and replacing them with a single environment-backed configuration module. The affected client and API routes now consume shared configuration values, reducing maintenance overhead and preventing deployment-specific values from being scattered across multiple files.

The update also adds environment variable documentation in `.env.example` and `README.md`, along with production safeguards for required configuration. A verification audit was performed to ensure the hardcoded operator address no longer exists in the application source and the project continues to build successfully after the refactor.

Closes #19
