### PR TITLE
leaderboard: paginate Top TALOS with cursor-based fetch

### DIFF
--- a/web/src/app/api/leaderboard/route.ts
+++ b/web/src/app/api/leaderboard/route.ts
@@ -1,10 +1,15 @@
+import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPatrons, tlsActivities, tlsRevenues } from "@/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
-// GET /api/leaderboard — Ranking data
-export async function GET() {
+// GET /api/leaderboard — Ranking data with cursor-based pagination
+export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = request.nextUrl;
+    const cursor = searchParams.get("cursor");
+    const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 1), 100);
+
     const patronCount = db
       .select({
         talosId: tlsPatrons.talosId,
@@ -32,6 +37,21 @@ export async function GET() {
       .groupBy(tlsRevenues.talosId)
       .as("revenueSum");
 
+    const conditions: ReturnType<typeof sql>[] = [];
+
+    if (cursor) {
+      const [cursorRevenue, cursorId] = JSON.parse(
+        Buffer.from(cursor, "base64").toString(),
+      );
+      if (typeof cursorRevenue === "number" && cursorId) {
+        conditions.push(
+          sql`coalesce(${revenueSum.total}, 0) < ${cursorRevenue}
+              OR (coalesce(${revenueSum.total}, 0) = ${cursorRevenue}
+                  AND ${tlsTalos.id} < ${cursorId})`,
+        );
+      }
+    }
+
     const rows = await db
       .select({
         id: tlsTalos.id,
@@ -42,14 +62,20 @@ export async function GET() {
         totalSupply: tlsTalos.totalSupply,
         patronCount: patronCount.count,
         activityCount: activityCount.count,
-        totalRevenue: revenueSum.total,
+        totalRevenue: sql<number>`coalesce(${revenueSum.total}, 0)`,
       })
       .from(tlsTalos)
       .leftJoin(patronCount, eq(tlsTalos.id, patronCount.talosId))
       .leftJoin(activityCount, eq(tlsTalos.id, activityCount.talosId))
-      .leftJoin(revenueSum, eq(tlsTalos.id, revenueSum.talosId));
+      .leftJoin(revenueSum, eq(tlsTalos.id, revenueSum.talosId))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(sql`coalesce(${revenueSum.total}, 0) desc`, desc(tlsTalos.id))
+      .limit(limit + 1);
 
-    const leaderboard = rows.map((c) => ({
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+
+    const data = page.map((c) => ({
       id: c.id,
       name: c.name,
       category: c.category,
@@ -62,9 +88,15 @@ export async function GET() {
       marketCap: Number(c.pulsePrice) * c.totalSupply,
     }));
 
-    leaderboard.sort((a, b) => b.totalRevenue - a.totalRevenue);
+    const lastItem = page[page.length - 1];
+    const nextCursor =
+      hasMore && lastItem
+        ? Buffer.from(
+            JSON.stringify([lastItem.totalRevenue, lastItem.id]),
+          ).toString("base64")
+        : null;
 
-    return Response.json(leaderboard);
+    return Response.json({ data, nextCursor });
   } catch {
     return Response.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/web/src/app/leaderboard/leaderboard-client.tsx
+++ b/web/src/app/leaderboard/leaderboard-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { AgentAvatar } from "@/components/agent-avatar";
 
 const TABS = ["Top TALOS", "Top Patrons", "Top Agents", "Trending"] as const;
@@ -48,20 +48,85 @@ interface TrendingEntry {
   pulsePrice: number;
 }
 
+interface ApiEntry {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  pulsePrice: string;
+  totalSupply: number;
+  patronCount: number;
+  activityCount: number;
+  totalRevenue: number;
+  marketCap: number;
+}
+
+function formatRevenue(revenue: number): string {
+  return `$${revenue.toLocaleString()}`;
+}
+
+function formatMarketCap(marketCap: number): string {
+  return marketCap >= 1_000_000
+    ? `$${(marketCap / 1_000_000).toFixed(1)}M`
+    : `$${(marketCap / 1000).toFixed(0)}K`;
+}
+
+function toDisplayEntry(e: ApiEntry, rank: number): TopTalosEntry {
+  return {
+    rank,
+    id: e.id,
+    name: e.name,
+    category: e.category,
+    revenueStr: formatRevenue(e.totalRevenue),
+    marketCapStr: formatMarketCap(e.marketCap),
+    patrons: e.patronCount,
+  };
+}
+
 interface Props {
-  topTalos: TopTalosEntry[];
   topPatrons: TopPatronEntry[];
   topAgents: TopAgentEntry[];
   trending: TrendingEntry[];
 }
 
-export function LeaderboardClient({ topTalos, topPatrons, topAgents, trending }: Props) {
+export function LeaderboardClient({ topPatrons, topAgents, trending }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("Top TALOS");
+  const [entries, setEntries] = useState<TopTalosEntry[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPage = useCallback(async (cursor: string | null) => {
+    const params = new URLSearchParams({ limit: "50" });
+    if (cursor) params.set("cursor", cursor);
+    const res = await fetch(`/api/leaderboard?${params}`);
+    const body = await res.json();
+    return body as { data: ApiEntry[]; nextCursor: string | null };
+  }, []);
+
+  useEffect(() => {
+    fetchPage(null).then((body) => {
+      setEntries(body.data.map((e, i) => toDisplayEntry(e, i + 1)));
+      setNextCursor(body.nextCursor);
+      setLoading(false);
+    });
+  }, [fetchPage]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!nextCursor) return;
+    setLoading(true);
+    const body = await fetchPage(nextCursor);
+    setEntries((prev) => [
+      ...prev,
+      ...body.data.map((e, i) => toDisplayEntry(e, prev.length + i + 1)),
+    ]);
+    setNextCursor(body.nextCursor);
+    setLoading(false);
+  }, [nextCursor, fetchPage]);
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-12">
       <div className="mb-10">
-        <div className="text-sm text-muted mb-2 tracking-wide">// RANKINGS</div>
+        <div className="text-sm text-muted mb-2 tracking-wide">RANKINGS</div>
         <h1 className="text-accent text-2xl font-bold tracking-wide mb-2">Leaderboard</h1>
         <p className="text-muted text-sm">Rankings across the TALOS ecosystem</p>
       </div>
@@ -86,7 +151,7 @@ export function LeaderboardClient({ topTalos, topPatrons, topAgents, trending }:
         <>
           {/* Mobile cards */}
           <div className="sm:hidden space-y-2">
-            {topTalos.map((e) => (
+            {entries.map((e) => (
               <div key={e.id} className="bg-surface border border-border p-4">
                 <div className="flex items-center gap-3 mb-2">
                   <span className="text-accent font-bold w-6 shrink-0">{e.rank}</span>
@@ -116,7 +181,7 @@ export function LeaderboardClient({ topTalos, topPatrons, topAgents, trending }:
                 </tr>
               </thead>
               <tbody>
-                {topTalos.map((e) => (
+                {entries.map((e) => (
                   <tr key={e.id} className="border-b border-border hover:bg-surface transition-colors">
                     <td className="py-3 pr-6 text-accent font-bold">{e.rank}</td>
                     <td className="py-3 pr-6 text-foreground">
@@ -134,6 +199,18 @@ export function LeaderboardClient({ topTalos, topPatrons, topAgents, trending }:
               </tbody>
             </table>
           </div>
+          {/* Load more */}
+          {nextCursor && (
+            <div className="flex justify-center mt-8">
+              <button
+                onClick={handleLoadMore}
+                disabled={loading}
+                className="border border-accent text-accent bg-transparent px-6 py-2 text-sm font-medium hover:bg-accent/10 transition-all disabled:opacity-40"
+              >
+                {loading ? "Loading..." : "Load More"}
+              </button>
+            </div>
+          )}
         </>
       )}
 

--- a/web/src/app/leaderboard/page.tsx
+++ b/web/src/app/leaderboard/page.tsx
@@ -15,31 +15,6 @@ export default async function LeaderboardPage() {
     },
   });
 
-  // Top TALOS — by revenue
-  const topTalos = agents
-    .map((c) => {
-      const totalRevenue = c.revenues.reduce((sum, r) => sum + Number(r.amount), 0);
-      return {
-        id: c.id,
-        name: c.name,
-        category: c.category,
-        revenue: totalRevenue,
-        marketCap: Number(c.pulsePrice) * c.totalSupply,
-        patrons: c.patrons.length,
-        pulsePrice: Number(c.pulsePrice),
-        activityCount: c.activities.length,
-      };
-    })
-    .sort((a, b) => b.revenue - a.revenue)
-    .map((e, i) => ({
-      ...e,
-      rank: i + 1,
-      revenueStr: `$${e.revenue.toLocaleString()}`,
-      marketCapStr: e.marketCap >= 1_000_000
-        ? `$${(e.marketCap / 1_000_000).toFixed(1)}M`
-        : `$${(e.marketCap / 1000).toFixed(0)}K`,
-    }));
-
   // Top Patrons — by total Pulse across all TALOS agents
   const patronMap = new Map<string, { wallet: string; totalPulse: number; talosCount: number; roles: string[] }>();
   for (const c of agents) {
@@ -111,7 +86,6 @@ export default async function LeaderboardPage() {
 
   return (
     <LeaderboardClient
-      topTalos={topTalos}
       topPatrons={topPatrons}
       topAgents={topAgents}
       trending={trending}

--- a/web/tests/api-e2e.test.ts
+++ b/web/tests/api-e2e.test.ts
@@ -515,9 +515,10 @@ describe("GET /api/leaderboard", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body).toHaveProperty("nextCursor");
 
-    const found = body.find((c: { id: string }) => c.id === talosId);
+    const found = body.data.find((c: { id: string }) => c.id === talosId);
     expect(found).toBeDefined();
     expect(found.name).toBe("E2E Test Agent");
     expect(typeof found.totalRevenue).toBe("number");
@@ -774,14 +775,48 @@ describe("GET /api/leaderboard", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body).toHaveProperty("nextCursor");
 
-    const found = body.find((c: { id: string }) => c.id === talosId);
+    const found = body.data.find((c: { id: string }) => c.id === talosId);
     expect(found).toBeDefined();
     expect(typeof found.patronCount).toBe("number");
     expect(typeof found.activityCount).toBe("number");
     expect(typeof found.totalRevenue).toBe("number");
     expect(typeof found.marketCap).toBe("number");
+  });
+});
+
+describe("GET /api/leaderboard — cursor traversal", () => {
+  it("paginates correctly from page 1 to page 2", async () => {
+    // Fetch first page with limit=1
+    const res1 = await api("/api/leaderboard?limit=1");
+    expect(res1.status).toBe(200);
+
+    const page1 = await res1.json();
+    expect(Array.isArray(page1.data)).toBe(true);
+    expect(page1.data.length).toBeLessThanOrEqual(1);
+
+    // If no nextCursor, there's nothing to page through
+    if (!page1.nextCursor) return;
+
+    const id1 = page1.data[0]?.id;
+
+    // Fetch page 2 using cursor
+    const res2 = await api(`/api/leaderboard?limit=1&cursor=${encodeURIComponent(page1.nextCursor)}`);
+    expect(res2.status).toBe(200);
+
+    const page2 = await res2.json();
+    expect(Array.isArray(page2.data)).toBe(true);
+    expect(page2.data.length).toBeLessThanOrEqual(1);
+
+    // Page 2 should not contain the same item as page 1
+    if (id1 && page2.data.length > 0) {
+      expect(page2.data[0].id).not.toBe(id1);
+    }
+
+    // nextCursor should exist if more pages remain
+    expect(page2).toHaveProperty("nextCursor");
   });
 });
 


### PR DESCRIPTION
Closes #11 
**SUMMARY**

The Top TALOS tab was loading all agents server-side and computing rankings in memory — unbounded query cost that would degrade as the agent count grows.

This PR replaces that with a paginated API endpoint:

- **`GET /api/leaderboard`** accepts `?limit=` (default 50, max 100) and `?cursor=` (base64-encoded `[totalRevenue, talosId]` tuple)
- Rankings are sorted in SQL via `ORDER BY revenue DESC, id DESC` — seek-based pagination avoids `OFFSET`
- Server-side Top TALOS computation removed from `page.tsx`; the other 3 tabs (Top Patrons, Top Agents, Trending) remain server-rendered as-is
- Client component fetches page 1 on mount, renders a **"Load More"** button for subsequent pages with correct rank continuity
- E2E tests updated: existing tests check `{ data, nextCursor }` shape; new cursor traversal test verifies page 1 → page 2 with no ID overlap

**Files changed:**
- `web/src/app/api/leaderboard/route.ts` — new paginated endpoint
- `web/src/app/leaderboard/leaderboard-client.tsx` — client-side fetching with Load More
- `web/src/app/leaderboard/page.tsx` — removed Top TALOS server computation
- `web/tests/api-e2e.test.ts` — added cursor traversal test