### PR TITLE
feat(agent): run container as non-root user

### DIFF
--- a/packages/prime-agent/Dockerfile
+++ b/packages/prime-agent/Dockerfile
@@ -38,8 +38,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # ── uv (fast Python package manager) ──────────────────────────────────────────
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
 
 # ── Playwright Chromium (keyboard fallback) ────────────────────────────────────
 # Tell Playwright to use the system Chromium installed above
@@ -55,6 +54,10 @@ COPY src/ ./src/
 
 # ── Install Python dependencies (layer-cached) ────────────────────────────────
 RUN uv sync --frozen --no-dev
+
+# ── Non-root user setup ────────────────────────────────────────────────────────
+RUN useradd -m -u 1000 talos && chown -R talos:talos /app
+USER talos
 
 # ── Runtime environment ────────────────────────────────────────────────────────
 ENV PYTHONUNBUFFERED=1

--- a/packages/prime-agent/README.md
+++ b/packages/prime-agent/README.md
@@ -59,3 +59,19 @@ _MIGRATIONS.append(
    pytest tests/
    ```
 3. Deploy. The database will automatically upgrade on startup.
+
+## Deployment
+
+### Running the Docker Container
+
+The container is configured to run as an unprivileged non-root user `talos` (UID 1000) for security hardening.
+
+To build and run the Docker container locally:
+```bash
+# Build the image
+docker build -t prime-agent .
+
+# Run the container (which automatically runs as user 'talos')
+docker run --rm prime-agent
+```
+


### PR DESCRIPTION
## Summary

Improve the security of the prime-agent container by running the application as an unprivileged user instead of root, reducing the attack surface for the Stagehand/Chromium automation environment while preserving existing functionality.

## Changes

Updated the Dockerfile to create a dedicated `talos` user (UID 1000) and run the container under that account rather than root. Adjusted runtime permissions and ownership to ensure the application, virtual environment, and required runtime files remain accessible without elevated privileges. Updated the deployment documentation with instructions for building and running the container using the new non-root configuration.

## Validation

Successfully rebuilt the Docker image and verified runtime behavior.

`docker run --rm prime-agent id`
→ `uid=1000(talos) gid=1000(talos) groups=1000(talos)`

`docker run --rm prime-agent whoami`
→ `talos`

Confirmed the container starts correctly and executes under the expected non-root user.

## Acceptance Criteria


- [x] Container runs as a non-root UID (1000)
- [x] Runtime executes as the talos user
- [x] Docker image builds successfully
- [x] Deployment documentation updated
- [x] No changes to application functionality

Closes #22
