### PR TITLE
ci: Add web API E2E tests to GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,33 @@ jobs:
       run:
         working-directory: web
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: talos_test
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/talos_test
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/talos_test
+      STELLAR_NETWORK: testnet
+      STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      NEXT_PUBLIC_STELLAR_NETWORK: testnet
+      NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      STELLAR_OPERATOR_SECRET_KEY: SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      NEXT_PUBLIC_TALOS_REGISTRY_CONTRACT: CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      NEXT_PUBLIC_TALOS_NAME_SERVICE_CONTRACT: CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
     steps:
       - uses: actions/checkout@v4
 
@@ -49,6 +76,30 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+      - name: Push database schema
+        run: pnpm db:push
+
+      - name: Start Next.js development server
+        run: pnpm dev > next-dev.log 2>&1 &
+
+      - name: Wait for server to start
+        run: |
+          for i in {1..60}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health | grep -qE "200|503"; then
+              echo "Server is up!"
+              exit 0
+            fi
+            echo "Waiting for server to start..."
+            sleep 2
+          done
+          echo "Server failed to start! Printing logs:"
+          cat next-dev.log
+          exit 1
+        shell: bash
+
+      - name: Run E2E and Unit Tests
+        run: pnpm test
 
       # Deploy to Vercel (main branch only, using Vercel CLI)
       - name: Install Vercel CLI

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
     "test:e2e": "vitest run tests/api-e2e.test.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
Closes #32

---

This PR addresses issue #32 by integrating the web API E2E and unit test suites (api-e2e.test.ts, x402-e2e.test.ts, buy-token.test.ts) into the existing GitHub Actions deployment workflow (deploy.yml).

To support E2E tests that interact with the database, a PostgreSQL service container is provisioned during the workflow run, and the schema is pushed dynamically before starting the server.

Key Changes
GitHub Actions Workflow (.github/workflows/deploy.yml):
Provisioned a PostgreSQL (v15) service container with health checks.
Configured job-level environment variables (e.g. DATABASE_URL pointing to localhost, STELLAR_NETWORK, STELLAR_HORIZON_URL, registry contract addresses, and a dummy STELLAR_OPERATOR_SECRET_KEY for server-side cryptographic signatures).
Added pnpm db:push to apply migrations and sync the database schema.
Started the Next.js dev server in the background and redirected logs to a log file (next-dev.log) for debugging.
Added a robust health check loop that waits for the server to become active (checking for 200 or 503 status on /api/health) before starting test execution.
Integrated the pnpm test step to run all tests.
Package Scripts (web/package.json):
Added "test": "vitest run" to execute all Vitest tests.
Acceptance Criteria Checklist
 GitHub Actions workflow includes pnpm test or pnpm vitest step.
 Tests run on every push and PR to main affecting web/** or packages/sdk/**.
 Database is provisioned via a PostgreSQL service container.
 Failing tests return a non-zero exit code, blocking the merge.
Verification Plan
CI Execution
Once you push the branch and open the PR, GitHub Actions will:

Spin up the Postgres service container.
Install dependencies, run TypeScript checks, and linting.
Sync the DB schema via Drizzle.
Spin up Next.js on localhost:3000.
Wait for the server to be responsive.
Execute vitest run, testing API endpoints, x402 payment flows, and Stellar token purchase logic.