### PR TITLE
Add exponential backoff

### DIFF
--- a/packages/prime-agent/src/talos_agent/scheduler.py
+++ b/packages/prime-agent/src/talos_agent/scheduler.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+import random
 import signal
 from typing import TYPE_CHECKING
 
@@ -13,8 +15,53 @@ if TYPE_CHECKING:
     from talos_agent.config import Settings
 
 console = Console()
+logger = logging.getLogger(__name__)
 
 SHUTDOWN_GRACE_PERIOD = 10  # seconds before force-exit on second signal
+
+
+class Backoff:
+    """Exponential backoff with jitter for task retries."""
+
+    def __init__(
+        self,
+        base_delay: float,
+        initial_backoff: float = 2.0,
+        max_backoff: float = 300.0,
+        jitter: float = 0.2,
+    ):
+        self.base_delay = base_delay
+        self.initial_backoff = initial_backoff
+        self.max_backoff = max_backoff
+        self.jitter = jitter
+        self.fail_count = 0
+
+    def next_delay(self) -> float:
+        if self.fail_count == 0:
+            return self.base_delay
+
+        # Exponential backoff: initial * 2^(fail_count - 1)
+        delay = self.initial_backoff * (2 ** (self.fail_count - 1))
+        delay = min(delay, self.max_backoff)
+
+        # Add jitter (+- 20%)
+        if self.jitter > 0:
+            j = delay * self.jitter
+            delay = delay + random.uniform(-j, j)
+
+        actual_delay = max(delay, 0.1)  # floor at 100ms
+        logger.debug(
+            f"Backoff state: fail_count={self.fail_count}, next_delay={actual_delay:.2f}s"
+        )
+        return actual_delay
+
+    def success(self):
+        if self.fail_count > 0:
+            logger.debug("Backoff reset on success")
+        self.fail_count = 0
+
+    def failure(self):
+        self.fail_count += 1
 
 
 async def run(settings: Settings, agent_slot: int = 0) -> None:
@@ -112,6 +159,7 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
 
     async def polling_task():
         """Poll Web API for approvals and commerce jobs."""
+        backoff = Backoff(base_delay=settings.polling_interval)
         while not shutdown_event.is_set():
             try:
                 # Poll approvals
@@ -120,35 +168,52 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                     cached = db.get_pending_approvals()
                     cached_ids = {c["approval_id"] for c in cached}
                     if a["id"] not in cached_ids:
-                        db.cache_approval(a["id"], a["type"], a["title"], a.get("description"), a.get("amount"))
+                        db.cache_approval(
+                            a["id"],
+                            a["type"],
+                            a["title"],
+                            a.get("description"),
+                            a.get("amount"),
+                        )
 
                 # Poll pending jobs (as service provider)
                 jobs = await api.get_pending_jobs()
                 for job in jobs:
-                    db.add_commerce_job(job["id"], job["talosId"], job.get("serviceName", ""), job.get("payload"))
+                    db.add_commerce_job(
+                        job["id"], job["talosId"], job.get("serviceName", ""), job.get("payload")
+                    )
+
+                backoff.success()
             except Exception as e:
                 console.print(f"[dim red]Polling error: {e}[/dim red]")
+                backoff.failure()
+
             try:
-                await asyncio.wait_for(shutdown_event.wait(), timeout=settings.polling_interval)
+                await asyncio.wait_for(shutdown_event.wait(), timeout=backoff.next_delay())
                 break
             except asyncio.TimeoutError:
                 pass
 
     async def heartbeat_task():
         """Report online status periodically."""
+        backoff = Backoff(base_delay=settings.heartbeat_interval)
         while not shutdown_event.is_set():
             try:
                 await api.update_status(settings.talos_id, online=True)
-            except Exception:
-                pass
+                backoff.success()
+            except Exception as e:
+                logger.debug(f"Heartbeat error: {e}")
+                backoff.failure()
+
             try:
-                await asyncio.wait_for(shutdown_event.wait(), timeout=settings.heartbeat_interval)
+                await asyncio.wait_for(shutdown_event.wait(), timeout=backoff.next_delay())
                 break
             except asyncio.TimeoutError:
                 pass
 
     async def activity_flush_task():
         """Flush buffered activity logs to Web API."""
+        backoff = Backoff(base_delay=30)
         while not shutdown_event.is_set():
             try:
                 pending = db.get_pending_activities()
@@ -161,10 +226,13 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                             channel=act["channel"],
                         )
                     db.mark_activities_sent([a["id"] for a in pending])
-            except Exception:
-                pass
+                backoff.success()
+            except Exception as e:
+                logger.debug(f"Activity flush error: {e}")
+                backoff.failure()
+
             try:
-                await asyncio.wait_for(shutdown_event.wait(), timeout=30)
+                await asyncio.wait_for(shutdown_event.wait(), timeout=backoff.next_delay())
                 break
             except asyncio.TimeoutError:
                 pass

--- a/packages/prime-agent/tests/test_backoff.py
+++ b/packages/prime-agent/tests/test_backoff.py
@@ -1,0 +1,60 @@
+
+import pytest
+import logging
+from talos_agent.scheduler import Backoff
+
+def test_backoff_base_delay():
+    b = Backoff(base_delay=10.0)
+    assert b.next_delay() == 10.0
+    b.success()
+    assert b.next_delay() == 10.0
+
+def test_backoff_exponential():
+    # Disable jitter for deterministic testing
+    b = Backoff(base_delay=10.0, initial_backoff=2.0, jitter=0)
+
+    b.failure()
+    assert b.next_delay() == 2.0
+
+    b.failure()
+    assert b.next_delay() == 4.0
+
+    b.failure()
+    assert b.next_delay() == 8.0
+
+def test_backoff_max():
+    b = Backoff(base_delay=10.0, initial_backoff=2.0, max_backoff=10.0, jitter=0)
+    for _ in range(5):
+        b.failure()
+    assert b.next_delay() == 10.0
+
+def test_backoff_reset():
+    b = Backoff(base_delay=10.0, initial_backoff=2.0, jitter=0)
+    b.failure()
+    b.failure()
+    assert b.next_delay() == 4.0
+
+    b.success()
+    assert b.next_delay() == 10.0
+
+def test_backoff_jitter():
+    # With 20% jitter, 100.0 should be between 80.0 and 120.0
+    b = Backoff(base_delay=10.0, initial_backoff=100.0, jitter=0.2)
+    b.failure()
+
+    delays = [b.next_delay() for _ in range(100)]
+    for d in delays:
+        assert 80.0 <= d <= 120.0
+
+    # Ensure they are not all the same
+    assert len(set(delays)) > 1
+
+def test_backoff_logging(caplog):
+    caplog.set_level(logging.DEBUG)
+    b = Backoff(base_delay=10.0, initial_backoff=2.0, jitter=0)
+    b.failure()
+    _ = b.next_delay()
+    assert "Backoff state: fail_count=1, next_delay=2.00s" in caplog.text
+
+    b.success()
+    assert "Backoff reset on success" in caplog.text


### PR DESCRIPTION
Implemented exponential backoff with jitter for the agent's background tasks (`polling_task`, `heartbeat_task`, `activity_flush_task`) in `scheduler.py`. This ensures that when the Web API is unavailable, the agents don't overwhelm it with frequent retries, adhering to the requested 2s-300s backoff range with +/- 20% jitter. Added comprehensive unit tests for the backoff logic.

---

Closes #35 