### PR TITLE
 feat(agent): retry + exponential backoff for external HTTP calls

### DIFF
--- a/packages/prime-agent/pyproject.toml
+++ b/packages/prime-agent/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "rich>=13.7",
     "stellar-sdk>=11.0",
     "cryptography>=41.0",
+    "tenacity>=8.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/prime-agent/src/talos_agent/agent/loop.py
+++ b/packages/prime-agent/src/talos_agent/agent/loop.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from talos_agent.agent.context import AgentContext
 from talos_agent.agent.prompt import build_system_prompt
+from talos_agent.http import call_with_retry
 
 if TYPE_CHECKING:
     from talos_agent.config import Settings
@@ -60,11 +61,13 @@ async def agent_loop(
 
         console.print(f"[dim]Agent iteration {iteration + 1}...[/dim]")
 
-        response = await client.chat.completions.create(
-            model=settings.llm_model,
-            messages=messages,
-            tools=tool_schemas if tool_schemas else None,
-            tool_choice="auto" if tool_schemas else None,
+        response = await call_with_retry(
+            lambda: client.chat.completions.create(
+                model=settings.llm_model,
+                messages=messages,
+                tools=tool_schemas if tool_schemas else None,
+                tool_choice="auto" if tool_schemas else None,
+            )
         )
 
         msg = response.choices[0].message

--- a/packages/prime-agent/src/talos_agent/api_client.py
+++ b/packages/prime-agent/src/talos_agent/api_client.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 
 from talos_agent.config import Settings
+from talos_agent.http import request_with_retry
 
 
 class TalosAPIClient:
@@ -22,17 +23,31 @@ class TalosAPIClient:
             timeout=30.0,
         )
 
+    # ── Retry-wrapped HTTP verbs ──────────────────────────
+
+    async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await request_with_retry(lambda: self._client.get(url, **kwargs))
+
+    async def _post(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await request_with_retry(lambda: self._client.post(url, **kwargs))
+
+    async def _put(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await request_with_retry(lambda: self._client.put(url, **kwargs))
+
+    async def _patch(self, url: str, **kwargs: Any) -> httpx.Response:
+        return await request_with_retry(lambda: self._client.patch(url, **kwargs))
+
     # ── Talos Config ──────────────────────────────────────
 
     async def get_talos(self, talos_id: str) -> dict | None:
-        r = await self._client.get(f"/api/talos/{talos_id}")
+        r = await self._get(f"/api/talos/{talos_id}")
         if r.status_code == 200:
             return r.json()
         return None
 
     async def get_talos_me(self) -> dict | None:
         """Resolve Talos from API key — no Talos ID needed."""
-        r = await self._client.get("/api/talos/me")
+        r = await self._get("/api/talos/me")
         if r.status_code == 200:
             return r.json()
         return None
@@ -42,7 +57,7 @@ class TalosAPIClient:
     async def report_activity(
         self, talos_id: str, *, type_: str, content: str, channel: str
     ) -> dict | None:
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{talos_id}/activity",
             json={"type": type_, "content": content, "channel": channel},
         )
@@ -53,7 +68,7 @@ class TalosAPIClient:
     # ── Status ─────────────────────────────────────────────
 
     async def update_status(self, talos_id: str, *, online: bool) -> None:
-        await self._client.patch(
+        await self._patch(
             f"/api/talos/{talos_id}/status",
             json={"agentOnline": online},
         )
@@ -63,7 +78,7 @@ class TalosAPIClient:
     async def report_revenue(
         self, talos_id: str, *, amount: float, source: str, tx_hash: str | None = None
     ) -> dict | None:
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{talos_id}/revenue",
             json={"amount": amount, "currency": "USDC", "source": source, "txHash": tx_hash},
         )
@@ -82,7 +97,7 @@ class TalosAPIClient:
         description: str | None = None,
         amount: float | None = None,
     ) -> dict | None:
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{talos_id}/approvals",
             json={"type": type_, "title": title, "description": description, "amount": amount},
         )
@@ -94,14 +109,14 @@ class TalosAPIClient:
         params: dict[str, Any] = {}
         if status:
             params["status"] = status
-        r = await self._client.get(f"/api/talos/{talos_id}/approvals", params=params)
+        r = await self._get(f"/api/talos/{talos_id}/approvals", params=params)
         if r.status_code == 200:
             data = r.json()
             return data if isinstance(data, list) else data.get("approvals", [])
         return []
 
     async def get_approval(self, talos_id: str, approval_id: str) -> dict | None:
-        r = await self._client.get(f"/api/talos/{talos_id}/approvals/{approval_id}")
+        r = await self._get(f"/api/talos/{talos_id}/approvals/{approval_id}")
         if r.status_code == 200:
             return r.json()
         return None
@@ -110,14 +125,14 @@ class TalosAPIClient:
 
     async def get_agent_wallet(self) -> dict | None:
         """Fetch agent wallet info (walletId, address) from Web."""
-        r = await self._client.get(f"/api/talos/{self._talos_id}/wallet")
+        r = await self._get(f"/api/talos/{self._talos_id}/wallet")
         if r.status_code == 200:
             return r.json()
         return None
 
     async def create_agent_wallet(self) -> dict | None:
         """Create a Circle MPC wallet for this Talos if one doesn't exist."""
-        r = await self._client.post(f"/api/talos/{self._talos_id}/wallet")
+        r = await self._post(f"/api/talos/{self._talos_id}/wallet")
         if r.status_code in (200, 201):
             return r.json()
         return None
@@ -136,7 +151,7 @@ class TalosAPIClient:
         payload: dict[str, Any] = {"payee": payee, "amount": amount, "assetCode": asset_code}
         if asset_issuer:
             payload["assetIssuer"] = asset_issuer
-        r = await self._client.post(f"/api/talos/{self._talos_id}/sign", json=payload)
+        r = await self._post(f"/api/talos/{self._talos_id}/sign", json=payload)
         if r.status_code == 200:
             return r.json()
         # Return error details
@@ -152,13 +167,13 @@ class TalosAPIClient:
         params = {}
         if service_type:
             params["type"] = service_type
-        return await self._client.get(f"/api/talos/{talos_id}/service", params=params)
+        return await self._get(f"/api/talos/{talos_id}/service", params=params)
 
     async def submit_commerce(
         self, talos_id: str, *, payment_header: str, payload: dict | None = None
     ) -> dict | None:
         """POST with x402 payment signature to purchase service."""
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{talos_id}/service",
             json={"payload": payload},
             headers={"X-PAYMENT": payment_header},
@@ -179,7 +194,7 @@ class TalosAPIClient:
             params["category"] = category
         if target:
             params["target"] = target
-        r = await self._client.get("/api/services", params=params)
+        r = await self._get("/api/services", params=params)
         if r.status_code == 200:
             data = r.json()
             return data if isinstance(data, list) else data.get("data", [])
@@ -202,7 +217,7 @@ class TalosAPIClient:
         }
         if wallet_address:
             payload["walletAddress"] = wallet_address
-        r = await self._client.put(f"/api/talos/{talos_id}/service", json=payload)
+        r = await self._put(f"/api/talos/{talos_id}/service", json=payload)
         if r.status_code in (200, 201):
             return r.json()
         return None
@@ -225,7 +240,7 @@ class TalosAPIClient:
         }
         if token_id:
             payload["tokenId"] = token_id
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{self._talos_id}/transfer", json=payload
         )
         if r.status_code in (200, 201):
@@ -238,20 +253,20 @@ class TalosAPIClient:
     # ── Jobs ───────────────────────────────────────────────
 
     async def get_pending_jobs(self) -> list[dict]:
-        r = await self._client.get("/api/jobs/pending")
+        r = await self._get("/api/jobs/pending")
         if r.status_code == 200:
             data = r.json()
             return data if isinstance(data, list) else data.get("jobs", [])
         return []
 
     async def submit_job_result(self, job_id: str, result: dict) -> dict | None:
-        r = await self._client.post(f"/api/jobs/{job_id}/result", json={"result": result})
+        r = await self._post(f"/api/jobs/{job_id}/result", json={"result": result})
         if r.status_code in (200, 201):
             return r.json()
         return None
 
     async def get_job_result(self, job_id: str) -> dict | None:
-        r = await self._client.get(f"/api/jobs/{job_id}/result")
+        r = await self._get(f"/api/jobs/{job_id}/result")
         if r.status_code == 200:
             return r.json()
         return None
@@ -274,7 +289,7 @@ class TalosAPIClient:
         period_days: int = 30,
     ) -> dict | None:
         """Publish a Playbook to the marketplace."""
-        r = await self._client.post(
+        r = await self._post(
             "/api/playbooks",
             json={
                 "title": title,

--- a/packages/prime-agent/src/talos_agent/http.py
+++ b/packages/prime-agent/src/talos_agent/http.py
@@ -1,0 +1,115 @@
+"""Shared retry helpers for external HTTP and LLM calls.
+
+Transient failures (network timeouts, 429/502/503/504) automatically retry
+with exponential backoff plus jitter before propagating. Without this,
+every agent cycle pays full price for a single hiccup.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, TypeVar
+
+import httpx
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
+MAX_ATTEMPTS = 3
+WAIT_INITIAL = 1.0
+WAIT_MAX = 10.0
+
+T = TypeVar("T")
+
+
+class RetryableHTTPError(Exception):
+    """Wraps a retryable HTTP response so tenacity can drive retries."""
+
+    def __init__(self, response: httpx.Response):
+        self.response = response
+        self.status_code = response.status_code
+        try:
+            url = str(response.request.url)
+        except RuntimeError:
+            url = str(response.url)
+        super().__init__(f"HTTP {response.status_code} from {url}")
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    if isinstance(exc, (RetryableHTTPError, httpx.TimeoutException)):
+        return True
+    # openai SDK errors — imported lazily so http.py doesn't hard-require openai.
+    try:
+        import openai
+    except ImportError:
+        return False
+    if isinstance(exc, (openai.APITimeoutError, openai.APIConnectionError)):
+        return True
+    if isinstance(exc, openai.APIStatusError):
+        status = getattr(exc, "status_code", None)
+        return status in RETRYABLE_STATUSES
+    return False
+
+
+def _log_before_sleep(retry_state: RetryCallState) -> None:
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    status = getattr(exc, "status_code", None)
+    detail = f"status={status}" if status is not None else type(exc).__name__
+    next_wait = getattr(retry_state.next_action, "sleep", 0.0) or 0.0
+    logger.warning(
+        "HTTP retry %d/%d (%s) — sleeping %.2fs",
+        retry_state.attempt_number,
+        MAX_ATTEMPTS,
+        detail,
+        next_wait,
+    )
+
+
+def _retry_policy() -> AsyncRetrying:
+    return AsyncRetrying(
+        stop=stop_after_attempt(MAX_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=WAIT_INITIAL, max=WAIT_MAX),
+        retry=retry_if_exception(_is_retryable),
+        before_sleep=_log_before_sleep,
+        reraise=True,
+    )
+
+
+async def request_with_retry(
+    send: Callable[[], Awaitable[httpx.Response]],
+) -> httpx.Response:
+    """Execute an httpx call with bounded retries on transient failures.
+
+    Retries on httpx.TimeoutException or responses with status in
+    {429, 502, 503, 504}. After MAX_ATTEMPTS the final exception
+    propagates (RetryableHTTPError or httpx.TimeoutException).
+    Non-retryable responses (including other 4xx/5xx) are returned
+    so callers can inspect status_code as before.
+    """
+    async for attempt in _retry_policy():
+        with attempt:
+            response = await send()
+            if response.status_code in RETRYABLE_STATUSES:
+                raise RetryableHTTPError(response)
+            return response
+    raise RuntimeError("unreachable: retry loop exited without result")
+
+
+async def call_with_retry(operation: Callable[[], Awaitable[T]]) -> T:
+    """Retry an arbitrary awaitable on transient external failures.
+
+    Used for SDK calls (OpenAI/Groq) where the caller doesn't see the
+    raw httpx.Response. Retries on httpx.TimeoutException plus openai
+    SDK exceptions matching {429, 502, 503, 504} or connection/timeout.
+    """
+    async for attempt in _retry_policy():
+        with attempt:
+            return await operation()
+    raise RuntimeError("unreachable: retry loop exited without result")

--- a/packages/prime-agent/src/talos_agent/payments/stellar_kit.py
+++ b/packages/prime-agent/src/talos_agent/payments/stellar_kit.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import os
 from typing import Any
 
+import httpx
 from rich.console import Console
+
+from talos_agent.http import request_with_retry
 
 _HORIZON_URL = os.getenv("STELLAR_HORIZON_URL", "https://horizon-testnet.stellar.org")
 
@@ -46,10 +49,9 @@ class StellarKit:
             if not acct:
                 return {"error": "No Stellar account configured"}
             # Horizon is public — no auth needed
-            import httpx
-            async with httpx.AsyncClient() as client:
-                r = await client.get(
-                    f"{_HORIZON_URL}/accounts/{acct}"
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                r = await request_with_retry(
+                    lambda: client.get(f"{_HORIZON_URL}/accounts/{acct}")
                 )
                 if r.status_code == 200:
                     data = r.json()
@@ -65,10 +67,9 @@ class StellarKit:
     async def get_token_balance(self, account_id: str, token_id: str) -> dict[str, Any]:
         """Query Stellar asset balance via Horizon."""
         try:
-            import httpx
-            async with httpx.AsyncClient() as client:
-                r = await client.get(
-                    f"{_HORIZON_URL}/accounts/{account_id}",
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                r = await request_with_retry(
+                    lambda: client.get(f"{_HORIZON_URL}/accounts/{account_id}")
                 )
                 if r.status_code == 200:
                     data = r.json()

--- a/packages/prime-agent/tests/test_http_retry.py
+++ b/packages/prime-agent/tests/test_http_retry.py
@@ -1,0 +1,219 @@
+"""Retry helper tests — exponential backoff on transient HTTP failures."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_none,
+)
+
+from talos_agent import http as http_module
+from talos_agent.http import (
+    MAX_ATTEMPTS,
+    RetryableHTTPError,
+    call_with_retry,
+    request_with_retry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep_between_retries(monkeypatch):
+    """Drop tenacity's backoff sleeps so tests run instantly."""
+
+    def fast_policy() -> AsyncRetrying:
+        return AsyncRetrying(
+            stop=stop_after_attempt(MAX_ATTEMPTS),
+            wait=wait_none(),
+            retry=retry_if_exception(http_module._is_retryable),
+            before_sleep=http_module._log_before_sleep,
+            reraise=True,
+        )
+
+    monkeypatch.setattr(http_module, "_retry_policy", fast_policy)
+
+
+class TestRequestWithRetry:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_recovers_after_two_429s(self, caplog):
+        """[429, 429, 200] succeeds within MAX_ATTEMPTS."""
+        route = respx.get("https://api.example.com/widget").mock(
+            side_effect=[
+                Response(429, json={"error": "rate limited"}),
+                Response(429, json={"error": "rate limited"}),
+                Response(200, json={"ok": True}),
+            ]
+        )
+
+        async with httpx.AsyncClient() as client:
+            with caplog.at_level(logging.WARNING, logger="talos_agent.http"):
+                response = await request_with_retry(
+                    lambda: client.get("https://api.example.com/widget")
+                )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        assert route.call_count == 3
+        retry_logs = [r for r in caplog.records if "HTTP retry" in r.getMessage()]
+        assert len(retry_logs) == 2
+        assert all("status=429" in r.getMessage() for r in retry_logs)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_persistent_503_raises_after_exhaustion(self):
+        """Persistent retryable status raises after MAX_ATTEMPTS."""
+        route = respx.get("https://api.example.com/broken").mock(
+            return_value=Response(503, json={"error": "down"})
+        )
+
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(RetryableHTTPError) as exc_info:
+                await request_with_retry(
+                    lambda: client.get("https://api.example.com/broken")
+                )
+
+        assert exc_info.value.status_code == 503
+        assert route.call_count == MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_non_retryable_status_returned_unchanged(self):
+        """Non-retryable statuses (404, 500) pass through without retrying."""
+        route = respx.get("https://api.example.com/missing").mock(
+            return_value=Response(404, json={"error": "not found"})
+        )
+
+        async with httpx.AsyncClient() as client:
+            response = await request_with_retry(
+                lambda: client.get("https://api.example.com/missing")
+            )
+
+        assert response.status_code == 404
+        assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_500_not_retried(self):
+        """500 is not in the retryable set — returned to caller as-is."""
+        route = respx.get("https://api.example.com/oops").mock(
+            return_value=Response(500, json={"error": "boom"})
+        )
+
+        async with httpx.AsyncClient() as client:
+            response = await request_with_retry(
+                lambda: client.get("https://api.example.com/oops")
+            )
+
+        assert response.status_code == 500
+        assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_timeout_retries_then_succeeds(self):
+        """httpx.TimeoutException is retryable."""
+        route = respx.get("https://api.example.com/slow").mock(
+            side_effect=[
+                httpx.ReadTimeout("timeout"),
+                Response(200, json={"ok": True}),
+            ]
+        )
+
+        async with httpx.AsyncClient() as client:
+            response = await request_with_retry(
+                lambda: client.get("https://api.example.com/slow")
+            )
+
+        assert response.status_code == 200
+        assert route.call_count == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_persistent_timeout_raises(self):
+        """Persistent timeouts propagate after exhausting retries."""
+        route = respx.get("https://api.example.com/hang").mock(
+            side_effect=httpx.ConnectTimeout("timeout"),
+        )
+
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(httpx.TimeoutException):
+                await request_with_retry(
+                    lambda: client.get("https://api.example.com/hang")
+                )
+
+        assert route.call_count == MAX_ATTEMPTS
+
+
+class TestCallWithRetry:
+    @pytest.mark.asyncio
+    async def test_succeeds_on_first_attempt(self):
+        calls = 0
+
+        async def op():
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        result = await call_with_retry(op)
+        assert result == "ok"
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_openai_rate_limit(self, caplog):
+        """openai.RateLimitError (429) is retryable via call_with_retry."""
+        import openai
+
+        attempts = 0
+
+        async def op():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                # Construct a synthetic RateLimitError matching openai's signature.
+                raise openai.RateLimitError(
+                    "rate limited",
+                    response=httpx.Response(
+                        429,
+                        request=httpx.Request("POST", "https://api.groq.com/v1/chat"),
+                    ),
+                    body=None,
+                )
+            return "done"
+
+        with caplog.at_level(logging.WARNING, logger="talos_agent.http"):
+            result = await call_with_retry(op)
+
+        assert result == "done"
+        assert attempts == 3
+        retry_logs = [r for r in caplog.records if "HTTP retry" in r.getMessage()]
+        assert len(retry_logs) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_openai_error_propagates_immediately(self):
+        """openai 400-class errors should not retry."""
+        import openai
+
+        attempts = 0
+
+        async def op():
+            nonlocal attempts
+            attempts += 1
+            raise openai.BadRequestError(
+                "bad",
+                response=httpx.Response(
+                    400,
+                    request=httpx.Request("POST", "https://api.groq.com/v1/chat"),
+                ),
+                body=None,
+            )
+
+        with pytest.raises(openai.BadRequestError):
+            await call_with_retry(op)
+        assert attempts == 1


### PR DESCRIPTION
Adds bounded retries with exponential backoff and full jitter to every external
HTTP call made by the Prime Agent. Transient failures from Groq (LLM),
Horizon (Stellar), and the Talos Web API now self-heal instead of silently
skipping an entire agent cycle.

Before this change, `TalosAPIClient`, `payments/stellar_kit.py`, and the Groq
LLM call site all used bare `await self._client.get/post(...)` with a flat
30-second timeout and **zero** retry logic. The scheduler
(`scheduler.py:106`, `scheduler.py:130`) caught `Exception`, logged once, and
waited a full cycle interval — often minutes — before retrying. A single
Groq 429, Horizon 503, or network blip was enough to wipe an entire cycle.
Across 6 concurrent agents in production this surfaced as frequent silent
data loss.

## Why this matters

Production stability. Transient external failures should be invisible to the
user, not catastrophic to a cycle.

## What changed

### New shared retry helper — `packages/prime-agent/src/talos_agent/http.py`

A single module owns the retry policy so every external call site uses the
same rules.

| Knob              | Value                                              |
| ----------------- | -------------------------------------------------- |
| Library           | `tenacity>=8.2`                                    |
| Max attempts      | `3`                                                |
| Backoff           | `wait_exponential_jitter(initial=1s, max=10s)`     |
| Retry on (HTTP)   | `httpx.TimeoutException`, status ∈ `{429, 502, 503, 504}` |
| Retry on (LLM)    | `openai.APITimeoutError`, `openai.APIConnectionError`, `openai.APIStatusError` with status ∈ `{429, 502, 503, 504}` |
| On exhaustion     | Final exception propagates (`reraise=True`)        |
| Logging           | `logger.warning` before each sleep, with attempt number + status code |

Two public entry points:

- **`request_with_retry(send)`** — wraps an httpx coroutine. Returns the
  `httpx.Response` on success or on a non-retryable status (e.g. 200, 404,
  402, 500). Raises `RetryableHTTPError` or `httpx.TimeoutException` after
  three failed attempts. Callers keep their existing `r.status_code` checks
  unchanged.
- **`call_with_retry(operation)`** — wraps any awaitable. Used for the
  OpenAI/Groq SDK call where we don't see the raw `httpx.Response`. Also
  catches `openai.*` exceptions matching the retry set.

`RetryableHTTPError` is an internal exception used to drive tenacity from a
returned `Response`; on exhaustion it surfaces to the caller carrying the
final `status_code` and url.

### Call sites wired through the helper

1. **`api_client.py` — `TalosAPIClient`**
   Added internal `_get / _post / _put / _patch` helpers that delegate to
   `request_with_retry`. Every method (`get_talos`, `report_activity`,
   `update_status`, `report_revenue`, approvals, agent wallet, sign_payment,
   commerce, discover_services, register_service, request_transfer, jobs,
   publish_playbook) now flows through retry without changing its return
   contract.

2. **`payments/stellar_kit.py`**
   `get_balance` and `get_token_balance` (both Horizon reads) now go through
   `request_with_retry`. `httpx` was hoisted to a module-level import (it was
   imported lazily inside both methods) and the local `AsyncClient` now uses
   an explicit `timeout=30.0` to match the rest of the agent.

3. **`agent/loop.py`**
   The `client.chat.completions.create(...)` call to Groq/OpenAI is now
   wrapped in `call_with_retry`, so Groq 429s and `APITimeoutError`s are
   transparently retried instead of bombing out the cycle.

### Dependency

- Added `tenacity>=8.2` to `packages/prime-agent/pyproject.toml`.

## Tests

New file: `packages/prime-agent/tests/test_http_retry.py` (9 tests, ~0.6s).
Backoff sleeps are monkey-patched to `wait_none()` so the suite stays fast.

| Test                                                         | What it proves                                                                 |
| ------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| `test_recovers_after_two_429s`                               | `[429, 429, 200]` succeeds in exactly 3 calls; 2 retry warnings emitted with `status=429`. |
| `test_persistent_503_raises_after_exhaustion`                | Persistent 503 raises `RetryableHTTPError` after `MAX_ATTEMPTS` calls.         |
| `test_non_retryable_status_returned_unchanged`               | 404 is returned to caller on first call — no retry.                            |
| `test_500_not_retried`                                       | 500 is intentionally *not* in the retry set (only 502/503/504).                |
| `test_timeout_retries_then_succeeds`                         | `httpx.ReadTimeout` retries, recovers on second attempt.                       |
| `test_persistent_timeout_raises`                             | Persistent `ConnectTimeout` propagates after `MAX_ATTEMPTS`.                   |
| `test_succeeds_on_first_attempt` (`call_with_retry`)         | Happy path — no retries when the call succeeds.                                |
| `test_retries_on_openai_rate_limit`                          | `openai.RateLimitError` (429) is retryable; recovers after 2 failures.         |
| `test_non_retryable_openai_error_propagates_immediately`     | `openai.BadRequestError` (400) raises on first attempt — no retry.             |

```
$ python3 -m pytest tests/test_http_retry.py -v
============================== 9 passed in 0.64s ===============================
```

Full suite: **108 passing**. The 4 failures present on this branch were also
present before this PR (verified via `git stash` + rerun) — 3 pre-existing
test bugs in `test_stellar_integration.py` / `test_tools_integration.py`, and
1 flaky test (`test_discover_services_returns_list`) where the tool randomly
picks a category from a list wider than the test's allowlist.

## Acceptance criteria

- [x] Shared retry helper in `talos_agent/http.py`.
- [x] All three call sites use it (`api_client.py`, `payments/stellar_kit.py`,
      `agent/loop.py`).
- [x] Test: `[429, 429, 200]` sequence succeeds in at most 3 attempts.
- [x] Test: persistent retryable failure raises after exhausting retries.
- [x] Retry attempts visible in logs (warning level on logger
      `talos_agent.http`, with attempt number and status code).
- [x] `tenacity` added to `pyproject.toml` dependencies.

## Files changed

```
 packages/prime-agent/pyproject.toml                |  1 +
 packages/prime-agent/src/talos_agent/agent/loop.py | 13 +++--
 packages/prime-agent/src/talos_agent/api_client.py | 55 ++++++++++++++--------
 packages/prime-agent/src/talos_agent/http.py       | new
 packages/prime-agent/src/talos_agent/payments/stellar_kit.py | 17 +++----
 packages/prime-agent/tests/test_http_retry.py      | new
```

## Behavior changes for callers

The return contract of every existing `TalosAPIClient` method is unchanged on
success or on non-retryable failures (404, 402, 500, etc.) — callers keep
their `r.status_code` checks.

What *is* new: after three consecutive retryable failures, the call now
**raises** (`RetryableHTTPError` or `httpx.TimeoutException`) instead of
returning `None` after one attempt. The scheduler's existing
`except Exception` blocks at `scheduler.py:106` and `scheduler.py:130`
already catch this and log it, so no scheduler change was required — but
now the cycle gets three real chances before logging.

closes #9