### PR TITLE
refactor: use shared OPERATOR_PUBLIC_KEY in buy-token route

### DIFF
--- a/web/src/app/api/talos/[id]/buy-token/route.ts
+++ b/web/src/app/api/talos/[id]/buy-token/route.ts
@@ -3,6 +3,7 @@ import { tlsTalos, tlsPatrons, tlsRevenues } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { getAccountInfo, getNetworkPassphrase, getUSDCIssuer } from "@/lib/stellar";
+import { OPERATOR_PUBLIC_KEY } from "@/lib/stellar-config";
 
 /**
  * Buy Mitos tokens from a Talos.
@@ -101,8 +102,7 @@ export async function POST(
       amount?: string;
     }>;
 
-    const operatorTreasury = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
-    const expectedDestinations = [operatorTreasury];
+    const expectedDestinations = [OPERATOR_PUBLIC_KEY];
     if (talos.agentWalletAddress) {
       expectedDestinations.push(talos.agentWalletAddress);
     }

--- a/web/tests/buy-token.test.ts
+++ b/web/tests/buy-token.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../src/app/api/talos/[id]/buy-token/route";
 import { Keypair, Asset, TransactionBuilder, Operation, Networks, Account } from "@stellar/stellar-sdk";
+import { OPERATOR_PUBLIC_KEY } from "../src/lib/stellar-config";
 
 // Use vi.hoisted to declare mock functions so they are hoisted along with the vi.mock calls,
 // preventing any TypeScript linting or execution scoping warnings.
@@ -89,7 +90,7 @@ vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
 });
 
 describe("POST /api/talos/[id]/buy-token — Verification Tests", () => {
-  const operatorTreasury = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL";
+  const operatorTreasury = OPERATOR_PUBLIC_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -328,7 +329,7 @@ describe("POST /api/talos/[id]/buy-token — Verification Tests", () => {
     })
       .addOperation(
         Operation.payment({
-          destination: "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL",
+          destination: operatorTreasury,
           asset: usdcAsset,
           amount: "5.0000000",
         })


### PR DESCRIPTION
Use shared OPERATOR_PUBLIC_KEY in buy-token route
Context
After PR #86 landed web/src/lib/stellar-config.ts as the single source of truth for OPERATOR_PUBLIC_KEY, the buy-token route still had a hardcoded GCEFRN... address — the last remaining server-side route with a literal operator address.
Changes
- web/src/app/api/talos/[id]/buy-token/route.ts — imported OPERATOR_PUBLIC_KEY from @/lib/stellar-config and replaced the hardcoded operatorTreasury constant
- web/tests/buy-token.test.ts — updated the test to import OPERATOR_PUBLIC_KEY from the same config, keeping the mocked treasury in sync
Verification
- grep "GCEFRN" web/src/ returns only web/src/lib/stellar-config.ts (the config file itself) — no hardcoded address in any route
- Existing buy-token vitest cases continue to use the same address value from the shared import


closes #109