### PR TITLE
fix(lint): include json and mjs config files

### DIFF
--- a/web/eslint-json-parser.mjs
+++ b/web/eslint-json-parser.mjs
@@ -1,0 +1,61 @@
+function getLocation(source, index) {
+  const before = source.slice(0, index);
+  const lines = before.split(/\r\n|\r|\n/);
+
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1].length,
+  };
+}
+
+function normalizeJsonError(error, source) {
+  if (!(error instanceof SyntaxError)) {
+    throw error;
+  }
+
+  const match = /position (\d+)/u.exec(error.message);
+  if (match) {
+    const position = Number(match[1]);
+    const loc = getLocation(source, position);
+
+    error.lineNumber = loc.line;
+    error.column = loc.column + 1;
+  }
+
+  return error;
+}
+
+const parser = {
+  meta: {
+    name: "json-parse-eslint-parser",
+    version: "1.0.0",
+  },
+  parseForESLint(source) {
+    try {
+      JSON.parse(source);
+    } catch (error) {
+      throw normalizeJsonError(error, source);
+    }
+
+    return {
+      ast: {
+        type: "Program",
+        body: [],
+        sourceType: "script",
+        range: [0, source.length],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: getLocation(source, source.length),
+        },
+        tokens: [],
+        comments: [],
+      },
+      scopeManager: null,
+      visitorKeys: {
+        Program: ["body"],
+      },
+    };
+  },
+};
+
+export default parser;

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import jsonParser from "./eslint-json-parser.mjs";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
@@ -13,6 +14,18 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    files: ["**/*.json"],
+    languageOptions: {
+      parser: jsonParser,
+    },
+  },
+  {
+    files: ["**/*.mjs"],
+    rules: {
+      "no-undef": "error",
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
Closes #526

## Summary
- Adds JSON files to ESLint coverage with a local JSON parser that rejects invalid JSON/trailing commas
- Adds an explicit `*.mjs` config block so MJS files are linted

## Testing
- `git diff --check`
- Could not run `npm run lint` because `web/node_modules` is not installed in this workspace.