### PR TITLE
feat(web): enforce per-ip and per-api-key rate limiting via proxy mid…

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,14 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { rateLimit, rateLimitResponse } from "@/lib/rate-limit";
-
-/**
- * Next.js Middleware — IP-based rate limiting for all /api routes.
- *
- * Tiers:
- *   - POST/PUT/PATCH (mutating): 30 req / 60 s per IP
- *   - GET  (read):               120 req / 60 s per IP
- *   - Auth routes (/api/talos/me, check-name): 20 req / 60 s per IP (brute-force guard)
- */
+import { rateLimit, rateLimitResponse, RateLimitResult } from "@/lib/rate-limit";
 
 function getClientIp(request: NextRequest): string {
   return (
@@ -16,6 +7,14 @@ function getClientIp(request: NextRequest): string {
     request.headers.get("x-real-ip") ??
     "unknown"
   );
+}
+
+function getApiKey(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    return authHeader.substring(7).trim();
+  }
+  return null;
 }
 
 export function proxy(request: NextRequest) {
@@ -27,6 +26,7 @@ export function proxy(request: NextRequest) {
   }
 
   const ip = getClientIp(request);
+  const apiKey = getApiKey(request);
   const method = request.method.toUpperCase();
 
   // Strict tier: auth-sensitive endpoints
@@ -35,24 +35,32 @@ export function proxy(request: NextRequest) {
     pathname.includes("check-name") ||
     pathname.includes("regenerate-key");
 
+  let result: RateLimitResult;
+
   if (isAuthRoute) {
-    const result = rateLimit(`auth:${ip}`, { limit: 20, windowMs: 60_000 });
-    if (!result.ok) return rateLimitResponse(result);
-    return NextResponse.next();
+    result = rateLimit(`auth:${ip}`, { limit: 20, windowMs: 60_000 });
+  } else if (method === "GET") {
+    // Public GET endpoints: 100 req/min per IP
+    result = rateLimit(`read:${ip}`, { limit: 100, windowMs: 60_000 });
+  } else if (method === "POST" && apiKey) {
+    // Authenticated POST endpoints: 30 req/min per API Key
+    result = rateLimit(`write_key:${apiKey}`, { limit: 30, windowMs: 60_000 });
+  } else {
+    // Other mutating requests or public POST: 30 req/min per IP
+    result = rateLimit(`write_ip:${ip}`, { limit: 30, windowMs: 60_000 });
   }
 
-  // Mutating requests: stricter limit
-  if (method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE") {
-    const result = rateLimit(`write:${ip}`, { limit: 30, windowMs: 60_000 });
-    if (!result.ok) return rateLimitResponse(result);
-    return NextResponse.next();
+  if (!result.ok) {
+    return rateLimitResponse(result);
   }
 
-  // Read requests
-  const result = rateLimit(`read:${ip}`, { limit: 120, windowMs: 60_000 });
-  if (!result.ok) return rateLimitResponse(result);
+  // Return standard headers on successful responses
+  const response = NextResponse.next();
+  response.headers.set("X-RateLimit-Limit", String(result.limit));
+  response.headers.set("X-RateLimit-Remaining", String(result.remaining));
+  response.headers.set("X-RateLimit-Reset", String(Math.ceil(result.resetAt / 1000)));
 
-  return NextResponse.next();
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Implement per-IP and per-API-key rate limiting across the application's API surface by activating the existing rate-limiting infrastructure through the Next.js 16 Proxy layer.

## Changes

Updated the API proxy layer to enforce sliding-window rate limits using the existing `rate-limit.ts` utility. Public GET endpoints are now limited to 100 requests per minute per IP, while authenticated POST requests are limited to 30 requests per minute per API key. Additional protection was added for mutating endpoints and sensitive authentication-related routes.

Rate limit metadata is now returned on successful requests through standard headers, including `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`. Requests that exceed the configured limits receive a `429 Too Many Requests` response along with a `Retry-After` header.

The implementation reuses the project's existing rate-limiting utilities and aligns the configuration with the current Next.js 16 Proxy middleware conventions.

## Validation

Successfully built the application with `pnpm run build` and verified the proxy layer was loaded correctly.

Performed manual verification by issuing 105 consecutive requests from the same IP address. The first 100 requests were processed normally and returned the expected rate-limit headers with a decreasing remaining count. The 101st request was correctly blocked with a `429 Too Many Requests` response and included `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` headers.

## Acceptance Criteria

* [x] Public GET endpoints are rate limited
* [x] Authenticated POST endpoints are rate limited
* [x] `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers are returned
* [x] `429 Too Many Requests` responses include a `Retry-After` header
* [x] Existing rate-limiting infrastructure is actively enforced

Closes #36
