### PR TITLE
docs: fix clone url and local file links in contributor docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ For any user interface changes, please add screenshots or screen recordings show
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING.md](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/CONTRIBUTING.md) guide.
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
 - [ ] My code follows the style guidelines of this project.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Talos Protocol
 
+> **Looking for a place to start?** Check out our [open Wave issues](https://github.com/enliven17/talos-stellar/issues?q=is%3Aissue+is%3Aopen+label%3A%22Stellar+Wave%22) to find beginner-friendly and rewarded tasks.
+
 Thank you for your interest in contributing to Talos Protocol! This document provides instructions for setting up your local environment, running the services, executing tests, and submitting your contributions.
 
 ## Prerequisites
@@ -16,7 +18,7 @@ Before getting started, make sure you have the following installed:
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/Muyideen-js/talos-stellar.git
+   git clone https://github.com/enliven17/talos-stellar.git
    cd talos-stellar
    ```
 
@@ -29,9 +31,9 @@ Before getting started, make sure you have the following installed:
 
 You need to configure the environment variables for each subproject:
 
-- **Web (Next.js)**: Copy [web/.env.example](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/web/.env.example) to `web/.env.local` and fill in the required values.
-- **Prime Agent (Python)**: Copy [packages/prime-agent/.env.example](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/packages/prime-agent/.env.example) to `packages/prime-agent/.env` and configure your API keys.
-- **Contracts (Soroban)**: Copy [contracts/.env.example](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/contracts/.env.example) to `contracts/.env` if you plan to deploy or invoke contracts directly via scripts.
+- **Web (Next.js)**: Copy [web/.env.example](./web/.env.example) to `web/.env.local` and fill in the required values.
+- **Prime Agent (Python)**: Copy [packages/prime-agent/.env.example](./packages/prime-agent/.env.example) to `packages/prime-agent/.env` and configure your API keys.
+- **Contracts (Soroban)**: Copy [contracts/.env.example](./contracts/.env.example) to `contracts/.env` if you plan to deploy or invoke contracts directly via scripts.
 
 ## Running the Project
 
@@ -90,4 +92,4 @@ pnpm test:e2e
    ```
 2. Make your changes and commit them with descriptive commit messages following the Conventional Commits style.
 3. Ensure all tests pass.
-4. Push your branch and open a Pull Request. Your PR will auto-populate with the [Pull Request Template](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/.github/PULL_REQUEST_TEMPLATE.md).
+4. Push your branch and open a Pull Request. Your PR will auto-populate with the [Pull Request Template](./.github/PULL_REQUEST_TEMPLATE.md).

--- a/packages/prime-agent/README.md
+++ b/packages/prime-agent/README.md
@@ -9,7 +9,7 @@ This package implements an automated schema versioning and migration framework u
 ### How Schema Versioning Works
 
 1. **Schema Version Tracking**: SQLite's native `PRAGMA user_version` integer is used to track the database schema version. Fresh databases start at version `0`.
-2. **Ordered Migrations**: Migrations are registered in `_MIGRATIONS` inside [db.py](file:///home/gamp/drips/talos-stellar/packages/prime-agent/src/talos_agent/db.py). They are ordered sequentially ascending by their version integer.
+2. **Ordered Migrations**: Migrations are registered in `_MIGRATIONS` inside [db.py](./src/talos_agent/db.py). They are ordered sequentially ascending by their version integer.
 3. **Automatic Upgrades**: When a `LocalDB` connection is initialized:
    - The current `user_version` is checked.
    - Any migrations in `_MIGRATIONS` with a version greater than `user_version` are run sequentially.
@@ -43,7 +43,7 @@ _MIGRATIONS.append(
 
 ### Example Workflow
 
-1. Update the migrations registry in [db.py](file:///home/gamp/drips/talos-stellar/packages/prime-agent/src/talos_agent/db.py):
+1. Update the migrations registry in [db.py](./src/talos_agent/db.py):
    ```python
    _MIGRATIONS = [
        (1, "..."),


### PR DESCRIPTION
Closes #113

## Summary
- Replaced the fork clone URL (`Muyideen-js/talos-stellar`) with the canonical repository URL (`enliven17/talos-stellar`) in `CONTRIBUTING.md`.
- Removed local file artifacts (`file:///c:/Users/Wittig_Lyon/...`) from `.github/PULL_REQUEST_TEMPLATE.md`, `packages/prime-agent/README.md`, and `CONTRIBUTING.md`, replacing them with functional relative paths.
- Added a one-line note linking to the open Stellar Wave issues for discoverability at the top of `CONTRIBUTING.md`.

## Testing
- Verified zero hits remain for `Muyideen-js` and `file:///` in all tracked files.
- Verified relative links resolve correctly on GitHub.