### PR TITLE
fix(web): use credentials for font preconnect

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -23,6 +23,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${ruthie.variable} h-full antialiased bg-background`} style={{ colorScheme: "light", backgroundColor: "#FCF8F8" }}>
+      <head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="use-credentials" />
+      </head>
       <body className="min-h-full flex flex-col bg-background text-foreground font-mono" style={{ backgroundColor: "#FCF8F8" }}>
         <SplashScreen />
         <Providers>


### PR DESCRIPTION
Closes #511
## Summary
- Adds a font preconnect link with `crossOrigin="use-credentials"` in the root layout
- Ensures authenticated font requests can include credentials when required by the font host

## Testing
- `git diff --check`
- Could not run lint/tests because dependencies are not installed locally.## Summary
- Adds a font preconnect link with `crossOrigin="use-credentials"` in the root layout
- Ensures authenticated font requests can include credentials when required by the font host

## Testing
- `git diff --check`
- Could not run lint/tests because dependencies are not installed locally.