### PR TITLE
fix(auth): fix #3 add auth and replay protection to buy-token

### DIFF
--- a/web/src/app/api/talos/[id]/buy-token/route.ts
+++ b/web/src/app/api/talos/[id]/buy-token/route.ts
@@ -2,7 +2,7 @@ import { db } from "@/db";
 import { tlsTalos, tlsPatrons, tlsRevenues } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { getAccountInfo } from "@/lib/stellar";
+import { getAccountInfo, getNetworkPassphrase, getUSDCIssuer } from "@/lib/stellar";
 
 /**
  * Buy Mitos tokens from a Talos.
@@ -53,6 +53,79 @@ export async function POST(
   }
 
   const totalCost = Math.round(amount * pricePerToken * 1e6) / 1e6;
+
+  // ── Replay prevention ──────────────────────────────────────────────
+  const duplicate = await db.query.tlsRevenues.findFirst({
+    where: eq(tlsRevenues.txHash, txHash),
+  });
+  if (duplicate) {
+    return NextResponse.json({ error: "Transaction already used (replay)" }, { status: 409 });
+  }
+
+  // ── Horizon Transaction Verification ────────────────────────────────
+  let txResult;
+  try {
+    const { Horizon } = await import("@stellar/stellar-sdk");
+    const server = new Horizon.Server(process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org");
+    txResult = await server.transactions().transaction(txHash).call();
+  } catch (err: any) {
+    console.error("[buy-token] Transaction fetch failed:", err?.message ?? err);
+    return NextResponse.json({ error: "Transaction not found on Stellar network" }, { status: 400 });
+  }
+
+  if (!txResult.successful) {
+    return NextResponse.json({ error: "Transaction was not successful on-chain" }, { status: 400 });
+  }
+
+  try {
+    const { TransactionBuilder, Asset } = await import("@stellar/stellar-sdk");
+    const networkPassphrase = getNetworkPassphrase();
+    const usdcIssuer = getUSDCIssuer();
+    const usdcAsset = new Asset("USDC", usdcIssuer);
+
+    const tx = TransactionBuilder.fromXDR(txResult.envelope_xdr, networkPassphrase);
+
+    // Validate: source_account == buyerPublicKey
+    if (tx.source !== buyerPublicKey && txResult.source_account !== buyerPublicKey) {
+      return NextResponse.json(
+        { error: "Transaction signer does not match buyerPublicKey" },
+        { status: 400 },
+      );
+    }
+
+    // Validate at least one operation is a USDC payment of the correct amount to the treasury
+    const ops = tx.operations as unknown as Array<{
+      type: string;
+      asset?: { code: string; issuer: string };
+      destination?: string;
+      amount?: string;
+    }>;
+
+    const operatorTreasury = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+    const expectedDestinations = [operatorTreasury];
+    if (talos.agentWalletAddress) {
+      expectedDestinations.push(talos.agentWalletAddress);
+    }
+
+    const hasValidPayment = ops.some(
+      (op) =>
+        op.type === "payment" &&
+        op.asset?.code === usdcAsset.code &&
+        op.asset?.issuer === usdcAsset.issuer &&
+        expectedDestinations.includes(op.destination ?? "") &&
+        Math.abs(parseFloat(op.amount ?? "0") - totalCost) <= 1e-6
+    );
+
+    if (!hasValidPayment) {
+      return NextResponse.json(
+        { error: "No matching USDC payment found in transaction" },
+        { status: 400 },
+      );
+    }
+  } catch (err: any) {
+    console.error("[buy-token] Transaction verification failed:", err?.message ?? err);
+    return NextResponse.json({ error: "Failed to verify transaction details" }, { status: 400 });
+  }
 
   // Verify buyer's Stellar account exists
   const accountInfo = await getAccountInfo(buyerPublicKey);

--- a/web/tests/buy-token.test.ts
+++ b/web/tests/buy-token.test.ts
@@ -1,0 +1,374 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../src/app/api/talos/[id]/buy-token/route";
+import { Keypair, Asset, TransactionBuilder, Operation, Networks, Account } from "@stellar/stellar-sdk";
+
+// Use vi.hoisted to declare mock functions so they are hoisted along with the vi.mock calls,
+// preventing any TypeScript linting or execution scoping warnings.
+const mocks = vi.hoisted(() => {
+  const transactionCall = vi.fn();
+  const submitTransaction = vi.fn();
+  const transactions = vi.fn(() => ({
+    transaction: vi.fn(() => ({
+      call: transactionCall,
+    })),
+  }));
+
+  return {
+    mockFindFirstTalos: vi.fn(),
+    mockFindFirstRevenue: vi.fn(),
+    mockFindFirstPatrons: vi.fn(),
+    mockInsert: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockGetAccountInfo: vi.fn(),
+    mockGetNetworkPassphrase: vi.fn(() => "Test SDF Network ; September 2015"),
+    mockGetUSDCIssuer: vi.fn(() => "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+    mockTransactionCall: transactionCall,
+    mockTransactions: transactions,
+    mockSubmitTransaction: submitTransaction,
+  };
+});
+
+const {
+  mockFindFirstTalos,
+  mockFindFirstRevenue,
+  mockFindFirstPatrons,
+  mockInsert,
+  mockUpdate,
+  mockGetAccountInfo,
+  mockGetNetworkPassphrase,
+  mockGetUSDCIssuer,
+  mockTransactionCall,
+  mockTransactions,
+  mockSubmitTransaction,
+} = mocks;
+
+vi.mock("@/db", () => {
+  return {
+    db: {
+      query: {
+        tlsTalos: {
+          findFirst: (...args: any[]) => mocks.mockFindFirstTalos(...args),
+        },
+        tlsRevenues: {
+          findFirst: (...args: any[]) => mocks.mockFindFirstRevenue(...args),
+        },
+        tlsPatrons: {
+          findFirst: (...args: any[]) => mocks.mockFindFirstPatrons(...args),
+        },
+      },
+      insert: (...args: any[]) => mocks.mockInsert(...args),
+      update: (...args: any[]) => mocks.mockUpdate(...args),
+    },
+  };
+});
+
+vi.mock("@/lib/stellar", () => {
+  return {
+    getAccountInfo: (...args: any[]) => mocks.mockGetAccountInfo(...args),
+    getNetworkPassphrase: (...args: any[]) => mocks.mockGetNetworkPassphrase(...args),
+    getUSDCIssuer: (...args: any[]) => mocks.mockGetUSDCIssuer(...args),
+  };
+});
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...original,
+    Horizon: {
+      Server: class {
+        loadAccount = vi.fn().mockImplementation(async (publicKey: string) => {
+          const account = new Account(publicKey, "12345");
+          (account as any).balances = [{ asset_type: "native", balance: "100" }];
+          return account;
+        });
+        transactions = mocks.mockTransactions;
+        submitTransaction = (...args: any[]) => mocks.mockSubmitTransaction(...args);
+      },
+    },
+  };
+});
+
+describe("POST /api/talos/[id]/buy-token — Verification Tests", () => {
+  const operatorTreasury = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockResolvedValue([]),
+    });
+    mockUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+  });
+
+  it("returns 409 Conflict if txHash has already been processed (duplicate/replay)", async () => {
+    // Mock existing revenue record with the same txHash
+    mockFindFirstTalos.mockResolvedValue({
+      id: "agent-id",
+      pulsePrice: "1.0",
+    });
+    mockFindFirstRevenue.mockResolvedValue({
+      id: "rev-123",
+      txHash: "duplicate-tx-hash",
+    });
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey: "GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV",
+        amount: 10,
+        txHash: "duplicate-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("replay");
+  });
+
+  it("returns 400 Bad Request if transaction is not found on Horizon", async () => {
+    mockFindFirstTalos.mockResolvedValue({
+      id: "agent-id",
+      pulsePrice: "1.0",
+    });
+    mockFindFirstRevenue.mockResolvedValue(null);
+
+    // Mock Horizon call throwing an error (transaction not found)
+    mockTransactionCall.mockRejectedValue(new Error("Horizon error: 404 Not Found"));
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey: "GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV",
+        amount: 10,
+        txHash: "missing-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Stellar network");
+  });
+
+  it("returns 400 Bad Request if the transaction was not successful on-chain", async () => {
+    mockFindFirstTalos.mockResolvedValue({
+      id: "agent-id",
+      pulsePrice: "1.0",
+    });
+    mockFindFirstRevenue.mockResolvedValue(null);
+
+    mockTransactionCall.mockResolvedValue({
+      successful: false,
+      source_account: "GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV",
+    });
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey: "GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV",
+        amount: 10,
+        txHash: "failed-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("was not successful");
+  });
+
+  it("returns 400 Bad Request if transaction source_account does not match buyerPublicKey", async () => {
+    mockFindFirstTalos.mockResolvedValue({
+      id: "agent-id",
+      pulsePrice: "1.0",
+    });
+    mockFindFirstRevenue.mockResolvedValue(null);
+
+    // Build a transaction signed by a different key than the claimed buyerPublicKey
+    const buyerKeypair = Keypair.random();
+    const otherKeypair = Keypair.random();
+    const sourceAccount = new Account(otherKeypair.publicKey(), "123456789012345");
+    const usdcAsset = new Asset("USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "100",
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: operatorTreasury,
+          asset: usdcAsset,
+          amount: "10.0000000",
+        })
+      )
+      .setTimeout(60)
+      .build();
+
+    tx.sign(otherKeypair);
+
+    mockTransactionCall.mockResolvedValue({
+      successful: true,
+      source_account: otherKeypair.publicKey(),
+      envelope_xdr: tx.toXDR(),
+    });
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey: buyerKeypair.publicKey(), // claim to be buyer, but transaction source is otherKeypair
+        amount: 10,
+        txHash: "valid-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("signer does not match");
+  });
+
+  it("returns 400 Bad Request if the payment destination, asset, or amount mismatch", async () => {
+    mockFindFirstTalos.mockResolvedValue({
+      id: "agent-id",
+      pulsePrice: "1.0",
+    });
+    mockFindFirstRevenue.mockResolvedValue(null);
+
+    const buyerKeypair = Keypair.random();
+    const buyerPublicKey = buyerKeypair.publicKey();
+    const sourceAccount = new Account(buyerPublicKey, "123456789012345");
+    const usdcAsset = new Asset("USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+
+    // Invalid Destination (pays to another user instead of Operator Treasury)
+    const txWrongDest = new TransactionBuilder(sourceAccount, {
+      fee: "100",
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: Keypair.random().publicKey(),
+          asset: usdcAsset,
+          amount: "10.0000000",
+        })
+      )
+      .setTimeout(60)
+      .build();
+    txWrongDest.sign(buyerKeypair);
+
+    mockTransactionCall.mockResolvedValue({
+      successful: true,
+      source_account: buyerPublicKey,
+      envelope_xdr: txWrongDest.toXDR(),
+    });
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey,
+        amount: 10, // expecting 10 USDC
+        txHash: "valid-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("No matching USDC payment");
+  });
+
+  it("processes happy path successfully, issuing Mitos tokens on valid payment details", async () => {
+    const mockTalos = {
+      id: "agent-id",
+      pulsePrice: "0.5",
+      stellarAssetCode: "MITOS:GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV",
+      minPatronPulse: 100,
+      agentWalletAddress: "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL",
+      tokenSymbol: "MITOS",
+    };
+    mockFindFirstTalos.mockResolvedValue(mockTalos);
+    mockFindFirstRevenue.mockResolvedValue(null);
+    mockFindFirstPatrons.mockResolvedValue(null);
+
+    mockGetAccountInfo.mockResolvedValue({
+      exists: true,
+      xlmBalance: "100",
+      usdcBalance: "1000",
+    });
+
+    const buyerKeypair = Keypair.random();
+    const buyerPublicKey = buyerKeypair.publicKey();
+    const sourceAccount = new Account(buyerPublicKey, "123456789012345");
+    const usdcAsset = new Asset("USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+
+    // Total cost for 10 tokens at 0.5 USDC = 5 USDC
+    const totalCost = 5;
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "100",
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL",
+          asset: usdcAsset,
+          amount: "5.0000000",
+        })
+      )
+      .setTimeout(60)
+      .build();
+
+    tx.sign(buyerKeypair);
+
+    mockTransactionCall.mockResolvedValue({
+      successful: true,
+      source_account: buyerPublicKey,
+      envelope_xdr: tx.toXDR(),
+    });
+
+    mockSubmitTransaction.mockResolvedValue({
+      hash: "mitos-transfer-tx-hash",
+    });
+
+    // Mock operator secret key
+    process.env.STELLAR_OPERATOR_SECRET_KEY = Keypair.random().secret();
+
+    const request = new Request("http://localhost/api/talos/agent-id/buy-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        buyerPublicKey,
+        amount: 10,
+        txHash: "valid-tx-hash",
+      }),
+    });
+
+    const params = Promise.resolve({ id: "agent-id" });
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.mitosTxHash).toBe("mitos-transfer-tx-hash");
+    expect(body.totalCost).toBe(totalCost);
+    expect(mockInsert).toHaveBeenCalled();
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     testTimeout: 30_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
Closes #3 

# PR Description
This PR implements robust authentication, replay prevention, and on-chain payment validation to the `POST /api/talos/[id]/buy-token` route.

### Context & Problem
Previously, the endpoint that credits Mitos token ownership lacked protection against malicious inputs:
1. There was no uniqueness validation for `txHash`, allowing the same transaction hash to be replayed multiple times.
2. The endpoint did not contact the Stellar Horizon network to verify if the payment actually occurred.
3. No cryptographic connection existed between the requesting `buyerPublicKey` and the on-chain sender of the USDC.

An attacker could exploit these gaps to repeatedly POST a single legitimate transaction hash, artificially inflating their pulse holdings and claiming patron status without paying.

### How the Flow Works Now
1. **Replay Protection**: The database `tlsRevenues` table is queried first for the incoming `txHash`. If the hash is found (representing a previously credited transaction), the route immediately returns a `409 Conflict`.
2. **On-Chain Retrieval**: The transaction details are fetched directly from the Stellar Horizon network using `@stellar/stellar-sdk`'s `Horizon.Server`. If the transaction cannot be retrieved, the route returns a `400 Bad Request`.
3. **Consensus Success Check**: The route verifies that `txResult.successful === true` to ensure that failed transactions (which do not transfer any funds) cannot be used to spoof payments.
4. **Identity Authentication**: The route decodes the transaction envelope from XDR and validates that the transaction's source account (`tx.source` or `txResult.source_account`) matches the `buyerPublicKey` supplied in the request body. This ensures that only the account that authorized the on-chain transaction can claim the corresponding Mitos tokens.
5. **Asset and Recipient Validation**: The route scans the transaction operations for a `payment` operation that:
   - Uses the correct `USDC` asset (matching the code and issuer depending on testnet/mainnet).
   - Pays the correct computed `totalCost` (based on amount bought and token price).
   - Sends the funds to either the agent's wallet address (`talos.agentWalletAddress`) or the Operator Treasury (`GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL`).
   If no such payment operation is found, a `400 Bad Request` is returned.

# Changed
- **`web/src/app/api/talos/[id]/buy-token/route.ts`**:
  - Added query to check for duplicate `txHash` usage to prevent transaction replays.
  - Added `@stellar/stellar-sdk` imports to retrieve on-chain transaction details and check `successful` status.
  - Decoded transaction XDR to assert `source_account` equals `buyerPublicKey` and verify valid `USDC` payments to the treasury or agent wallet for the computed cost.
- **`web/vitest.config.ts`**:
  - Configured custom resolve alias mappings for `@/` to support clean imports in the Vitest test environment.
- **`web/tests/buy-token.test.ts`**:
  - Implemented new Vitest suite testing error paths (duplicate txHash, non-existent tx, failed tx, mismatch signer, and parameter changes) and happy path validation.

# Testing
To run the automated verification suite for this issue, execute the following command:
```bash
npx vitest run tests/buy-token.test.ts
```