### PR TITLE
feat(contracts): add re-initialization guard to TalosRegistry and unit tests

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -23,6 +23,22 @@ for i in "$@"; do
   esac
 done
 
+# Load env variables if .env exists
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+PROTOCOL_WALLET="${TALOS_PROTOCOL_WALLET:-}"
+if [[ -z "$PROTOCOL_WALLET" ]]; then
+  echo "▶  Fetching address for source key '$SOURCE'..."
+  PROTOCOL_WALLET=$(stellar keys address "$SOURCE" 2>/dev/null || echo "")
+  if [[ -z "$PROTOCOL_WALLET" ]]; then
+     echo "✗  Could not retrieve address for '$SOURCE'. Please set TALOS_PROTOCOL_WALLET in .env or configure the source key."
+     exit 1
+  fi
+fi
+echo "Using protocol wallet: $PROTOCOL_WALLET"
+
 echo "▶  Building Soroban contracts (release)..."
 cargo build --target wasm32-unknown-unknown --release 2>&1 | tail -5
 
@@ -42,6 +58,15 @@ REGISTRY_ID=$(stellar contract deploy \
   --source "$SOURCE")
 
 echo "   TalosRegistry:    $REGISTRY_ID"
+
+echo "▶  Initializing TalosRegistry..."
+stellar contract invoke \
+  --id "$REGISTRY_ID" \
+  --network "$NETWORK" \
+  --source "$SOURCE" \
+  -- \
+  initialize \
+  --protocol_wallet "$PROTOCOL_WALLET"
 
 echo ""
 echo "▶  Deploying TalosNameService to $NETWORK..."

--- a/contracts/talos_registry/src/lib.rs
+++ b/contracts/talos_registry/src/lib.rs
@@ -9,7 +9,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, Env, Map, String, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, Map, String, Vec,
 };
 
 // ── Data Types ──────────────────────────────────────────────────────
@@ -64,6 +64,13 @@ pub enum DataKey {
     CreatorOf(u32),
     ProtocolWallet,
     ProtocolFeeBps,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
 }
 
 // ── Events ──────────────────────────────────────────────────────────
@@ -266,6 +273,9 @@ impl TalosRegistry {
 
     /// Initialize the contract with protocol wallet and fee.
     pub fn initialize(e: Env, protocol_wallet: Address) {
+        if e.storage().persistent().has(&DataKey::ProtocolWallet) {
+            e.panic_with_error(ContractError::AlreadyInitialized);
+        }
         e.storage()
             .persistent()
             .set(&DataKey::ProtocolWallet, &protocol_wallet);
@@ -287,5 +297,39 @@ impl TalosRegistry {
     /// Get the protocol fee in basis points.
     pub fn protocol_fee_bps(e: Env) -> Option<u32> {
         e.storage().persistent().get(&DataKey::ProtocolFeeBps)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{Env, Address};
+
+    #[test]
+    fn test_initialize_happy_path() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TalosRegistry);
+        let client = TalosRegistryClient::new(&env, &contract_id);
+
+        let protocol_wallet = Address::generate(&env);
+        client.initialize(&protocol_wallet);
+
+        assert_eq!(client.protocol_wallet(), Some(protocol_wallet));
+        assert_eq!(client.protocol_fee_bps(), Some(300));
+        assert_eq!(client.next_talos_id(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "HostError: Error(Contract, #1)")]
+    fn test_initialize_already_initialized() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TalosRegistry);
+        let client = TalosRegistryClient::new(&env, &contract_id);
+
+        let protocol_wallet = Address::generate(&env);
+        client.initialize(&protocol_wallet);
+
+        // Second initialize must panic
+        client.initialize(&protocol_wallet);
     }
 }


### PR DESCRIPTION
Closes #1

### Summary
Adds a re-initialization guard to the `TalosRegistry` contract so that `initialize` cannot be executed a second time.

### Changes
- Defines `ContractError::AlreadyInitialized = 1`.
- Panics with `AlreadyInitialized` if contract is already initialized.
- Includes unit tests covering the happy path and re-initialization failure.
- Updates the deploy script `contracts/deploy.sh` to auto-initialize immediately after deploying the contract.