### PR TITLE
Add /api/health endpoint with DB + Stellar RPC probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,21 @@ uv run talos-agent encrypt-keys --env-file .env
 
 ## Health check
 
-- The web app exposes a health endpoint at `GET /api/health` that returns JSON with `status`, `database`, `stellar`, `timestamp`, and `response_time_ms`. Monitoring tools can use this endpoint to verify service & dependency availability.
+`GET /api/health` — returns `200` when all dependencies are reachable, `503` when any check fails.
+
+```jsonc
+// 200 OK
+{ "ok": true,  "checks": { "db": "ok",    "stellar": "ok"    }, "ts": "2026-06-25T12:00:00.000Z" }
+
+// 503 Service Unavailable (Supabase paused)
+{ "ok": false, "checks": { "db": "error", "stellar": "ok"    }, "ts": "..." }
+```
+
+Probes:
+- **db** — `SELECT 1` against Postgres, 2 s timeout
+- **stellar** — `GET` to Horizon RPC (`STELLAR_HORIZON_URL` or testnet fallback), 3 s timeout
+
+Response is always `Cache-Control: no-store`.
+
+**Recommended monitoring** — wire a free [UptimeRobot](https://uptimerobot.com) or [Better Uptime](https://betteruptime.com) monitor to `GET /api/health` on a 1-minute interval. Set an email or Telegram alert on any non-200 response so outages like the 2026-05-22 Supabase pause are caught in seconds, not 30 minutes.
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,10 @@
   "framework": "nextjs",
   "buildCommand": "pnpm run build",
   "installCommand": "pnpm install",
-  "outputDirectory": "web/.next"
+  "outputDirectory": "web/.next",
+  "functions": {
+    "web/src/app/api/health/route.ts": {
+      "maxDuration": 10
+    }
+  }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:unit": "vitest run tests/health.test.ts",
     "test:e2e": "vitest run tests/api-e2e.test.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,46 +1,46 @@
-import { Pool } from "pg";
+import { db } from "@/db";
+import { sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
 
 const DEFAULT_HORIZON = "https://horizon-testnet.stellar.org";
 
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timerId = setTimeout(() => reject(new Error("timeout")), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timerId));
+}
+
 export async function GET() {
-  const start = Date.now();
-
-  // Check database
-  let dbOk = false;
-  try {
-    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-    await pool.query("SELECT 1");
-    await pool.end();
-    dbOk = true;
-  } catch (err) {
-    dbOk = false;
-  }
-
-  // Check Stellar Horizon
-  const horizonUrl = process.env.STELLAR_HORIZON_URL ?? DEFAULT_HORIZON;
-  let stellarOk = false;
-  try {
-    const res = await fetch(horizonUrl, { method: "GET" });
-    stellarOk = res.ok;
-  } catch (err) {
-    stellarOk = false;
-  }
-
-  const elapsed = Date.now() - start;
-
-  const overall = dbOk && stellarOk ? "ok" : "degraded";
-  const statusCode = dbOk && stellarOk ? 200 : 503;
-
-  const body = {
-    status: overall,
-    database: { ok: dbOk },
-    stellar: { ok: stellarOk, horizon: horizonUrl },
-    timestamp: new Date().toISOString(),
-    response_time_ms: elapsed,
+  const checks: { db: "ok" | "error"; stellar: "ok" | "error" } = {
+    db: "error",
+    stellar: "error",
   };
 
-  return new Response(JSON.stringify(body), {
-    status: statusCode,
-    headers: { "Content-Type": "application/json" },
-  });
+  await Promise.allSettled([
+    withTimeout(db.execute(sql`SELECT 1`), 2000).then(() => {
+      checks.db = "ok";
+    }),
+    withTimeout(
+      fetch(process.env.STELLAR_HORIZON_URL ?? DEFAULT_HORIZON).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      }),
+      3000,
+    ).then(() => {
+      checks.stellar = "ok";
+    }),
+  ]);
+
+  const ok = checks.db === "ok" && checks.stellar === "ok";
+
+  return NextResponse.json(
+    { ok, checks, ts: new Date().toISOString() },
+    {
+      status: ok ? 200 : 503,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
 }

--- a/web/tests/health.test.ts
+++ b/web/tests/health.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/db", () => ({
+  db: { execute: vi.fn() },
+}));
+
+import { GET } from "@/app/api/health/route";
+import { db } from "@/db";
+
+const mockExecute = db.execute as ReturnType<typeof vi.fn>;
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with ok=true when both checks pass", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.checks.db).toBe("ok");
+    expect(body.checks.stellar).toBe("ok");
+    expect(typeof body.ts).toBe("string");
+  });
+
+  it("returns 503 with checks.db=error when DB is down", async () => {
+    mockExecute.mockRejectedValue(new Error("ECONNREFUSED"));
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.db).toBe("error");
+    expect(body.checks.stellar).toBe("ok");
+  });
+
+  it("returns 503 with checks.stellar=error when Stellar is unreachable", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("fetch failed"),
+    );
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.db).toBe("ok");
+    expect(body.checks.stellar).toBe("error");
+  });
+
+  it("sets Cache-Control: no-store on all responses", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await GET();
+
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});


### PR DESCRIPTION
Production had zero external health visibility. When Supabase paused on 2026-05-22, the app served HTTP 500 for ~30 minutes before anyone noticed — caught manually via Vercel logs, not an alert.

## What this PR does

Adds a lightweight `GET /api/health` endpoint that actively probes both critical dependencies and returns a machine-readable result uptime monitors can act on.

**Response shape**
```json
// 200 — all clear
{ "ok": true,  "checks": { "db": "ok",    "stellar": "ok"    }, "ts": "2026-06-25T12:00:00.000Z" }

// 503 — Supabase paused
{ "ok": false, "checks": { "db": "error", "stellar": "ok"    }, "ts": "..." }
```

**Probes**
- **DB** — `SELECT 1` via the existing Drizzle pool, 2 s hard timeout
- **Stellar** — `GET` to Horizon RPC (`STELLAR_HORIZON_URL` env or testnet fallback), 3 s hard timeout

**Implementation details**
- Both probes run concurrently via `Promise.allSettled` — one failure never blocks the other
- Fail-closed: `checks` initialises to `"error"` on both fields, flipped to `"ok"` only on success
- `withTimeout` wraps each probe in `Promise.race` with `clearTimeout` in `.finally()` — no timer leaks
- `Cache-Control: no-store` on all responses
- `export const runtime = "nodejs"` — required for the DB probe to use the Node.js `pg` driver

## Files changed

| File | Change |
|---|---|
| `web/src/app/api/health/route.ts` | Full rewrite — correct shape, timeouts, headers, runtime |
| `web/tests/health.test.ts` | New — 4 Vitest unit tests (happy path, DB down, Stellar down, cache header) |
| `web/package.json` | Added `test:unit` script |
| `vercel.json` | Added `functions.maxDuration: 10` for the health route |
| `README.md` | Updated health section with correct shape, probe docs, monitoring recommendation |

## Testing

```bash
pnpm test:unit   # unit tests — mocks db + fetch, no live deps needed
```

## Recommended follow-up

Wire a free [UptimeRobot](https://uptimerobot.com) or [Better Uptime](https://betteruptime.com) monitor to `GET /api/health` on a 1-minute interval with email/Telegram alerting. This turns a 30-minute blind spot into a <2-minute page.



closes #16