### PR TITLE
faet: Add branded error boundary, global-error, and not-found pages

### DIFF
--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error("[Error boundary]", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center">
+      <Link href="/" className="text-nav-accent text-4xl font-ruthie mb-10">
+        Talos
+      </Link>
+
+      <div className="text-xs text-muted mb-4 tracking-wide">// ERROR</div>
+
+      <h1 className="text-2xl font-bold text-accent mb-3">
+        Something went wrong
+      </h1>
+
+      <p className="text-sm text-muted max-w-sm mb-10 leading-relaxed">
+        A transient error occurred. Our team has been notified — please try
+        again or return home.
+      </p>
+
+      <div className="flex gap-4">
+        <button
+          onClick={reset}
+          className="border border-accent text-accent bg-transparent px-6 py-2.5 text-sm font-medium hover:bg-accent/10 transition-all"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="bg-accent text-background px-6 py-2.5 text-sm font-medium hover:bg-foreground transition-colors"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect } from "react";
+import { Ruthie } from "next/font/google";
+import "./globals.css";
+
+const ruthie = Ruthie({
+  variable: "--font-ruthie",
+  subsets: ["latin"],
+  weight: "400",
+});
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error("[Global error boundary]", error);
+  }, [error]);
+
+  return (
+    <html
+      lang="en"
+      className={`${ruthie.variable} h-full antialiased`}
+      style={{ backgroundColor: "#FCF8F8" }}
+    >
+      <body
+        className="min-h-full flex flex-col items-center justify-center font-mono px-6"
+        style={{ backgroundColor: "#FCF8F8", color: "#2D2D2D" }}
+      >
+        <a
+          href="/"
+          className="font-ruthie text-4xl mb-10"
+          style={{ color: "#F5AFAF" }}
+        >
+          Talos
+        </a>
+
+        <div
+          className="text-xs mb-4 tracking-wide"
+          style={{ color: "#8E8383" }}
+        >
+          // CRITICAL ERROR
+        </div>
+
+        <h1 className="text-2xl font-bold mb-3" style={{ color: "#F5AFAF" }}>
+          Something went wrong
+        </h1>
+
+        <p
+          className="text-sm max-w-sm mb-10 leading-relaxed text-center"
+          style={{ color: "#8E8383" }}
+        >
+          A critical error occurred while loading the application. Please try
+          again or return home.
+        </p>
+
+        <div className="flex gap-4">
+          <button
+            onClick={reset}
+            className="px-6 py-2.5 text-sm font-medium transition-all"
+            style={{
+              border: "1px solid #F5AFAF",
+              color: "#F5AFAF",
+              background: "transparent",
+            }}
+          >
+            Try again
+          </button>
+          <a
+            href="/"
+            className="px-6 py-2.5 text-sm font-medium transition-colors"
+            style={{ backgroundColor: "#F5AFAF", color: "#FCF8F8" }}
+          >
+            Go home
+          </a>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center">
+      <Link href="/" className="text-nav-accent text-4xl font-ruthie mb-10">
+        Talos
+      </Link>
+
+      <div className="text-xs text-muted mb-4 tracking-wide">// 404</div>
+
+      <h1 className="text-2xl font-bold text-accent mb-3">Page not found</h1>
+
+      <p className="text-sm text-muted max-w-sm mb-10 leading-relaxed">
+        This route does not exist. It may have moved or never existed.
+      </p>
+
+      <Link
+        href="/"
+        className="bg-accent text-background px-6 py-2.5 text-sm font-medium hover:bg-foreground transition-colors"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
web/src/app/error.tsx — Route-level error boundary (client component)
- Logs error to console.error (hits Vercel logs), never renders error.message
- "Try again" button calls reset(), "Go home" link to /
- Uses font-ruthie, Tailwind design tokens (text-accent, text-muted, bg-surface, etc.)

web/src/app/global-error.tsx — Root layout error boundary
- Self-contained <html><body> wrapper (required by Next.js for root layout errors)
- Imports globals.css and bootstraps the Ruthie font independently via next/font/google
- Uses inline styles as fallback where Tailwind might not resolve (since the layout is bypassed)

web/src/app/not-found.tsx — Server component 404 page
- Clean branded 404 with "Go home" CTA
- No client directive needed — purely static

All three pages match the existing design language: Maple Mono font, #F5AFAF accent, muted #8E8383 secondary text, and the Ruthie-font "Talos" wordmark logo.

closes #17