### PR TITLE
Complete cross-contract creator verification in TalosNameService regi…

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -53,6 +53,16 @@ NAME_SERVICE_ID=$(stellar contract deploy \
 echo "   TalosNameService: $NAME_SERVICE_ID"
 
 echo ""
+echo "▶  Initializing TalosNameService with TalosRegistry address..."
+stellar contract invoke \
+  --id "$NAME_SERVICE_ID" \
+  --network "$NETWORK" \
+  --source "$SOURCE" \
+  -- \
+  initialize \
+  --registry_id "$REGISTRY_ID"
+
+echo ""
 echo "═══════════════════════════════════════════════════════"
 echo "  Add these to web/.env.local:"
 echo ""

--- a/contracts/talos_name_service/Cargo.toml
+++ b/contracts/talos_name_service/Cargo.toml
@@ -11,6 +11,9 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+talos_registry = { path = "../talos_registry" }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 

--- a/contracts/talos_name_service/src/lib.rs
+++ b/contracts/talos_name_service/src/lib.rs
@@ -11,7 +11,7 @@
 #[cfg(all(test, not(target_arch = "wasm32")))]
 extern crate std;
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Env, String};
 
 // ── Data Types ──────────────────────────────────────────────────────
 
@@ -20,6 +20,14 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, E
 pub enum DataKey {
     NameRecord(String), // name → talos_id
     TalosName(u32),     // talos_id → name
+    RegistryContract,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    AlreadyInitialized,
+    UnauthorizedCaller,
 }
 
 // ── Events ──────────────────────────────────────────────────────────
@@ -67,6 +75,22 @@ impl TalosNameService {
             panic!("Name already taken");
         }
 
+        let registry_contract: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::RegistryContract)
+            .expect("Registry contract not initialized");
+
+        let creator: Option<Address> = e.invoke_contract(
+            &registry_contract,
+            &symbol_short!("creator_of"),
+            (&talos_id,),
+        );
+
+        if creator != Some(owner.clone()) {
+            panic_with_error!(&e, ContractError::UnauthorizedCaller);
+        }
+
         // Store mappings
         e.storage()
             .persistent()
@@ -76,6 +100,21 @@ impl TalosNameService {
             .set(&DataKey::TalosName(talos_id), &name);
 
         emit_name_registered(&e, talos_id, name);
+    }
+
+    pub fn initialize(e: Env, registry_id: Address) {
+        if e
+            .storage()
+            .persistent()
+            .get::<_, Address>(&DataKey::RegistryContract)
+            .is_some()
+        {
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
+        }
+
+        e.storage()
+            .persistent()
+            .set(&DataKey::RegistryContract, &registry_id);
     }
 
     /// Resolve a name to a Talos ID.
@@ -114,25 +153,108 @@ impl TalosNameService {
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
     use super::*;
+    use talos_registry::{TalosRegistry, TalosRegistryClient, Patron, Kernel, Pulse};
     use soroban_sdk::{
         testutils::{Address as _, MockAuth, MockAuthInvoke},
         Address, Env, IntoVal,
     };
 
-    fn setup() -> (Env, Address) {
+    fn setup() -> (
+        Env,
+        Address,
+        Address,
+        TalosRegistryClient,
+        TalosNameServiceClient,
+    ) {
         let env = Env::default();
-        let contract_id = env.register_contract(None, TalosNameService);
-        (env, contract_id)
+        let registry_contract = env.register_contract(None, TalosRegistry);
+        let name_service_contract = env.register_contract(None, TalosNameService);
+        let registry_client = TalosRegistryClient::new(&env, &registry_contract);
+        let name_service_client = TalosNameServiceClient::new(&env, &name_service_contract);
+        name_service_client.initialize(&registry_contract);
+        (env, registry_contract, name_service_contract, registry_client, name_service_client)
     }
 
     fn s(env: &Env, value: &str) -> String {
         String::from_str(env, value)
     }
 
+    fn patron(env: &Env, creator: &Address) -> Patron {
+        Patron {
+            creator_share: 60,
+            investor_share: 25,
+            treasury_share: 15,
+            creator_addr: creator.clone(),
+            investor_addr: Address::generate(env),
+            treasury_addr: Address::generate(env),
+        }
+    }
+
+    fn kernel() -> Kernel {
+        Kernel {
+            approval_threshold: 10,
+            gtm_budget: 1_000,
+            min_patron_pulse: 100,
+        }
+    }
+
+    fn pulse(env: &Env) -> Pulse {
+        Pulse {
+            total_supply: 1_000_000,
+            price_usd_cents: 100,
+            token_symbol: s(env, "TLOS"),
+        }
+    }
+
+    fn create_talos_with_auth(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        creator: &Address,
+        protocol_wallet: &Address,
+    ) -> u32 {
+        let name = s(env, "Genesis");
+        let category = s(env, "Marketing");
+        let description = s(env, "Autonomous marketing agent");
+        let patron = patron(env, creator);
+        let kernel = kernel();
+        let pulse = pulse(env);
+
+        client
+            .mock_auths(&[MockAuth {
+                address: creator,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "create_talos",
+                    args: (
+                        name.clone(),
+                        category.clone(),
+                        description.clone(),
+                        patron.clone(),
+                        kernel.clone(),
+                        pulse.clone(),
+                        protocol_wallet.clone(),
+                    )
+                        .into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .create_talos(
+                &name,
+                &category,
+                &description,
+                &patron,
+                &kernel,
+                &pulse,
+                protocol_wallet,
+            )
+    }
+
     fn register_name_with_auth(
         env: &Env,
         client: &TalosNameServiceClient,
         contract_id: &Address,
+        registry_contract: &Address,
         owner: &Address,
         talos_id: u32,
         name: &String,
@@ -144,7 +266,12 @@ mod tests {
                     contract: contract_id,
                     fn_name: "register_name",
                     args: (owner.clone(), talos_id, name.clone()).into_val(env),
-                    sub_invokes: &[],
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: registry_contract,
+                        fn_name: "creator_of",
+                        args: (talos_id,).into_val(env),
+                        sub_invokes: &[],
+                    }],
                 },
             }])
             .register_name(owner, &talos_id, name);
@@ -152,29 +279,61 @@ mod tests {
 
     #[test]
     fn register_name_success() {
-        let (env, contract_id) = setup();
-        let client = TalosNameServiceClient::new(&env, &contract_id);
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
         let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
         let name = s(&env, "marketbot");
 
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
         assert!(client.is_name_available(&name));
-        register_name_with_auth(&env, &client, &contract_id, &owner, 7, &name);
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
 
         assert!(!client.is_name_available(&name));
-        assert!(client.has_name(&7));
-        assert_eq!(client.resolve_name(&name), Some(7));
-        assert_eq!(client.name_of(&7), Some(name));
+        assert!(client.has_name(&talos_id));
+        assert_eq!(client.resolve_name(&name), Some(talos_id));
+        assert_eq!(client.name_of(&talos_id), Some(name));
     }
 
     #[test]
     fn duplicate_name_rejected() {
-        let (env, contract_id) = setup();
-        let client = TalosNameServiceClient::new(&env, &contract_id);
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
         let owner = Address::generate(&env);
         let second_owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
         let name = s(&env, "marketbot");
 
-        register_name_with_auth(&env, &client, &contract_id, &owner, 1, &name);
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
 
         let duplicate_result = client
             .mock_auths(&[MockAuth {
@@ -182,23 +341,55 @@ mod tests {
                 invoke: &MockAuthInvoke {
                     contract: &contract_id,
                     fn_name: "register_name",
-                    args: (second_owner.clone(), 2u32, name.clone()).into_val(&env),
+                    args: (second_owner.clone(), talos_id, name.clone()).into_val(&env),
                     sub_invokes: &[],
                 },
             }])
-            .try_register_name(&second_owner, &2, &name);
+            .try_register_name(&second_owner, &talos_id, &name);
 
         assert!(duplicate_result.is_err());
     }
 
     #[test]
     fn unauthorized_caller_rejected() {
-        let (env, contract_id) = setup();
-        let client = TalosNameServiceClient::new(&env, &contract_id);
-        let owner = Address::generate(&env);
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let creator = Address::generate(&env);
+        let unauthorized = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
         let name = s(&env, "marketbot");
 
-        assert!(client.try_register_name(&owner, &1, &name).is_err());
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &creator,
+            &protocol_wallet,
+        );
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &unauthorized,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (unauthorized.clone(), talos_id, name.clone()).into_val(&env),
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: &registry_contract,
+                        fn_name: "creator_of",
+                        args: (talos_id,).into_val(&env),
+                        sub_invokes: &[],
+                    }],
+                },
+            }])
+            .try_register_name(&unauthorized, &talos_id, &name);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn initialize_guard_rejects_reinitialization() {
+        let (env, registry_contract, _contract_id, _registry_client, client) = setup();
+        assert!(client.try_initialize(&registry_contract).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #108 

…ster_name

## Summary

Provide a brief description of the changes, background context, and what these changes accomplish.

## Related Issues

Closes #N (Replace N with the issue number, e.g. Closes #1)

## Test Plan

Detail the steps you took to test these changes.
- [ ] Automated tests run (e.g. `cargo test`, `uv run pytest`, `pnpm test:e2e`)
- [ ] Manual verification steps performed:
  - 1. ...
  - 2. ...

## Visual Changes (if applicable)

For any user interface changes, please add screenshots or screen recordings showing:
- Before
- After

## Checklist

- [ ] I have read the [CONTRIBUTING.md](file:///c:/Users/Wittig_Lyon/Desktop/wae/wave%206/talos-stellar/CONTRIBUTING.md) guide.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Summary

### What changed

- Added cross-contract verification in `TalosNameService.register_name`
- Ensured only the registered creator from `TalosRegistry` can register a name for a given `talos_id`
- Added `initialize(registry_id)` to store the `TalosRegistry` contract address in `TalosNameService`
- Added `AlreadyInitialized` guard to prevent repeated initialization
- Added typed error `ContractError::UnauthorizedCaller`
- Updated deployment script to initialize the name service with the registry contract ID after deployment

### Key implementation details

- lib.rs
  - Added `DataKey::RegistryContract`
  - Added `ContractError` enum with `AlreadyInitialized` and `UnauthorizedCaller`
  - Added `initialize(e, registry_id)` with persistent storage guard
  - Updated `register_name` to:
    - require owner auth
    - load registry contract address from storage
    - cross-invoke `TalosRegistry.creator_of(talos_id)`
    - reject if returned creator address does not match `owner`

- Cargo.toml
  - Added dev dependency on local `talos_registry` crate for cross-contract testing

- deploy.sh
  - After deploying `TalosNameService`, the script now invokes `initialize --registry_id <REGISTRY_ID>`

### Tests added / updated

- Added test coverage for:
  - successful registration when caller is the registry-authorized creator
  - rejection of unauthorized callers even if the signature is valid
  - `initialize` reentrancy prevention

### Notes

- This fix closes the previous gap where `register_name` only validated caller signature, but not creator ownership of `talos_id`
- The new deploy step wires the registry contract dependency into the name service at deployment time
- Branch pushed: `CompleteCrosscontractCreatorVerificationInTalosNameServiceRegistername`

### Copy/paste ready PR description

```markdown
## Summary

This PR hardens `TalosNameService.register_name` by verifying that the caller is the actual creator of the referenced `talos_id` in `TalosRegistry`, not just a signer of the transaction.

## What changed

- Added `initialize(registry_id)` to `TalosNameService`
- Stored the registry contract address in persistent storage
- Added `AlreadyInitialized` guard for initialization
- Added `ContractError::UnauthorizedCaller`
- Updated `register_name` to:
  - require owner auth
  - invoke `TalosRegistry.creator_of(talos_id)`
  - reject registrations where `owner != creator_of(talos_id)`

## Deployment

- `contracts/deploy.sh` now initializes `TalosNameService` immediately after deploying it:
  - `initialize --registry_id <REGISTRY_ID>`

## Tests

- Added coverage for:
  - authorized creator success
  - unauthorized caller rejection
  - initialize guard enforcement

## Files changed

- `contracts/talos_name_service/src/lib.rs`
- `contracts/talos_name_service/Cargo.toml`
- `contracts/deploy.sh`

## Why

This fixes a security gap where a malicious wallet could previously register a name for any `talos_id` so long as the transaction was signed, even if they were not the registered Talos creator.
```