### PR TITLE
test(web): add stable selectors to key controls

### DIFF
--- a/web/src/app/agents/agents-client.tsx
+++ b/web/src/app/agents/agents-client.tsx
@@ -147,6 +147,7 @@ export function AgentsClient({ agents }: { agents: TalosListItem[] }) {
               placeholder="Search agents, services..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              data-testid="agents-search-input"
               className="w-full bg-surface border border-border pl-9 pr-4 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent transition-colors"
             />
           </div>
@@ -158,6 +159,7 @@ export function AgentsClient({ agents }: { agents: TalosListItem[] }) {
                 <button
                   key={s}
                   onClick={() => setStatusFilter(s)}
+                  data-testid={`agents-status-filter-${s.toLowerCase()}`}
                   className={`px-3 py-2 text-sm transition-colors ${
                     statusFilter === s
                       ? "bg-surface text-accent"
@@ -179,6 +181,7 @@ export function AgentsClient({ agents }: { agents: TalosListItem[] }) {
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortOption)}
+              data-testid="agents-sort-select"
               className="bg-surface border border-border px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent cursor-pointer"
             >
               {SORT_OPTIONS.map((opt) => (
@@ -196,6 +199,7 @@ export function AgentsClient({ agents }: { agents: TalosListItem[] }) {
             <button
               key={cat}
               onClick={() => setActiveCategory(cat)}
+              data-testid={`agents-category-filter-${cat.toLowerCase()}`}
               className={`px-3 py-2 text-sm border transition-colors ${
                 activeCategory === cat
                   ? "border-accent text-accent bg-surface"
@@ -224,6 +228,7 @@ export function AgentsClient({ agents }: { agents: TalosListItem[] }) {
             <Link
               key={item.id}
               href={`/agents/${item.id}`}
+              data-testid={`agent-card-${item.id}`}
               className="bg-surface border border-border p-6 hover:bg-surface-hover transition-colors flex flex-col justify-between group"
             >
               {/* Top: avatar + name + status */}

--- a/web/src/app/dashboard/dashboard-client.tsx
+++ b/web/src/app/dashboard/dashboard-client.tsx
@@ -298,12 +298,15 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
           <section className="mb-10">
             <h2 className="text-sm text-muted mb-4 tracking-wide">// PORTFOLIO OVERVIEW</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              {PORTFOLIO_STATS.map((stat) => (
-                <div key={stat.label} className="bg-surface border border-border p-5 hover:bg-surface-hover transition-colors">
-                  <p className="text-muted text-sm mb-2 uppercase tracking-wider">{stat.label}</p>
-                  <p className="text-accent text-2xl font-bold">{stat.value}</p>
-                </div>
-              ))}
+              {PORTFOLIO_STATS.map((stat) => {
+                const testId = `portfolio-stat-${stat.label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+                return (
+                  <div key={stat.label} data-testid={testId} className="bg-surface border border-border p-5 hover:bg-surface-hover transition-colors">
+                    <p className="text-muted text-sm mb-2 uppercase tracking-wider">{stat.label}</p>
+                    <p data-testid={`${testId}-value`} className="text-accent text-2xl font-bold">{stat.value}</p>
+                  </div>
+                );
+              })}
             </div>
           </section>
 
@@ -344,7 +347,7 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                           <div className="flex items-center gap-2 mb-1">
                             <TypeBadge type={item.type} />
                             <span className="text-xs text-muted">{item.talosName}</span>
-                            {item.amount && <span className="text-xs text-accent">{item.amount}</span>}
+                            {item.amount && <span data-testid={`approval-amount-${item.id}`} className="text-xs text-accent">{item.amount}</span>}
                           </div>
                           <p className="text-sm text-foreground truncate">{item.title}</p>
                           {item.description && (
@@ -354,12 +357,14 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                         <div className="flex gap-2 shrink-0">
                           <button
                             onClick={() => handleDecision(item.id, item.talosId, "approved")}
+                            data-testid={`approve-approval-${item.id}`}
                             className="border border-accent text-accent px-3 py-1.5 text-xs hover:bg-accent hover:text-white transition-colors font-bold"
                           >
                             APPROVE
                           </button>
                           <button
                             onClick={() => handleDecision(item.id, item.talosId, "rejected")}
+                            data-testid={`reject-approval-${item.id}`}
                             className="border border-muted text-muted px-3 py-1.5 text-xs hover:bg-muted hover:text-white transition-colors"
                           >
                             REJECT
@@ -383,7 +388,7 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                           <div className="flex items-center gap-2 mb-1">
                             <TypeBadge type={item.type} />
                             <span className="text-xs text-muted">{item.talosName}</span>
-                            {item.amount && <span className="text-xs text-accent">{item.amount}</span>}
+                            {item.amount && <span data-testid={`approval-history-amount-${item.id}`} className="text-xs text-accent">{item.amount}</span>}
                             <span className={`text-xs font-bold ${item.status === "approved" ? "text-accent" : "text-muted"}`}>
                               [{item.status.toUpperCase()}]
                             </span>
@@ -461,7 +466,7 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                         <AgentAvatar name={rs.talosName} size={18} className="shrink-0" />
                         {rs.talosName}
                       </h3>
-                      <span className="text-sm text-foreground font-bold">${rs.totalRevenue.toFixed(2)}</span>
+                      <span data-testid={`revenue-total-${rs.talosId}`} className="text-sm text-foreground font-bold">${rs.totalRevenue.toFixed(2)}</span>
                     </div>
                     <div className="mb-4 px-3 py-2 bg-background border border-border text-xs text-muted">
                       100% Agent Treasury &mdash; revenue funds operations &amp; Mitos buyback
@@ -469,7 +474,7 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                     <div className="flex gap-3 mb-4">
                       {Object.entries(rs.bySource).map(([source, amount]) => (
                         <span key={source} className="text-xs text-muted">
-                          {source}: <span className="text-foreground">${amount.toFixed(2)}</span>
+                          {source}: <span data-testid={`revenue-source-${rs.talosId}-${source.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`} className="text-foreground">${amount.toFixed(2)}</span>
                         </span>
                       ))}
                     </div>
@@ -481,7 +486,7 @@ function DashboardContent({ stats, approvals: initialApprovals, approvalHistory:
                               <span className="text-muted">{new Date(tx.date).toLocaleDateString()}</span>
                               <span className="text-muted">[{tx.source.toUpperCase()}]</span>
                             </div>
-                            <span className="text-foreground">+${tx.amount.toFixed(2)} {tx.currency}</span>
+                            <span data-testid={`recent-revenue-${rs.talosId}-${i}`} className="text-foreground">+${tx.amount.toFixed(2)} {tx.currency}</span>
                           </div>
                         ))}
                       </div>

--- a/web/src/app/launch/page.tsx
+++ b/web/src/app/launch/page.tsx
@@ -380,12 +380,12 @@ function LaunchForm() {
 
           <div>
             <div className="text-xs text-muted mb-2">Agent Identity</div>
-            <div className="text-foreground font-mono text-sm">{genesisResult.agentName}.talos</div>
+            <div data-testid="launched-agent-identity" className="text-foreground font-mono text-sm">{genesisResult.agentName}.talos</div>
           </div>
 
           <div>
             <div className="text-xs text-accent font-bold mb-2">API Key (shown only once — save it now)</div>
-            <div className="bg-background border border-border p-3 font-mono text-xs text-accent break-all select-all">
+            <div data-testid="launched-api-key" className="bg-background border border-border p-3 font-mono text-xs text-accent break-all select-all">
               {genesisResult.apiKey}
             </div>
           </div>
@@ -411,6 +411,7 @@ function LaunchForm() {
                 setTimeout(() => setCopied(false), 2000);
               });
             }}
+            data-testid="copy-api-key-button"
             className={`px-6 py-2.5 text-sm border transition-colors ${
               copied ? "border-accent text-accent font-bold" : "border-border text-foreground hover:bg-surface-hover"
             }`}
@@ -419,6 +420,7 @@ function LaunchForm() {
           </button>
           <button
             onClick={() => router.push(`/agents/${genesisResult.talosId}`)}
+            data-testid="view-launched-talos-button"
             className="px-8 py-2.5 text-sm bg-accent text-background font-medium hover:bg-foreground transition-colors"
           >
             View TALOS &rarr;
@@ -461,6 +463,7 @@ function LaunchForm() {
             checkNameAvailability("nexus");
             setStep(0);
           }}
+          data-testid="load-demo-launch-form-button"
           className="px-4 py-2 text-xs border border-accent/30 text-accent hover:bg-surface-hover transition-colors"
         >
           Demo: Nexus
@@ -473,6 +476,7 @@ function LaunchForm() {
           <button
             key={s}
             onClick={() => i <= step && setStep(i)}
+            data-testid={`launch-step-${s.toLowerCase()}`}
             className={`px-3 py-1.5 text-xs border transition-colors whitespace-nowrap ${
               i === step
                 ? "border-accent text-accent bg-surface"
@@ -501,6 +505,7 @@ function LaunchForm() {
               <select
                 value={form.category}
                 onChange={(e) => update("category", e.target.value)}
+                data-testid="launch-input-category"
                 className="w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground focus:outline-none focus:border-accent"
               >
                 <option value="marketing">Marketing</option>
@@ -531,6 +536,7 @@ function LaunchForm() {
                     value={form.servicePrice}
                     onChange={(e) => update("servicePrice", e.target.value)}
                     placeholder="e.g. 5.00"
+                    data-testid="launch-input-service-price"
                     className="w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent"
                   />
                 </div>
@@ -547,7 +553,10 @@ function LaunchForm() {
             </p>
             <div>
               <label className="block text-xs text-muted mb-2">Creator Public Key (Stellar)</label>
-              <div className="w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground/70 font-mono select-all break-all">
+              <div
+                data-testid="creator-wallet-display"
+                className="w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground/70 font-mono select-all break-all"
+              >
                 {form.creatorWallet || address || "—"}
               </div>
               <p className="text-xs text-muted mt-1">This Stellar public key will be registered as the TALOS Creator on-chain.</p>
@@ -616,6 +625,7 @@ function LaunchForm() {
                     checkNameAvailability(v);
                   }}
                   placeholder="e.g. marketbot"
+                  data-testid="launch-input-agent-identity"
                   className="flex-1 bg-background border border-border px-4 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent"
                 />
                 <span className="text-sm text-muted">.talos</span>
@@ -641,6 +651,7 @@ function LaunchForm() {
               <select
                 value={form.tone}
                 onChange={(e) => update("tone", e.target.value)}
+                data-testid="launch-input-tone"
                 className="w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground focus:outline-none focus:border-accent"
               >
                 <option value="professional">Professional</option>
@@ -661,6 +672,7 @@ function LaunchForm() {
                         : [...form.channels, ch];
                       update("channels", channels);
                     }}
+                    data-testid={`launch-channel-${ch.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
                     className={`px-3 py-1.5 text-xs border transition-colors ${
                       form.channels.includes(ch)
                         ? "border-accent text-accent bg-surface"
@@ -745,6 +757,7 @@ function LaunchForm() {
         <button
           onClick={() => setStep(Math.max(0, step - 1))}
           disabled={step === 0}
+          data-testid="launch-back-button"
           className="px-6 py-2.5 text-sm border border-border text-foreground hover:bg-surface-hover transition-colors disabled:opacity-30 disabled:cursor-default"
         >
           Back
@@ -753,6 +766,7 @@ function LaunchForm() {
           <button
             onClick={() => setStep(step + 1)}
             disabled={!canNext()}
+            data-testid="launch-next-button"
             className="px-6 py-2.5 text-sm bg-accent text-background font-medium hover:bg-foreground transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
           >
             Next
@@ -761,6 +775,7 @@ function LaunchForm() {
           <button
             onClick={handleLaunch}
             disabled={submitting}
+            data-testid="launch-submit-button"
             className="px-8 py-2.5 text-sm bg-accent text-background font-medium hover:bg-foreground transition-colors disabled:opacity-50"
           >
             {submitting ? (deployStep || "Deploying...") : "Launch TALOS"}
@@ -786,6 +801,7 @@ function Field({
   type?: string;
   multiline?: boolean;
 }) {
+  const testId = `launch-input-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
   const cls =
     "w-full bg-background border border-border px-4 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent";
   return (
@@ -797,6 +813,7 @@ function Field({
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           rows={3}
+          data-testid={testId}
           className={`${cls} resize-none`}
         />
       ) : (
@@ -805,6 +822,7 @@ function Field({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
+          data-testid={testId}
           className={cls}
         />
       )}

--- a/web/src/app/playbooks/page.tsx
+++ b/web/src/app/playbooks/page.tsx
@@ -172,6 +172,7 @@ export default function PlaybooksPage() {
               setTab(t);
               setSelected(null);
             }}
+            data-testid={`playbooks-tab-${t}`}
             className={`pb-3 text-sm transition-colors whitespace-nowrap shrink-0 ${
               tab === t
                 ? "text-accent border-b border-accent"
@@ -196,6 +197,7 @@ export default function PlaybooksPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search playbooks..."
+              data-testid="playbooks-search-input"
               className="w-full bg-surface border border-border px-4 py-2.5 text-sm text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent"
             />
             <div className="flex flex-wrap gap-4">
@@ -206,6 +208,7 @@ export default function PlaybooksPage() {
                     <button
                       key={c}
                       onClick={() => setCategory(c)}
+                      data-testid={`playbooks-category-filter-${c.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
                       className={`px-2.5 py-1 text-xs border transition-colors ${
                         category === c
                           ? "border-accent text-accent"
@@ -224,6 +227,7 @@ export default function PlaybooksPage() {
                     <button
                       key={c}
                       onClick={() => setChannel(c)}
+                      data-testid={`playbooks-channel-filter-${c.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
                       className={`px-2.5 py-1 text-xs border transition-colors ${
                         channel === c
                           ? "border-accent text-accent"
@@ -253,6 +257,7 @@ export default function PlaybooksPage() {
                 <button
                   key={p.id}
                   onClick={() => setSelected(p)}
+                  data-testid={`playbook-card-${p.id}`}
                   className="bg-surface border border-border p-5 text-left hover:bg-surface-hover transition-colors group"
                 >
                   <div className="flex items-center justify-between mb-3">
@@ -293,6 +298,7 @@ export default function PlaybooksPage() {
         <div>
           <button
             onClick={() => setSelected(null)}
+            data-testid="playbook-detail-back-button"
             className="text-xs text-muted hover:text-foreground mb-6 transition-colors"
           >
             &larr; Back to browse
@@ -373,6 +379,7 @@ export default function PlaybooksPage() {
                 {isConnected ? (
                   <button
                     onClick={() => handlePurchase(selected.id)}
+                    data-testid={`purchase-playbook-${selected.id}`}
                     className="w-full bg-accent text-background py-2.5 text-sm font-medium hover:bg-foreground transition-colors mb-3"
                   >
                     Purchase Playbook
@@ -380,6 +387,7 @@ export default function PlaybooksPage() {
                 ) : (
                   <button
                     onClick={connect}
+                    data-testid="connect-to-purchase-button"
                     className="w-full bg-accent text-background py-2.5 text-sm font-medium hover:bg-foreground transition-colors mb-3 flex items-center justify-center gap-2"
                   >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -547,6 +555,7 @@ export default function PlaybooksPage() {
                     {!pp.appliedAt && (
                       <button
                         onClick={() => handleApply(pp.playbook.id)}
+                        data-testid={`apply-playbook-${pp.playbook.id}`}
                         className="px-3 py-1.5 text-xs bg-accent text-background hover:bg-foreground transition-colors"
                       >
                         Apply to Agent
@@ -679,6 +688,7 @@ function WalletRequiredTab({ message, onConnect }: { message: string; onConnect:
       <p className="text-sm text-muted mb-6">{message}</p>
       <button
         onClick={onConnect}
+        data-testid="connect-wallet-required-tab-button"
         className="bg-accent text-background px-6 py-2.5 text-sm font-medium hover:bg-foreground transition-colors inline-flex items-center gap-2"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -29,6 +29,7 @@ export function Header() {
         <div className="flex items-center gap-6 lg:gap-8 min-w-0">
           <Link
             href="/"
+            data-testid="nav-link-home"
             className="text-nav-accent text-3xl sm:text-4xl font-ruthie shrink-0"
             onClick={() => setMenuOpen(false)}
           >
@@ -39,6 +40,7 @@ export function Header() {
               <Link
                 key={item.href}
                 href={item.href}
+                data-testid={`nav-link-${item.href.slice(1)}`}
                 className={`text-sm transition-colors flex items-center gap-1.5 whitespace-nowrap ${
                   item.highlight
                     ? pathname === item.href
@@ -65,6 +67,7 @@ export function Header() {
           {isConnected && (
             <Link
               href="/dashboard"
+              data-testid="nav-link-dashboard"
               className={`hidden md:inline-flex text-sm transition-colors items-center gap-1.5 ${
                 pathname === "/dashboard" ? "text-nav-accent" : "text-muted hover:text-nav-foreground"
               }`}
@@ -74,6 +77,7 @@ export function Header() {
           )}
           <Link
             href="/launch"
+            data-testid="nav-link-launch"
             className={`hidden md:inline-flex px-4 py-2 text-sm font-medium transition-colors ${
               pathname === "/launch"
                 ? "bg-accent text-background"
@@ -84,11 +88,15 @@ export function Header() {
           </Link>
           {isConnected ? (
             <div className="hidden md:flex items-center gap-3">
-              <span className="text-xs text-nav-foreground font-mono bg-surface border border-border px-3 py-1.5">
+              <span
+                data-testid="connected-wallet-address"
+                className="text-xs text-nav-foreground font-mono bg-surface border border-border px-3 py-1.5"
+              >
                 {truncatedAddress}
               </span>
               <button
                 onClick={disconnect}
+                data-testid="disconnect-wallet-button"
                 className="text-xs text-muted hover:text-nav-foreground transition-colors"
               >
                 Disconnect
@@ -97,6 +105,7 @@ export function Header() {
           ) : (
             <button
               onClick={connect}
+              data-testid="connect-wallet-button"
               className="hidden md:inline-flex border border-border px-4 py-2 text-sm text-nav-foreground hover:bg-surface-hover transition-colors cursor-pointer"
             >
               Connect Wallet
@@ -115,6 +124,7 @@ export function Header() {
             className="md:hidden flex flex-col justify-center items-center w-8 h-8 gap-1.5 text-foreground"
             onClick={() => setMenuOpen((v) => !v)}
             aria-label={menuOpen ? "Close menu" : "Open menu"}
+            data-testid="mobile-menu-toggle"
           >
             <span
               className={`block h-px w-5 bg-current transition-transform origin-center ${menuOpen ? "translate-y-[7px] rotate-45" : ""}`}
@@ -138,6 +148,7 @@ export function Header() {
                 key={item.href}
                 href={item.href}
                 onClick={() => setMenuOpen(false)}
+                data-testid={`mobile-nav-link-${item.href.slice(1)}`}
                 className={`flex items-center gap-2 px-2 py-3 text-sm border-b border-border/50 last:border-0 ${
                   item.highlight
                     ? pathname === item.href
@@ -156,6 +167,7 @@ export function Header() {
               <Link
                 href="/dashboard"
                 onClick={() => setMenuOpen(false)}
+                data-testid="mobile-nav-link-dashboard"
                 className={`flex items-center px-2 py-3 text-sm border-b border-border/50 ${
                   pathname === "/dashboard" ? "text-nav-accent" : "text-muted"
                 }`}
@@ -166,6 +178,7 @@ export function Header() {
             <Link
               href="/launch"
               onClick={() => setMenuOpen(false)}
+              data-testid="mobile-nav-link-launch"
               className="flex items-center px-2 py-3 text-sm text-accent font-medium border-b border-border/50"
             >
               Launchpad →
@@ -174,6 +187,7 @@ export function Header() {
               {isConnected ? (
                 <button
                   onClick={() => { disconnect(); setMenuOpen(false); }}
+                  data-testid="mobile-disconnect-wallet-button"
                   className="text-xs text-muted hover:text-foreground transition-colors"
                 >
                   Disconnect wallet
@@ -181,6 +195,7 @@ export function Header() {
               ) : (
                 <button
                   onClick={() => { connect(); setMenuOpen(false); }}
+                  data-testid="mobile-connect-wallet-button"
                   className="w-full border border-border py-2.5 text-sm text-foreground hover:bg-surface transition-colors"
                 >
                   Connect Wallet

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -158,6 +158,7 @@ function WalletModal({
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
       onClick={onClose}
+      data-testid="wallet-modal"
     >
       <div
         className="bg-background border border-border w-full max-w-sm mx-4"
@@ -171,6 +172,7 @@ function WalletModal({
           </div>
           <button
             onClick={onClose}
+            data-testid="wallet-modal-close-button"
             className="text-muted hover:text-foreground transition-colors text-lg leading-none"
           >
             ×
@@ -184,6 +186,7 @@ function WalletModal({
               key={w.id}
               onClick={() => handleSelect(w.id)}
               disabled={!!connecting}
+              data-testid={`wallet-option-${w.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
               className="w-full flex items-center gap-3 px-4 py-3 border border-transparent hover:border-accent/40 hover:bg-surface text-left transition-all disabled:opacity-50 group"
             >
               <span className="text-xl w-7 text-center">{w.icon}</span>

--- a/web/src/components/wallet-gate.tsx
+++ b/web/src/components/wallet-gate.tsx
@@ -40,6 +40,7 @@ export function WalletGate({
         <p className="text-sm text-muted mb-8 leading-relaxed">{description}</p>
         <button
           onClick={connect}
+          data-testid="connect-wallet-button"
           className="bg-accent text-background px-8 py-2.5 text-sm font-medium hover:bg-foreground transition-colors"
         >
           Connect Stellar Wallet
@@ -66,6 +67,7 @@ export function ConnectButton({
   return (
     <button
       onClick={connect}
+      data-testid="connect-wallet-button"
       className={`border border-border px-4 py-2 text-sm text-foreground hover:bg-surface-hover transition-colors ${className}`}
     >
       {label}


### PR DESCRIPTION
## Summary
- Adds `data-testid` attributes to wallet, nav, launch form, dashboard, agents, and playbook controls
- Tags key inputs, submit/action buttons, balance/revenue displays, and modal controls for res.ilient E2E selectors

## Testing
- `git diff --check`
- Could not run lint/tests because dependencies are not installed locally.

Closes #525