### PR TITLE
fix: update OpenAPI spec and snapshot guard

### DIFF
--- a/.github/workflows/web-openapi-ci.yml
+++ b/.github/workflows/web-openapi-ci.yml
@@ -1,0 +1,54 @@
+name: Web OpenAPI CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/src/app/api/**'
+      - 'web/src/lib/openapi.ts'
+      - 'web/tests/openapi-snapshot.test.ts'
+      - 'web/tests/fixtures/openapi.snapshot.json'
+      - 'web/scripts/write-openapi-snapshot.ts'
+      - 'web/package.json'
+      - 'web/pnpm-lock.yaml'
+      - '.github/workflows/web-openapi-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/src/app/api/**'
+      - 'web/src/lib/openapi.ts'
+      - 'web/tests/openapi-snapshot.test.ts'
+      - 'web/tests/fixtures/openapi.snapshot.json'
+      - 'web/scripts/write-openapi-snapshot.ts'
+      - 'web/package.json'
+      - 'web/pnpm-lock.yaml'
+      - '.github/workflows/web-openapi-ci.yml'
+
+jobs:
+  openapi-snapshot:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check OpenAPI snapshot
+        run: pnpm test:openapi

--- a/web/README.md
+++ b/web/README.md
@@ -18,6 +18,27 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## OpenAPI Contract
+
+The public API spec lives in `src/lib/openapi.ts` and is served at `/api/docs/openapi.json`.
+
+When an API route request or response shape changes:
+
+1. Update `src/lib/openapi.ts`, including `info.version` for public contract changes.
+2. Regenerate the checked-in snapshot:
+
+```bash
+pnpm openapi:snapshot
+```
+
+3. Run the drift check:
+
+```bash
+pnpm test:openapi
+```
+
+CI runs the same snapshot test and fails if `/api/docs/openapi.json` differs from `tests/fixtures/openapi.snapshot.json`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test:e2e": "vitest run tests/api-e2e.test.ts",
+    "test:openapi": "vitest run tests/openapi-snapshot.test.ts",
+    "openapi:snapshot": "tsx scripts/write-openapi-snapshot.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx src/db/seed.ts",

--- a/web/scripts/write-openapi-snapshot.ts
+++ b/web/scripts/write-openapi-snapshot.ts
@@ -1,0 +1,10 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { openApiSpec } from "../src/lib/openapi";
+
+const snapshotPath = path.resolve("tests/fixtures/openapi.snapshot.json");
+
+await mkdir(path.dirname(snapshotPath), { recursive: true });
+await writeFile(snapshotPath, `${JSON.stringify(openApiSpec, null, 2)}\n`);
+
+console.log(`Wrote ${snapshotPath}`);

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -15,7 +15,7 @@ export const openApiSpec = {
   openapi: "3.0.3",
   info: {
     title: "TALOS Stellar API",
-    version: "1.0.0",
+    version: "1.1.0",
     description: `
 REST API for the TALOS Protocol — autonomous agent corporations on the Stellar blockchain.
 
@@ -289,10 +289,21 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
       BecomePatronRequest: {
         type: "object",
-        required: ["stellarPublicKey", "pulseAmount"],
+        required: ["stellarPublicKey", "pulseAmount", "signature", "message"],
         properties: {
           stellarPublicKey: { type: "string", description: "Stellar public key of the patron" },
           pulseAmount: { type: "number", minimum: 0.000001, description: "Number of Pulse (MITOS) tokens held" },
+          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
+          message: { type: "string", description: "Must include the TALOS ID and `register-patron` action" },
+        },
+      },
+      RevokePatronRequest: {
+        type: "object",
+        required: ["stellarPublicKey", "signature", "message"],
+        properties: {
+          stellarPublicKey: { type: "string", description: "Stellar public key of the active patron" },
+          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
+          message: { type: "string", description: "Must include the TALOS ID and `revoke-patron` action" },
         },
       },
       Revenue: {
@@ -369,6 +380,174 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
           amount: { type: "number", minimum: 0.000001, description: "Number of MITOS tokens to buy" },
           txHash: { type: "string", description: "USDC payment tx hash (submit payment first)" },
+        },
+      },
+      FinancialSummary: {
+        type: "object",
+        properties: {
+          talosId: { type: "string" },
+          talosName: { type: "string" },
+          category: { type: "string" },
+          status: { type: "string" },
+          generatedAt: { type: "string", format: "date-time" },
+          cashFlow: {
+            type: "object",
+            properties: {
+              totalRevenue: { type: "number" },
+              totalSpending: { type: "number" },
+              netProfit: { type: "number" },
+              profitMargin: { type: "number" },
+              revenueTransactionCount: { type: "integer" },
+              spendingTransactionCount: { type: "integer" },
+              revenueBySource: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    source: { type: "string" },
+                    total: { type: "number" },
+                    count: { type: "integer" },
+                  },
+                },
+              },
+              spendingByType: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    type: { type: "string" },
+                    total: { type: "number" },
+                    count: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+          trends: {
+            type: "object",
+            properties: {
+              revenueLast30Days: { type: "number" },
+              revenuePrevious30Days: { type: "number" },
+              revenueGrowthRate: { type: "number" },
+              spendingLast30Days: { type: "number" },
+              netProfitLast30Days: { type: "number" },
+              annualizedRunRate: { type: "number" },
+              monthlyRevenue: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    month: { type: "string", example: "2026-06" },
+                    revenue: { type: "number" },
+                    transactionCount: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+          budget: {
+            type: "object",
+            properties: {
+              gtmBudget: { type: "number" },
+              totalApprovedSpending: { type: "number" },
+              budgetUtilization: { type: "number" },
+              budgetRemaining: { type: "number" },
+            },
+          },
+          spendingHistory: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                type: { type: "string" },
+                title: { type: "string" },
+                description: { type: "string", nullable: true },
+                amount: { type: "number" },
+                decidedAt: { type: "string", format: "date-time", nullable: true },
+                txHash: { type: "string", nullable: true },
+                createdAt: { type: "string", format: "date-time" },
+              },
+            },
+          },
+          playbookSales: {
+            type: "object",
+            properties: {
+              totalPlaybooks: { type: "integer" },
+              totalSales: { type: "integer" },
+              totalRevenue: { type: "number" },
+              playbooks: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    title: { type: "string" },
+                    price: { type: "number" },
+                    currency: { type: "string" },
+                    category: { type: "string" },
+                    status: { type: "string" },
+                    purchaseCount: { type: "integer" },
+                    salesRevenue: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      FinancialProjection: {
+        type: "object",
+        properties: {
+          projection: {
+            type: "object",
+            properties: {
+              expectedRevenue: {
+                type: "object",
+                properties: {
+                  monthly: { type: "array", items: { type: "number" }, minItems: 6, maxItems: 6 },
+                  quarterly: { type: "array", items: { type: "number" }, minItems: 3, maxItems: 3 },
+                  yearly: { type: "number" },
+                },
+              },
+              budgetSuggestions: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    category: { type: "string" },
+                    amount: { type: "number" },
+                    rationale: { type: "string" },
+                  },
+                },
+              },
+              roiEstimations: {
+                type: "object",
+                properties: {
+                  shortTerm: { type: "number", description: "3-month ROI percentage" },
+                  mediumTerm: { type: "number", description: "6-month ROI percentage" },
+                  longTerm: { type: "number", description: "12-month ROI percentage" },
+                  confidence: { type: "string", enum: ["low", "medium", "high"] },
+                },
+              },
+              insights: { type: "array", items: { type: "string" } },
+            },
+          },
+          metadata: {
+            type: "object",
+            properties: {
+              talosId: { type: "string" },
+              generatedAt: { type: "string", format: "date-time" },
+              dataPoints: {
+                type: "object",
+                properties: {
+                  revenues: { type: "integer" },
+                  activities: { type: "integer" },
+                  patrons: { type: "integer" },
+                },
+              },
+            },
+          },
         },
       },
       CommerceService: {
@@ -616,7 +795,40 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         description: "Max items per page (1–100)",
       },
     },
+    headers: {
+      RateLimitLimit: {
+        schema: { type: "integer" },
+        description: "The rate limit ceiling for your request (requests per minute)",
+      },
+      RateLimitRemaining: {
+        schema: { type: "integer" },
+        description: "Number of requests left for the time window",
+      },
+      RateLimitReset: {
+        schema: { type: "integer" },
+        description: "Unix timestamp when the rate limit window resets",
+      },
+      RetryAfter: {
+        schema: { type: "integer" },
+        description: "Seconds to wait before retrying (sent on 429 Too Many Requests)",
+      },
+    },
     responses: {
+      RateLimitError: {
+        description: "Too many requests — rate limit exceeded",
+        headers: {
+          "X-RateLimit-Limit": { $ref: "#/components/headers/RateLimitLimit" },
+          "X-RateLimit-Remaining": { $ref: "#/components/headers/RateLimitRemaining" },
+          "X-RateLimit-Reset": { $ref: "#/components/headers/RateLimitReset" },
+          "Retry-After": { $ref: "#/components/headers/RetryAfter" },
+        },
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: "Rate limit exceeded" },
+          },
+        },
+      },
       UnauthorizedError: {
         description: "Missing or invalid Authorization header",
         content: {
@@ -1145,8 +1357,8 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": { description: "Invalid input or account not found on-chain" },
-          "403": { description: "pulseAmount below minimum threshold" },
+          "400": { description: "Invalid input, signature message mismatch, or account not found on-chain" },
+          "403": { description: "Invalid signature or pulseAmount below minimum threshold" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": { description: "Already an active Patron" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1155,20 +1367,14 @@ Creators are registered automatically at TALOS genesis.`,
       delete: {
         tags: ["Patrons"],
         summary: "Withdraw Patron status",
-        description: "Revoke Patron status. Creator Patrons cannot withdraw. Sets status to `revoked`.",
+        description: "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
         operationId: "withdrawPatron",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
           required: true,
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                required: ["stellarPublicKey"],
-                properties: {
-                  stellarPublicKey: { type: "string" },
-                },
-              },
+              schema: { $ref: "#/components/schemas/RevokePatronRequest" },
             },
           },
         },
@@ -1181,7 +1387,8 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "403": { description: "Creator cannot withdraw" },
+          "400": { description: "Invalid input or signature message mismatch" },
+          "403": { description: "Invalid signature or creator cannot withdraw" },
           "404": { description: "No active Patron found for this wallet" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -1521,13 +1728,20 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
       post: {
         tags: ["Wallet & Payments"],
         summary: "Buy MITOS tokens",
-        description: `Purchase MITOS tokens from a TALOS's token sale.
+        description: `Purchase MITOS tokens from a TALOS's token sale with Stellar payment verification.
 
-Flow:
+**Flow:**
 1. Client submits USDC payment on-chain (not via this endpoint)
 2. Call this endpoint with the tx hash + amount
-3. Server sends MITOS tokens to the buyer
-4. If buyer reaches \`minPatronPulse\`, they're automatically registered as a Patron`,
+3. Server validates the transaction on Stellar Horizon
+4. Server checks for replay attempts (txHash must be unique)
+5. Server sends MITOS tokens to the buyer
+6. If buyer reaches \`minPatronPulse\`, they're automatically registered as a Patron
+
+**Validation:**
+- Transaction must exist on Stellar Horizon
+- Transaction must be successful on-chain
+- txHash must not have been used before (409 Conflict if duplicate)`,
         operationId: "buyToken",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1563,7 +1777,60 @@ Flow:
               },
             },
           },
-          "400": { description: "Invalid input, account not found, or token not for sale" },
+          "400": { description: "Invalid input, account not found, token not for sale, or Horizon lookup failed" },
+          "404": { $ref: "#/components/responses/NotFoundError" },
+          "409": {
+            description: "Transaction already used (replay detected)",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+                example: { error: "Transaction already used (replay)" },
+              },
+            },
+          },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+
+    "/api/talos/{id}/financial-summary": {
+      get: {
+        tags: ["Revenue"],
+        summary: "Financial summary",
+        description: "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
+        operationId: "getFinancialSummary",
+        parameters: [{ $ref: "#/components/parameters/talosId" }],
+        responses: {
+          "200": {
+            description: "Aggregated financial summary",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/FinancialSummary" },
+              },
+            },
+          },
+          "404": { $ref: "#/components/responses/NotFoundError" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+
+    "/api/talos/{id}/financial-projection": {
+      get: {
+        tags: ["Revenue"],
+        summary: "Financial projection",
+        description: "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
+        operationId: "getFinancialProjection",
+        parameters: [{ $ref: "#/components/parameters/talosId" }],
+        responses: {
+          "200": {
+            description: "Financial projection with generation metadata",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/FinancialProjection" },
+              },
+            },
+          },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -2307,30 +2574,44 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Leaderboard",
-        description: "Returns all TALOS agents ranked by total revenue descending, with patron counts, activity counts, and market cap.",
+        description: "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
         operationId: "getLeaderboard",
+        parameters: [
+          { $ref: "#/components/parameters/cursorParam" },
+          { $ref: "#/components/parameters/limitParam" },
+        ],
         responses: {
           "200": {
-            description: "Leaderboard entries",
+            description: "Leaderboard entries with pagination",
             content: {
               "application/json": {
                 schema: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      id: { type: "string" },
-                      name: { type: "string" },
-                      category: { type: "string" },
-                      status: { type: "string" },
-                      pulsePrice: { type: "string" },
-                      totalSupply: { type: "integer" },
-                      patronCount: { type: "integer" },
-                      activityCount: { type: "integer" },
-                      totalRevenue: { type: "number" },
-                      marketCap: { type: "number" },
+                  allOf: [
+                    { $ref: "#/components/schemas/CursorPage" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              id: { type: "string" },
+                              name: { type: "string" },
+                              category: { type: "string" },
+                              status: { type: "string" },
+                              pulsePrice: { type: "string" },
+                              totalSupply: { type: "integer" },
+                              patronCount: { type: "integer" },
+                              activityCount: { type: "integer" },
+                              totalRevenue: { type: "number" },
+                              marketCap: { type: "number" },
+                            },
+                          },
+                        },
+                      },
                     },
-                  },
+                  ],
                 },
               },
             },

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -1,0 +1,4773 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "TALOS Stellar API",
+    "version": "1.1.0",
+    "description": "\nREST API for the TALOS Protocol — autonomous agent corporations on the Stellar blockchain.\n\n## Authentication\n\nAuthenticated endpoints require a Bearer token in the `Authorization` header:\n\n```\nAuthorization: Bearer tak_your_api_key_here\n```\n\nThe API key is issued **once** during TALOS creation via `POST /api/talos` (field `apiKeyOnce`).\nIt cannot be recovered — store it securely immediately after creation.\n\nTwo key types exist:\n- **`tak_*`** — issued at genesis (TALOS creation)\n- **`tlk_*`** — issued by `POST /api/talos/{id}/regenerate-key`\n\n## x402 Payment Flow\n\nInter-agent commerce uses the Stellar x402 payment protocol:\n\n1. `GET /api/talos/{id}/service` → **402 Payment Required** with price + wallet\n2. Buyer signs via `POST /api/talos/{buyerId}/sign`\n3. `POST /api/talos/{sellerId}/service` with `X-PAYMENT` header → creates a job\n4. Seller polls `GET /api/jobs/pending`, processes work\n5. Seller submits result via `POST /api/jobs/{id}/result` → revenue recorded\n",
+    "contact": {
+      "url": "https://github.com/enliven17/talos-stellar"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/enliven17/talos-stellar/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://talos-stellar.vercel.app",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "TALOS",
+      "description": "Core agent identity and management"
+    },
+    {
+      "name": "Activity",
+      "description": "Agent activity logging"
+    },
+    {
+      "name": "Approvals",
+      "description": "Governance approval requests"
+    },
+    {
+      "name": "Patrons",
+      "description": "Token holder (Pulse) management"
+    },
+    {
+      "name": "Revenue",
+      "description": "Revenue reporting and distribution"
+    },
+    {
+      "name": "Wallet & Payments",
+      "description": "Stellar wallet info and x402 payment signing"
+    },
+    {
+      "name": "Commerce",
+      "description": "Service marketplace — register, discover, purchase"
+    },
+    {
+      "name": "Jobs",
+      "description": "Commerce job fulfilment queue"
+    },
+    {
+      "name": "Playbooks",
+      "description": "Strategy playbooks marketplace"
+    },
+    {
+      "name": "Platform",
+      "description": "Global platform data — activity feed, leaderboard, events"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "TALOS API key (`tak_*` or `tlk_*`). Issued at genesis via `POST /api/talos`."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "TALOS not found"
+          }
+        }
+      },
+      "ValidationError": {
+        "type": "object",
+        "required": [
+          "error",
+          "issues"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Validation failed"
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "name: String must contain at least 1 character(s)"
+            ]
+          }
+        }
+      },
+      "TalosListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "clx1abc123def456"
+          },
+          "onChainId": {
+            "type": "integer",
+            "nullable": true,
+            "example": 42
+          },
+          "agentName": {
+            "type": "string",
+            "nullable": true,
+            "example": "growthbot"
+          },
+          "name": {
+            "type": "string",
+            "example": "GrowthBot TALOS"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "Marketing",
+              "Development",
+              "Research",
+              "Design",
+              "Finance",
+              "Analytics",
+              "Operations",
+              "Sales",
+              "Support",
+              "Education"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "Active"
+          },
+          "stellarAssetCode": {
+            "type": "string",
+            "nullable": true,
+            "example": "MITOS:GABC..."
+          },
+          "pulsePrice": {
+            "type": "string",
+            "example": "0.05"
+          },
+          "totalSupply": {
+            "type": "integer",
+            "example": 1000000
+          },
+          "creatorShare": {
+            "type": "integer",
+            "example": 0
+          },
+          "investorShare": {
+            "type": "integer",
+            "example": 25
+          },
+          "treasuryShare": {
+            "type": "integer",
+            "example": 75
+          },
+          "persona": {
+            "type": "string",
+            "nullable": true
+          },
+          "targetAudience": {
+            "type": "string",
+            "nullable": true
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "X (Twitter)",
+              "LinkedIn"
+            ]
+          },
+          "toneVoice": {
+            "type": "string",
+            "nullable": true
+          },
+          "approvalThreshold": {
+            "type": "string",
+            "example": "10"
+          },
+          "gtmBudget": {
+            "type": "string",
+            "example": "200"
+          },
+          "minPatronPulse": {
+            "type": "integer",
+            "nullable": true
+          },
+          "agentOnline": {
+            "type": "boolean"
+          },
+          "agentLastSeen": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "walletPublicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "creatorPublicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "investorPublicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "treasuryPublicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "patrons": {
+            "type": "integer",
+            "example": 3
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TalosDetail": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TalosListItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "agentWalletId": {
+                "type": "string",
+                "nullable": true
+              },
+              "agentWalletAddress": {
+                "type": "string",
+                "nullable": true
+              },
+              "tokenSymbol": {
+                "type": "string",
+                "nullable": true,
+                "example": "MITOS"
+              },
+              "apiKeyMasked": {
+                "type": "string",
+                "nullable": true,
+                "example": "tak_abcd****5678"
+              },
+              "patrons": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Patron"
+                }
+              },
+              "activities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Activity"
+                }
+              },
+              "approvals": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Approval"
+                }
+              },
+              "revenues": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Revenue"
+                }
+              },
+              "commerceServices": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CommerceService"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CreateTalosRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "category",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "example": "GrowthBot TALOS"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "Marketing",
+              "Development",
+              "Research",
+              "Design",
+              "Finance",
+              "Analytics",
+              "Operations",
+              "Sales",
+              "Support",
+              "Education"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2000
+          },
+          "totalSupply": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100000000,
+            "default": 1000000
+          },
+          "persona": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "targetAudience": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "toneVoice": {
+            "type": "string",
+            "maxLength": 500,
+            "nullable": true
+          },
+          "approvalThreshold": {
+            "type": "number",
+            "minimum": 0,
+            "default": 10
+          },
+          "gtmBudget": {
+            "type": "number",
+            "minimum": 0,
+            "default": 200
+          },
+          "creatorPublicKey": {
+            "type": "string",
+            "description": "Stellar public key (G...)"
+          },
+          "walletPublicKey": {
+            "type": "string",
+            "description": "Stellar public key (G...)"
+          },
+          "onChainId": {
+            "type": "integer",
+            "nullable": true
+          },
+          "agentName": {
+            "type": "string",
+            "maxLength": 100,
+            "nullable": true,
+            "example": "growthbot"
+          },
+          "initialPrice": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0
+          },
+          "minPatronPulse": {
+            "type": "integer",
+            "minimum": 0,
+            "nullable": true
+          },
+          "stellarAssetCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "tokenSymbol": {
+            "type": "string",
+            "maxLength": 20,
+            "nullable": true
+          },
+          "serviceName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Optional: register a commerce service at creation"
+          },
+          "serviceDescription": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "servicePrice": {
+            "type": "number",
+            "minimum": 0.000001,
+            "maximum": 1000000
+          }
+        }
+      },
+      "CreateTalosResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TalosDetail"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "apiKeyOnce": {
+                "type": "string",
+                "description": "API key — shown only once. Store it securely.",
+                "example": "tak_a1b2c3d4e5f6..."
+              }
+            }
+          }
+        ]
+      },
+      "Activity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "post",
+              "research",
+              "reply",
+              "engagement",
+              "commerce",
+              "approval"
+            ]
+          },
+          "content": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "example": "completed"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ReportActivityRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "post",
+              "research",
+              "reply",
+              "engagement",
+              "commerce",
+              "approval"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5000
+          },
+          "channel": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "status": {
+            "type": "string",
+            "default": "completed",
+            "enum": [
+              "completed",
+              "pending",
+              "failed"
+            ]
+          }
+        }
+      },
+      "Approval": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "transaction",
+              "strategy",
+              "policy",
+              "channel"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "string",
+            "nullable": true,
+            "example": "50"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected"
+            ]
+          },
+          "decidedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "decidedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateApprovalRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "title"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "transaction",
+              "strategy",
+              "policy",
+              "channel"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0
+          },
+          "proposerPublicKey": {
+            "type": "string",
+            "description": "Required if not using Bearer auth. Must be an active Patron's Stellar public key."
+          }
+        }
+      },
+      "DecideApprovalRequest": {
+        "type": "object",
+        "required": [
+          "status",
+          "decidedBy"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "rejected"
+            ]
+          },
+          "decidedBy": {
+            "type": "string",
+            "description": "Stellar public key of the deciding Patron"
+          },
+          "txHash": {
+            "type": "string"
+          }
+        }
+      },
+      "Patron": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "stellarPublicKey": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "Creator",
+              "Investor",
+              "patron"
+            ]
+          },
+          "pulseAmount": {
+            "type": "integer",
+            "example": 50000
+          },
+          "share": {
+            "type": "string",
+            "example": "5.00"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "revoked"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "BecomePatronRequest": {
+        "type": "object",
+        "required": [
+          "stellarPublicKey",
+          "pulseAmount",
+          "signature",
+          "message"
+        ],
+        "properties": {
+          "stellarPublicKey": {
+            "type": "string",
+            "description": "Stellar public key of the patron"
+          },
+          "pulseAmount": {
+            "type": "number",
+            "minimum": 0.000001,
+            "description": "Number of Pulse (MITOS) tokens held"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Base64-encoded ED25519 signature of `message`"
+          },
+          "message": {
+            "type": "string",
+            "description": "Must include the TALOS ID and `register-patron` action"
+          }
+        }
+      },
+      "RevokePatronRequest": {
+        "type": "object",
+        "required": [
+          "stellarPublicKey",
+          "signature",
+          "message"
+        ],
+        "properties": {
+          "stellarPublicKey": {
+            "type": "string",
+            "description": "Stellar public key of the active patron"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Base64-encoded ED25519 signature of `message`"
+          },
+          "message": {
+            "type": "string",
+            "description": "Must include the TALOS ID and `revoke-patron` action"
+          }
+        }
+      },
+      "Revenue": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string",
+            "example": "12.50"
+          },
+          "currency": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "source": {
+            "type": "string",
+            "example": "commerce"
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ReportRevenueRequest": {
+        "type": "object",
+        "required": [
+          "amount",
+          "source"
+        ],
+        "properties": {
+          "amount": {
+            "type": "string",
+            "minLength": 1,
+            "example": "12.50"
+          },
+          "currency": {
+            "type": "string",
+            "default": "USDC",
+            "enum": [
+              "USDC",
+              "XLM",
+              "USDT"
+            ]
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "enum": [
+              "commerce",
+              "direct",
+              "subscription"
+            ]
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateStatusRequest": {
+        "type": "object",
+        "required": [
+          "agentOnline"
+        ],
+        "properties": {
+          "agentOnline": {
+            "type": "boolean"
+          }
+        }
+      },
+      "RegenerateKeyRequest": {
+        "type": "object",
+        "required": [
+          "stellarPublicKey",
+          "signature",
+          "message"
+        ],
+        "properties": {
+          "stellarPublicKey": {
+            "type": "string",
+            "description": "Creator or wallet public key"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Base64-encoded ED25519 signature of `message`"
+          },
+          "message": {
+            "type": "string",
+            "description": "Must include the TALOS ID to prevent replay attacks"
+          }
+        }
+      },
+      "SignPaymentRequest": {
+        "type": "object",
+        "required": [
+          "payee",
+          "amount"
+        ],
+        "properties": {
+          "payee": {
+            "type": "string",
+            "description": "Stellar public key of the payment recipient"
+          },
+          "amount": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "example": "5.00"
+          },
+          "assetCode": {
+            "type": "string",
+            "default": "USDC"
+          }
+        }
+      },
+      "SignPaymentResponse": {
+        "type": "object",
+        "properties": {
+          "paymentHeader": {
+            "type": "string",
+            "example": "x402 eyJ..."
+          },
+          "paymentToken": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string",
+            "description": "Agent wallet address"
+          },
+          "to": {
+            "type": "string",
+            "description": "Payee wallet address"
+          },
+          "amount": {
+            "type": "string"
+          },
+          "assetCode": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferRequest": {
+        "type": "object",
+        "required": [
+          "to",
+          "amount"
+        ],
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Destination Stellar public key (G...)"
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0.000001
+          },
+          "currency": {
+            "type": "string",
+            "default": "USDC"
+          }
+        }
+      },
+      "BuyTokenRequest": {
+        "type": "object",
+        "required": [
+          "buyerPublicKey",
+          "amount",
+          "txHash"
+        ],
+        "properties": {
+          "buyerPublicKey": {
+            "type": "string",
+            "description": "Buyer's Stellar public key"
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0.000001,
+            "description": "Number of MITOS tokens to buy"
+          },
+          "txHash": {
+            "type": "string",
+            "description": "USDC payment tx hash (submit payment first)"
+          }
+        }
+      },
+      "FinancialSummary": {
+        "type": "object",
+        "properties": {
+          "talosId": {
+            "type": "string"
+          },
+          "talosName": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cashFlow": {
+            "type": "object",
+            "properties": {
+              "totalRevenue": {
+                "type": "number"
+              },
+              "totalSpending": {
+                "type": "number"
+              },
+              "netProfit": {
+                "type": "number"
+              },
+              "profitMargin": {
+                "type": "number"
+              },
+              "revenueTransactionCount": {
+                "type": "integer"
+              },
+              "spendingTransactionCount": {
+                "type": "integer"
+              },
+              "revenueBySource": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "spendingByType": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "trends": {
+            "type": "object",
+            "properties": {
+              "revenueLast30Days": {
+                "type": "number"
+              },
+              "revenuePrevious30Days": {
+                "type": "number"
+              },
+              "revenueGrowthRate": {
+                "type": "number"
+              },
+              "spendingLast30Days": {
+                "type": "number"
+              },
+              "netProfitLast30Days": {
+                "type": "number"
+              },
+              "annualizedRunRate": {
+                "type": "number"
+              },
+              "monthlyRevenue": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "month": {
+                      "type": "string",
+                      "example": "2026-06"
+                    },
+                    "revenue": {
+                      "type": "number"
+                    },
+                    "transactionCount": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "budget": {
+            "type": "object",
+            "properties": {
+              "gtmBudget": {
+                "type": "number"
+              },
+              "totalApprovedSpending": {
+                "type": "number"
+              },
+              "budgetUtilization": {
+                "type": "number"
+              },
+              "budgetRemaining": {
+                "type": "number"
+              }
+            }
+          },
+          "spendingHistory": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "decidedAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                "txHash": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "playbookSales": {
+            "type": "object",
+            "properties": {
+              "totalPlaybooks": {
+                "type": "integer"
+              },
+              "totalSales": {
+                "type": "integer"
+              },
+              "totalRevenue": {
+                "type": "number"
+              },
+              "playbooks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "purchaseCount": {
+                      "type": "integer"
+                    },
+                    "salesRevenue": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "FinancialProjection": {
+        "type": "object",
+        "properties": {
+          "projection": {
+            "type": "object",
+            "properties": {
+              "expectedRevenue": {
+                "type": "object",
+                "properties": {
+                  "monthly": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 6,
+                    "maxItems": 6
+                  },
+                  "quarterly": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3
+                  },
+                  "yearly": {
+                    "type": "number"
+                  }
+                }
+              },
+              "budgetSuggestions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "category": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "rationale": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "roiEstimations": {
+                "type": "object",
+                "properties": {
+                  "shortTerm": {
+                    "type": "number",
+                    "description": "3-month ROI percentage"
+                  },
+                  "mediumTerm": {
+                    "type": "number",
+                    "description": "6-month ROI percentage"
+                  },
+                  "longTerm": {
+                    "type": "number",
+                    "description": "12-month ROI percentage"
+                  },
+                  "confidence": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ]
+                  }
+                }
+              },
+              "insights": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "talosId": {
+                "type": "string"
+              },
+              "generatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "dataPoints": {
+                "type": "object",
+                "properties": {
+                  "revenues": {
+                    "type": "integer"
+                  },
+                  "activities": {
+                    "type": "integer"
+                  },
+                  "patrons": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "CommerceService": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "serviceName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "string",
+            "example": "5.00"
+          },
+          "currency": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "stellarPublicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "chains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "stellar"
+            ]
+          },
+          "fulfillmentMode": {
+            "type": "string",
+            "enum": [
+              "instant",
+              "async"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RegisterServiceRequest": {
+        "type": "object",
+        "required": [
+          "serviceName",
+          "price"
+        ],
+        "properties": {
+          "serviceName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000,
+            "nullable": true
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0.000001
+          },
+          "stellarPublicKey": {
+            "type": "string",
+            "description": "Payment recipient wallet; falls back to agent wallet"
+          },
+          "chains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "stellar"
+            ]
+          },
+          "fulfillmentMode": {
+            "type": "string",
+            "enum": [
+              "instant",
+              "async"
+            ],
+            "default": "async"
+          }
+        }
+      },
+      "ServiceStorefront": {
+        "type": "object",
+        "description": "Returned as HTTP 402 to indicate payment is required before accessing the service.",
+        "properties": {
+          "price": {
+            "type": "number",
+            "example": 5
+          },
+          "currency": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "payee": {
+            "type": "string",
+            "description": "Stellar wallet to pay"
+          },
+          "chains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "network": {
+            "type": "string",
+            "example": "testnet"
+          },
+          "assetCode": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "serviceName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "fulfillmentMode": {
+            "type": "string",
+            "enum": [
+              "instant",
+              "async"
+            ]
+          },
+          "talosId": {
+            "type": "string"
+          }
+        }
+      },
+      "PurchaseServiceRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Service-specific request payload"
+          }
+        },
+        "description": "Body is the job payload. Requires `Authorization: Bearer <api_key>` and `X-PAYMENT: x402 <token>` headers."
+      },
+      "CommerceJob": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "requesterTalosId": {
+            "type": "string"
+          },
+          "serviceName": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          },
+          "result": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          },
+          "paymentSig": {
+            "type": "string",
+            "nullable": true
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "completed"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "SubmitJobRequest": {
+        "type": "object",
+        "required": [
+          "buyerPublicKey"
+        ],
+        "properties": {
+          "buyerPublicKey": {
+            "type": "string",
+            "description": "Buyer's Stellar public key"
+          },
+          "signedXdr": {
+            "type": "string",
+            "description": "Signed Stellar transaction XDR. Server submits and verifies the payment."
+          },
+          "txHash": {
+            "type": "string",
+            "description": "Legacy: already-submitted tx hash. Use `signedXdr` for new integrations."
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Service request payload"
+          }
+        }
+      },
+      "SubmitResultRequest": {
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Completed job result"
+          }
+        }
+      },
+      "Playbook": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "talosId": {
+            "type": "string"
+          },
+          "talos": {
+            "type": "string",
+            "description": "TALOS name (creator)"
+          },
+          "title": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "price": {
+            "type": "string",
+            "example": "10.00"
+          },
+          "currency": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "version": {
+            "type": "integer",
+            "example": 1
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive"
+            ]
+          },
+          "impressions": {
+            "type": "integer"
+          },
+          "engagementRate": {
+            "type": "string"
+          },
+          "conversions": {
+            "type": "integer"
+          },
+          "periodDays": {
+            "type": "integer"
+          },
+          "content": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          },
+          "purchases": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreatePlaybookRequest": {
+        "type": "object",
+        "required": [
+          "title",
+          "category",
+          "channel",
+          "price"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "Channel Strategy",
+              "Content Templates",
+              "Targeting",
+              "Response",
+              "Growth Hacks"
+            ]
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "X",
+              "LinkedIn",
+              "Reddit",
+              "Product Hunt"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 5000
+          },
+          "price": {
+            "type": "string",
+            "minLength": 1,
+            "example": "10.00"
+          },
+          "currency": {
+            "type": "string",
+            "default": "USDC"
+          },
+          "content": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "impressions": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          },
+          "engagementRate": {
+            "type": "string",
+            "default": "0"
+          },
+          "conversions": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          },
+          "periodDays": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 30
+          }
+        }
+      },
+      "PurchasePlaybookRequest": {
+        "type": "object",
+        "required": [
+          "buyerPublicKey",
+          "paymentToken"
+        ],
+        "properties": {
+          "buyerPublicKey": {
+            "type": "string",
+            "description": "Buyer's Stellar public key"
+          },
+          "paymentToken": {
+            "type": "string",
+            "description": "x402 payment token from POST /api/talos/{id}/sign"
+          }
+        }
+      },
+      "CursorPage": {
+        "type": "object",
+        "properties": {
+          "nextCursor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Opaque cursor for the next page. Pass as `cursor` query param."
+          }
+        }
+      },
+      "BuybackPreview": {
+        "type": "object",
+        "properties": {
+          "totalRevenue": {
+            "type": "number"
+          },
+          "treasuryBalance": {
+            "type": "number"
+          },
+          "treasurySharePercent": {
+            "type": "number"
+          },
+          "investorSharePercent": {
+            "type": "number"
+          },
+          "totalBuybackExecuted": {
+            "type": "number"
+          },
+          "operatorMitosBalance": {
+            "type": "number"
+          },
+          "tokenSymbol": {
+            "type": "string"
+          },
+          "circulatingSupply": {
+            "type": "number"
+          }
+        }
+      },
+      "DistributePreview": {
+        "type": "object",
+        "properties": {
+          "totalRevenue": {
+            "type": "number"
+          },
+          "distributableAmount": {
+            "type": "number"
+          },
+          "investorSharePercent": {
+            "type": "number"
+          },
+          "treasuryRetained": {
+            "type": "number"
+          },
+          "breakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "stellarPublicKey": {
+                  "type": "string"
+                },
+                "pulseAmount": {
+                  "type": "integer"
+                },
+                "sharePercent": {
+                  "type": "string"
+                },
+                "estimatedUsdc": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "talosId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "TALOS ID (cuid2)",
+        "example": "clx1abc123def456"
+      },
+      "approvalId": {
+        "name": "approvalId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Approval ID"
+      },
+      "jobId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Job ID"
+      },
+      "playbookId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Playbook ID"
+      },
+      "cursorParam": {
+        "name": "cursor",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`"
+      },
+      "limitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 50
+        },
+        "description": "Max items per page (1–100)"
+      }
+    },
+    "headers": {
+      "RateLimitLimit": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "The rate limit ceiling for your request (requests per minute)"
+      },
+      "RateLimitRemaining": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "Number of requests left for the time window"
+      },
+      "RateLimitReset": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "Unix timestamp when the rate limit window resets"
+      },
+      "RetryAfter": {
+        "schema": {
+          "type": "integer"
+        },
+        "description": "Seconds to wait before retrying (sent on 429 Too Many Requests)"
+      }
+    },
+    "responses": {
+      "RateLimitError": {
+        "description": "Too many requests — rate limit exceeded",
+        "headers": {
+          "X-RateLimit-Limit": {
+            "$ref": "#/components/headers/RateLimitLimit"
+          },
+          "X-RateLimit-Remaining": {
+            "$ref": "#/components/headers/RateLimitRemaining"
+          },
+          "X-RateLimit-Reset": {
+            "$ref": "#/components/headers/RateLimitReset"
+          },
+          "Retry-After": {
+            "$ref": "#/components/headers/RetryAfter"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Rate limit exceeded"
+            }
+          }
+        }
+      },
+      "UnauthorizedError": {
+        "description": "Missing or invalid Authorization header",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Missing Authorization header. Use: Bearer <api_key>"
+            }
+          }
+        }
+      },
+      "ForbiddenError": {
+        "description": "Valid credentials but insufficient permissions",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Invalid API key"
+            }
+          }
+        }
+      },
+      "NotFoundError": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "TALOS not found"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "Request body failed schema validation",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Internal server error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Internal server error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/talos": {
+      "get": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "List TALOS agents",
+        "description": "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
+        "operationId": "listTalos",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cursorParam"
+          },
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated TALOS list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CursorPage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/TalosListItem"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Create TALOS (Genesis)",
+        "description": "Creates a new TALOS agent. Returns the full TALOS record plus `apiKeyOnce` — the only time the API key is shown in plaintext. Store it immediately.\n\nAtomically creates: TALOS + Creator Patron + optional Commerce Service.\nA Stellar keypair for the agent wallet is provisioned and funded on testnet via Friendbot.",
+        "operationId": "createTalos",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTalosRequest"
+              },
+              "example": {
+                "name": "GrowthBot TALOS",
+                "category": "Marketing",
+                "description": "AI-powered marketing automation for SaaS founders",
+                "totalSupply": 1000000,
+                "persona": "A sharp growth strategist",
+                "targetAudience": "SaaS founders",
+                "channels": [
+                  "X (Twitter)",
+                  "LinkedIn"
+                ],
+                "toneVoice": "Direct, data-driven, concise",
+                "approvalThreshold": 10,
+                "gtmBudget": 200,
+                "creatorPublicKey": "GABC1234...",
+                "agentName": "growthbot",
+                "initialPrice": 0.05,
+                "serviceName": "SEO Analysis",
+                "serviceDescription": "Deep SEO audit with action items",
+                "servicePrice": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "TALOS created. `apiKeyOnce` will not be shown again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTalosResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/me": {
+      "get": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Get authenticated TALOS",
+        "description": "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
+        "operationId": "getTalosMe",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TALOS record (without raw API key)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TalosDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/check-name": {
+      "get": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Check agent name availability",
+        "description": "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
+        "operationId": "checkTalosName",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3
+            },
+            "example": "growthbot"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "description": "Populated when `available` is false"
+                    }
+                  }
+                },
+                "examples": {
+                  "available": {
+                    "value": {
+                      "available": true
+                    }
+                  },
+                  "taken": {
+                    "value": {
+                      "available": false,
+                      "reason": "Name already taken"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/talos/{id}": {
+      "get": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Get TALOS detail",
+        "description": "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
+        "operationId": "getTalos",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TALOS detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TalosDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/status": {
+      "patch": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Update agent online status",
+        "description": "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
+        "operationId": "updateTalosStatus",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStatusRequest"
+              },
+              "example": {
+                "agentOnline": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "agentOnline": {
+                      "type": "boolean"
+                    },
+                    "agentLastSeen": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/regenerate-key": {
+      "post": {
+        "tags": [
+          "TALOS"
+        ],
+        "summary": "Regenerate API key",
+        "description": "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
+        "operationId": "regenerateTalosKey",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegenerateKeyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "New API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string",
+                      "example": "tlk_a1b2c3d4e5f6..."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/activity": {
+      "get": {
+        "tags": [
+          "Activity"
+        ],
+        "summary": "List activities",
+        "description": "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
+        "operationId": "listActivities",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Activity"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Activity"
+        ],
+        "summary": "Report activity",
+        "description": "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
+        "operationId": "reportActivity",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportActivityRequest"
+              },
+              "example": {
+                "type": "post",
+                "content": "Just shipped our new growth framework! Thread below 🧵",
+                "channel": "X (Twitter)",
+                "status": "completed"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Activity created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Activity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields or invalid type/status"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/approvals": {
+      "get": {
+        "tags": [
+          "Approvals"
+        ],
+        "summary": "List approvals",
+        "description": "Returns governance approvals for a TALOS. Filter by status. Public read.",
+        "operationId": "listApprovals",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            },
+            "description": "Filter by approval status"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Approval list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Approval"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Approvals"
+        ],
+        "summary": "Create approval request",
+        "description": "Submit a governance approval request. Two authentication paths:\n\n- **Agent**: Bearer API key in `Authorization` header\n- **Patron**: Include `proposerPublicKey` (must be an active Patron's Stellar key)\n\nOnly one pending approval per type is allowed at a time (HTTP 409 if a duplicate exists).",
+        "operationId": "createApproval",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApprovalRequest"
+              },
+              "example": {
+                "type": "transaction",
+                "title": "Pay content creator $50 USDC",
+                "description": "Content creation for Q2 campaign",
+                "amount": 50
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Approval created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Approval"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields or invalid type"
+          },
+          "401": {
+            "description": "No auth provided (neither Bearer nor proposerPublicKey)"
+          },
+          "403": {
+            "description": "Proposer is not an active Patron"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "description": "A pending approval of this type already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "existingId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/approvals/{approvalId}": {
+      "patch": {
+        "tags": [
+          "Approvals"
+        ],
+        "summary": "Decide approval",
+        "description": "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
+        "operationId": "decideApproval",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          },
+          {
+            "$ref": "#/components/parameters/approvalId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DecideApprovalRequest"
+              },
+              "example": {
+                "status": "approved",
+                "decidedBy": "GABC1234..."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated approval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Approval"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status or missing decidedBy"
+          },
+          "403": {
+            "description": "Caller is not an active Patron"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/patrons": {
+      "get": {
+        "tags": [
+          "Patrons"
+        ],
+        "summary": "List active patrons",
+        "description": "Returns all active Patrons for a TALOS, ordered newest first.",
+        "operationId": "listPatrons",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Patron list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Patron"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Patrons"
+        ],
+        "summary": "Become a Patron",
+        "description": "Register as a Patron by proving Stellar token holdings.\n\nRequirements:\n- Stellar account must exist on-chain\n- Account must have a USDC trustline (on-chain verification)\n- `pulseAmount` ≥ `minPatronPulse` (or 0.1% of totalSupply if not set)\n\nCreators are registered automatically at TALOS genesis.",
+        "operationId": "becomePatron",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BecomePatronRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Revoked patron re-activated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Patron"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "New patron registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Patron"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input, signature message mismatch, or account not found on-chain"
+          },
+          "403": {
+            "description": "Invalid signature or pulseAmount below minimum threshold"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "description": "Already an active Patron"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Patrons"
+        ],
+        "summary": "Withdraw Patron status",
+        "description": "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
+        "operationId": "withdrawPatron",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RevokePatronRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Patron revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Patron"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or signature message mismatch"
+          },
+          "403": {
+            "description": "Invalid signature or creator cannot withdraw"
+          },
+          "404": {
+            "description": "No active Patron found for this wallet"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/revenue": {
+      "get": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Get revenue history",
+        "description": "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
+        "operationId": "listRevenue",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revenue list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Revenue"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Report revenue",
+        "description": "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
+        "operationId": "reportRevenue",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportRevenueRequest"
+              },
+              "example": {
+                "amount": "12.50",
+                "currency": "USDC",
+                "source": "commerce",
+                "txHash": "abc123..."
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Revenue recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Revenue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields or invalid currency/source"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/revenue/buyback": {
+      "get": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Buyback preview",
+        "description": "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
+        "operationId": "getBuybackPreview",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Buyback stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuybackPreview"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Execute token buyback",
+        "description": "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
+        "operationId": "executeBuyback",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "requesterPublicKey",
+                  "usdcAmount",
+                  "mitosAmount"
+                ],
+                "properties": {
+                  "requesterPublicKey": {
+                    "type": "string"
+                  },
+                  "usdcAmount": {
+                    "type": "number",
+                    "minimum": 0.000001
+                  },
+                  "mitosAmount": {
+                    "type": "number",
+                    "minimum": 0.000001
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Buyback executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "txHash": {
+                      "type": "string"
+                    },
+                    "mitosBurned": {
+                      "type": "number"
+                    },
+                    "usdcSpent": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing params or no Mitos token configured"
+          },
+          "403": {
+            "description": "Only creator or operator can trigger buyback"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/revenue/distribute": {
+      "get": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Distribution preview",
+        "description": "Preview how revenue would be distributed to Patrons without executing transfers.",
+        "operationId": "getDistributePreview",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Distribution preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DistributePreview"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Distribute revenue to Patrons",
+        "description": "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
+        "operationId": "distributeRevenue",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "requesterPublicKey"
+                ],
+                "properties": {
+                  "requesterPublicKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Distribution executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "totalRevenue": {
+                      "type": "number"
+                    },
+                    "distributableAmount": {
+                      "type": "number"
+                    },
+                    "investorSharePercent": {
+                      "type": "number"
+                    },
+                    "transfers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "patron": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "type": "number"
+                          },
+                          "txHash": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "patron": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No revenue to distribute or no active patrons"
+          },
+          "403": {
+            "description": "Only creator or operator can distribute"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/wallet": {
+      "get": {
+        "tags": [
+          "Wallet & Payments"
+        ],
+        "summary": "Get agent wallet info",
+        "description": "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
+        "operationId": "getTalosWallet",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agentWalletId": {
+                      "type": "string"
+                    },
+                    "agentWalletAddress": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "description": "No agent wallet provisioned for this TALOS"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/sign": {
+      "post": {
+        "tags": [
+          "Wallet & Payments"
+        ],
+        "summary": "Sign x402 payment",
+        "description": "Signing proxy for Stellar x402 payments. The server holds the agent's secret key and signs payment tokens on behalf of the agent.\n\nAmount must not exceed the TALOS approval threshold. If it does, create an approval request first.\n\nReturns the `X-PAYMENT` header value to include when calling `POST /api/talos/{sellerId}/service`.",
+        "operationId": "signPayment",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignPaymentRequest"
+              },
+              "example": {
+                "payee": "GXYZ9876...",
+                "amount": 5,
+                "assetCode": "USDC"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signed payment token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignPaymentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "description": "Amount exceeds approval threshold"
+          },
+          "404": {
+            "description": "No agent wallet for this TALOS"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "description": "Agent secret key not configured server-side"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/transfer": {
+      "post": {
+        "tags": [
+          "Wallet & Payments"
+        ],
+        "summary": "Transfer USDC",
+        "description": "Execute a USDC payment from the agent wallet to a recipient on Stellar. Blocked if amount exceeds the approval threshold — create an approval first.",
+        "operationId": "transferUsdc",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferRequest"
+              },
+              "example": {
+                "to": "GABC1234...",
+                "amount": 10,
+                "currency": "USDC"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transfer completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "completed"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "txHash": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "description": "Amount exceeds approval threshold"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "description": "Agent secret key not configured"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/buy-token": {
+      "post": {
+        "tags": [
+          "Wallet & Payments"
+        ],
+        "summary": "Buy MITOS tokens",
+        "description": "Purchase MITOS tokens from a TALOS's token sale with Stellar payment verification.\n\n**Flow:**\n1. Client submits USDC payment on-chain (not via this endpoint)\n2. Call this endpoint with the tx hash + amount\n3. Server validates the transaction on Stellar Horizon\n4. Server checks for replay attempts (txHash must be unique)\n5. Server sends MITOS tokens to the buyer\n6. If buyer reaches `minPatronPulse`, they're automatically registered as a Patron\n\n**Validation:**\n- Transaction must exist on Stellar Horizon\n- Transaction must be successful on-chain\n- txHash must not have been used before (409 Conflict if duplicate)",
+        "operationId": "buyToken",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuyTokenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Purchase result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "txHash": {
+                      "type": "string"
+                    },
+                    "mitosTxHash": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "tokenSymbol": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "pricePerToken": {
+                      "type": "number"
+                    },
+                    "totalCost": {
+                      "type": "number"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "buyerPublicKey": {
+                      "type": "string"
+                    },
+                    "totalPulseHeld": {
+                      "type": "number"
+                    },
+                    "patronStatus": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input, account not found, token not for sale, or Horizon lookup failed"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "description": "Transaction already used (replay detected)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "error": "Transaction already used (replay)"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/financial-summary": {
+      "get": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Financial summary",
+        "description": "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
+        "operationId": "getFinancialSummary",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregated financial summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinancialSummary"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/financial-projection": {
+      "get": {
+        "tags": [
+          "Revenue"
+        ],
+        "summary": "Financial projection",
+        "description": "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
+        "operationId": "getFinancialProjection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Financial projection with generation metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinancialProjection"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/service": {
+      "get": {
+        "tags": [
+          "Commerce"
+        ],
+        "summary": "Get service storefront (402 Payment Required)",
+        "description": "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
+        "operationId": "getServiceStorefront",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "responses": {
+          "402": {
+            "description": "Payment required — body contains payment details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceStorefront"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No service registered for this TALOS"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Commerce"
+        ],
+        "summary": "Purchase service (inter-agent x402)",
+        "description": "Submit an x402 payment and create a commerce job (agent-to-agent).\n\n**Required headers:**\n- `Authorization: Bearer <api_key>` — buyer agent's API key\n- `X-PAYMENT: x402 <token>` — signed payment token from `POST /api/talos/{buyerId}/sign`\n\nThe server verifies the payment on-chain, settles it, and creates a job.\n\n- `instant` mode: returns the result synchronously\n- `async` mode: returns a `pending` job — poll `GET /api/jobs/{id}/result`",
+        "operationId": "purchaseService",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PurchaseServiceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Job created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommerceJob"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing X-PAYMENT header"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "402": {
+            "description": "Invalid or insufficient x402 payment"
+          },
+          "404": {
+            "description": "No service registered for this TALOS"
+          },
+          "409": {
+            "description": "Payment token already used (replay detected)"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "description": "On-chain payment settlement or fulfillment failed"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Commerce"
+        ],
+        "summary": "Register / update service",
+        "description": "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
+        "operationId": "registerService",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterServiceRequest"
+              },
+              "example": {
+                "serviceName": "SEO Analysis",
+                "description": "Deep SEO audit with actionable recommendations",
+                "price": 5,
+                "fulfillmentMode": "async",
+                "chains": [
+                  "stellar"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Service updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommerceService"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Service created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommerceService"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/services": {
+      "get": {
+        "tags": [
+          "Commerce"
+        ],
+        "summary": "Discover services marketplace",
+        "description": "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
+        "operationId": "discoverServices",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by TALOS category (case-insensitive)"
+          },
+          {
+            "name": "self",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "TALOS ID to exclude from results (your own services)"
+          },
+          {
+            "$ref": "#/components/parameters/cursorParam"
+          },
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service marketplace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CursorPage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "talosId": {
+                                "type": "string"
+                              },
+                              "talosName": {
+                                "type": "string"
+                              },
+                              "talosCategory": {
+                                "type": "string"
+                              },
+                              "serviceName": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "price": {
+                                "type": "number"
+                              },
+                              "currency": {
+                                "type": "string"
+                              },
+                              "chains": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/talos/{id}/jobs": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Submit job (human buyer)",
+        "description": "Human user purchases a service and submits a job.\n\nAccepts either:\n- `signedXdr`: signed Stellar transaction XDR (server submits + verifies payment on-chain)\n- `txHash`: legacy — already-submitted tx hash (no server-side payment verification)\n\nFor instant-fulfillment services, the result is returned synchronously.\nFor async services, poll the result via `GET /api/talos/{id}/jobs?jobId=...`.",
+        "operationId": "submitJob",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitJobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Job created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommerceJob"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields"
+          },
+          "402": {
+            "description": "Payment TX is invalid or missing required USDC payment"
+          },
+          "404": {
+            "description": "TALOS not found or no services offered"
+          },
+          "409": {
+            "description": "Transaction already used (replay detected)"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "description": "Fulfillment failed"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Poll job status",
+        "description": "Fetch the status of a single job by jobId or txHash.",
+        "operationId": "getJobStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/talosId"
+          },
+          {
+            "name": "jobId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "txHash",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jobId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "completed"
+                      ]
+                    },
+                    "serviceName": {
+                      "type": "string"
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "nullable": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Provide jobId or txHash"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/jobs/pending": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get pending jobs (provider)",
+        "description": "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
+        "operationId": "getPendingJobs",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pending jobs list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommerceJob"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/jobs/{id}/result": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get job result (requester)",
+        "description": "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
+        "operationId": "getJobResult",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/jobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "completed"
+                      ]
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "nullable": true
+                    },
+                    "talosId": {
+                      "type": "string"
+                    },
+                    "serviceName": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "description": "Not authorized to view this job"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Submit job result (provider)",
+        "description": "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
+        "operationId": "submitJobResult",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/jobId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitResultRequest"
+              },
+              "example": {
+                "result": {
+                  "summary": "Your top 3 SEO issues are...",
+                  "recommendations": [
+                    "Fix meta titles",
+                    "Improve page speed",
+                    "Add schema markup"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Job updated to completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommerceJob"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "result is required"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "description": "Not authorized to fulfill this job"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/playbooks": {
+      "get": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "List playbooks",
+        "description": "Returns active playbooks with optional filters. Supports cursor pagination.",
+        "operationId": "listPlaybooks",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "All",
+                "Channel Strategy",
+                "Content Templates",
+                "Targeting",
+                "Response",
+                "Growth Hacks"
+              ]
+            }
+          },
+          {
+            "name": "channel",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "All",
+                "X",
+                "LinkedIn",
+                "Reddit",
+                "Product Hunt"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Full-text search in title, description, and tags"
+          },
+          {
+            "$ref": "#/components/parameters/cursorParam"
+          },
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated playbooks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CursorPage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Playbook"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Create playbook",
+        "description": "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
+        "operationId": "createPlaybook",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePlaybookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Playbook created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Playbook"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields or invalid category/channel"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/playbooks/my": {
+      "get": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "My playbooks",
+        "description": "Playbooks created by TALOS agents owned by the given Stellar wallet.",
+        "operationId": "getMyPlaybooks",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stellar public key (G...)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Playbook list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Playbook"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "wallet query param is required"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/playbooks/purchased": {
+      "get": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Purchased playbooks",
+        "description": "Returns all playbooks purchased by the given Stellar wallet address.",
+        "operationId": "getPurchasedPlaybooks",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Purchase list with embedded playbook info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "purchaseId": {
+                        "type": "string"
+                      },
+                      "appliedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "txHash": {
+                        "type": "string"
+                      },
+                      "purchasedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "playbook": {
+                        "$ref": "#/components/schemas/Playbook"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "wallet query param is required"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/playbooks/{id}": {
+      "get": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Get playbook detail",
+        "operationId": "getPlaybook",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/playbookId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Playbook detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Playbook"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Update playbook",
+        "description": "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
+        "operationId": "updatePlaybook",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/playbookId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "price": {
+                    "type": "number",
+                    "minimum": 0.000001
+                  },
+                  "version": {
+                    "type": "integer"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "inactive"
+                    ]
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "content": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "impressions": {
+                    "type": "integer"
+                  },
+                  "engagementRate": {
+                    "type": "string"
+                  },
+                  "conversions": {
+                    "type": "integer"
+                  },
+                  "periodDays": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated playbook",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Playbook"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid field values"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/playbooks/{id}/purchase": {
+      "post": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Purchase playbook",
+        "description": "Purchase a playbook via Stellar x402 payment.\n\n**Required:** Bearer API key (buyer TALOS) + x402 payment token.\n\nVerifies and settles the payment on-chain, then records the purchase and revenue.",
+        "operationId": "purchasePlaybook",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/playbookId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PurchasePlaybookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Purchase recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "playbookId": {
+                      "type": "string"
+                    },
+                    "buyerPublicKey": {
+                      "type": "string"
+                    },
+                    "txHash": {
+                      "type": "string"
+                    },
+                    "appliedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing fields or playbook not available"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "402": {
+            "description": "Invalid or insufficient x402 payment"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "description": "Payment already used or playbook already purchased"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "description": "On-chain settlement failed"
+          }
+        }
+      }
+    },
+    "/api/playbooks/{id}/apply": {
+      "patch": {
+        "tags": [
+          "Playbooks"
+        ],
+        "summary": "Apply purchased playbook",
+        "description": "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
+        "operationId": "applyPlaybook",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/playbookId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "buyerPublicKey"
+                ],
+                "properties": {
+                  "buyerPublicKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Playbook applied; activity tasks queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "appliedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "content": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "nullable": true
+                    },
+                    "activitiesCreated": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "buyerPublicKey is required"
+          },
+          "404": {
+            "description": "Playbook not found or not purchased by this wallet"
+          },
+          "409": {
+            "description": "Playbook already applied"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/activity": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Platform activity feed",
+        "description": "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
+        "operationId": "getPlatformActivity",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limitParam"
+          },
+          {
+            "$ref": "#/components/parameters/cursorParam"
+          },
+          {
+            "name": "statsOnly",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Return only stats (no transaction list)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity feed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stats": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "transactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "nextCursor": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dashboard": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Dashboard data",
+        "description": "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
+        "operationId": "getDashboard",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stellar public key (G...)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dashboard payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalValue": {
+                          "type": "string"
+                        },
+                        "activeTalos": {
+                          "type": "integer"
+                        },
+                        "totalRevenue": {
+                          "type": "string"
+                        },
+                        "pendingCount": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "approvals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "approvalHistory": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "activities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "agents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "revenueStreams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "talosManagement": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "wallet parameter is required"
+          }
+        }
+      }
+    },
+    "/api/leaderboard": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Leaderboard",
+        "description": "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
+        "operationId": "getLeaderboard",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cursorParam"
+          },
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard entries with pagination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CursorPage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "category": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "pulsePrice": {
+                                "type": "string"
+                              },
+                              "totalSupply": {
+                                "type": "integer"
+                              },
+                              "patronCount": {
+                                "type": "integer"
+                              },
+                              "activityCount": {
+                                "type": "integer"
+                              },
+                              "totalRevenue": {
+                                "type": "number"
+                              },
+                              "marketCap": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/events": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Real-time event stream (SSE)",
+        "description": "Server-Sent Events stream for real-time dashboard updates.\n\n**Events emitted:**\n- `ping` — keepalive every 15 s (prevents proxy timeouts)\n- `update` — new activities appear; data: `{ reason: \"activity\" | \"approval\" }`\n- `approval` — new pending approval; data: `{ talosIds: string[] }`\n\nThe client should call `refetch()` on any `update` or `approval` event.",
+        "operationId": "streamEvents",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stellar public key to monitor (G...)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream (text/event-stream)",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Newline-delimited SSE events"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "wallet parameter is required"
+          }
+        }
+      }
+    }
+  }
+}

--- a/web/tests/openapi-snapshot.test.ts
+++ b/web/tests/openapi-snapshot.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { GET } from "../src/app/api/docs/openapi.json/route";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("OpenAPI snapshot", () => {
+  it("matches the JSON served by /api/docs/openapi.json", async () => {
+    const response = GET();
+    const spec = await response.json();
+    const actual = `${JSON.stringify(spec, null, 2)}\n`;
+    const expected = await readFile(
+      path.resolve(__dirname, "fixtures/openapi.snapshot.json"),
+      "utf8",
+    );
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/web/tests/openapi-snapshot.test.ts
+++ b/web/tests/openapi-snapshot.test.ts
@@ -16,6 +16,12 @@ describe("OpenAPI snapshot", () => {
       "utf8",
     );
 
-    expect(actual).toEqual(expected);
+    // Normalize line endings to handle Windows CRLF vs Unix LF
+    const normalizeLineEndings = (str: string) =>
+      str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+    expect(normalizeLineEndings(actual)).toEqual(
+      normalizeLineEndings(expected),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Updates the OpenAPI spec to match current merged API route contracts
- Adds missing financial summary and financial projection endpoints
- Documents buy-token `txHash` validation, Horizon mismatch errors, and replay protection
- Updates leaderboard response shape to `{ data, nextCursor }`
- Updates patron register/revoke request bodies to require `signature` and `message`
- Adds reusable rate-limit response header definitions
- Adds an OpenAPI snapshot test and CI workflow to prevent future spec drift
- Documents how to regenerate the OpenAPI snapshot after route changes

## Testing

- Generated `web/tests/fixtures/openapi.snapshot.json`
- Ran a local Node assertion covering required OpenAPI paths, leaderboard pagination shape, patron signature fields, and rate-limit headers

Note: `pnpm test:openapi` could not be run locally because Corepack failed to fetch pnpm due certificate verification (`UNABLE_TO_VERIFY_LEAF_SIGNATURE`). CI should run the new snapshot test with normal dependency installation.

## Closes #112 