### PR TITLE
feat: secure financial endpoints with agent API key auth

### DIFF
--- a/web/src/app/api/talos/[id]/financial-projection/__tests__/route.test.ts
+++ b/web/src/app/api/talos/[id]/financial-projection/__tests__/route.test.ts
@@ -1,0 +1,212 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+// ── Hoisted mocks ──────────────────────────────────────────────
+const mocks = vi.hoisted(() => ({
+  mockVerifyAgentApiKey: vi.fn(),
+  mockFindFirstTalos: vi.fn(),
+  mockSelect: vi.fn(),
+  mockAnalyzeWithGPT: vi.fn(),
+}));
+
+// ── Module mocks ───────────────────────────────────────────────
+vi.mock("@/lib/auth", () => ({
+  verifyAgentApiKey: mocks.mockVerifyAgentApiKey,
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      tlsTalos: {
+        findFirst: mocks.mockFindFirstTalos,
+      },
+    },
+    select: mocks.mockSelect,
+  },
+}));
+
+vi.mock("@/lib/fulfillment/clients", () => ({
+  analyzeWithGPT: mocks.mockAnalyzeWithGPT,
+}));
+
+// ── Helper: mock a Drizzle select chain ────────────────────────
+function selectChain(result: unknown) {
+  const chain: any = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    then: vi.fn().mockImplementation((resolve?: Function) => {
+      if (resolve) return Promise.resolve(resolve(result));
+      return Promise.resolve(result);
+    }),
+  };
+  return chain;
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+describe("GET /api/talos/:id/financial-projection — auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: false,
+      response: Response.json(
+        { error: "Missing Authorization header. Use: Bearer <api_key>" },
+        { status: 401 },
+      ),
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-projection",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toContain("Authorization");
+  });
+
+  it("returns 403 when an invalid API key is provided", async () => {
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Invalid API key" }, { status: 403 }),
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-projection",
+      { headers: { Authorization: "Bearer wrong_key_here" } },
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Invalid");
+  });
+
+  it("returns financial projections with valid auth", async () => {
+    // 1. Auth succeeds
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: true,
+      talos: { id: "agent-1", apiKey: "valid-key" },
+    });
+
+    // 2. Talos lookup succeeds
+    const mockTalos = {
+      id: "agent-1",
+      name: "Test Agent",
+      category: "Development",
+      description: "A test TALOS agent",
+      gtmBudget: "1000",
+      totalSupply: 500_000,
+      pulsePrice: "1.0",
+      creatorShare: 40,
+      investorShare: 30,
+      treasuryShare: 30,
+    };
+    mocks.mockFindFirstTalos.mockResolvedValue(mockTalos);
+
+    // 3. Revenue, activity & patron queries
+    const now = new Date();
+    mocks.mockSelect
+      .mockReturnValueOnce(
+        selectChain([
+          {
+            id: "r1",
+            talosId: "agent-1",
+            amount: "250",
+            source: "commerce",
+            currency: "USDC",
+            createdAt: now,
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        selectChain([
+          {
+            id: "a1",
+            talosId: "agent-1",
+            type: "post",
+            content: "Hello X",
+            channel: "X",
+            status: "completed",
+            createdAt: now,
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        selectChain([
+          {
+            id: "p1",
+            talosId: "agent-1",
+            walletAddress: "0xPATRON",
+            pulseAmount: 1000,
+            role: "Investor",
+            status: "active",
+          },
+        ]),
+      );
+
+    // 4. LLM returns projection
+    const mockProjection = {
+      expectedRevenue: {
+        monthly: [100, 200, 300, 400, 500, 600],
+        quarterly: [600, 1500, 1500],
+        yearly: 3600,
+      },
+      budgetSuggestions: [
+        {
+          category: "Marketing",
+          amount: 400,
+          rationale: "GTM budget allocation",
+        },
+      ],
+      roiEstimations: {
+        shortTerm: 10,
+        mediumTerm: 25,
+        longTerm: 50,
+        confidence: "medium" as const,
+      },
+      insights: ["Revenue is trending upward"],
+    };
+    mocks.mockAnalyzeWithGPT.mockResolvedValue(
+      JSON.stringify(mockProjection),
+    );
+
+    // 5. Execute handler
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-projection",
+      { headers: { Authorization: "Bearer valid-key" } },
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.projection).toBeDefined();
+    expect(body.metadata).toBeDefined();
+    expect(body.metadata.talosId).toBe("agent-1");
+    expect(body.projection.expectedRevenue.monthly).toEqual([
+      100, 200, 300, 400, 500, 600,
+    ]);
+    expect(body.projection.roiEstimations.confidence).toBe("medium");
+    expect(body.projection.insights).toContain("Revenue is trending upward");
+
+    // Verify auth was called with correct args
+    expect(mocks.mockVerifyAgentApiKey).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      "agent-1",
+    );
+  });
+});

--- a/web/src/app/api/talos/[id]/financial-projection/route.ts
+++ b/web/src/app/api/talos/[id]/financial-projection/route.ts
@@ -1,7 +1,9 @@
+import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsRevenues, tlsActivities, tlsPatrons } from "@/db/schema";
 import { eq, desc } from "drizzle-orm";
 import { analyzeWithGPT } from "@/lib/fulfillment/clients";
+import { verifyAgentApiKey } from "@/lib/auth";
 
 interface FinancialProjection {
   expectedRevenue: {
@@ -25,12 +27,15 @@ interface FinancialProjection {
 
 // GET /api/talos/:id/financial-projection - AI-driven financial projections
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
 
   try {
+    const auth = await verifyAgentApiKey(request, id);
+    if (!auth.ok) return auth.response;
+
     // Fetch TALOS basic info
     const talos = await db.query.tlsTalos.findFirst({
       where: eq(tlsTalos.id, id),

--- a/web/src/app/api/talos/[id]/financial-summary/__tests__/route.test.ts
+++ b/web/src/app/api/talos/[id]/financial-summary/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+// ── Hoisted mocks ──────────────────────────────────────────────
+const mocks = vi.hoisted(() => ({
+  mockVerifyAgentApiKey: vi.fn(),
+  mockSelect: vi.fn(),
+}));
+
+// ── Module mocks ───────────────────────────────────────────────
+vi.mock("@/lib/auth", () => ({
+  verifyAgentApiKey: mocks.mockVerifyAgentApiKey,
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: mocks.mockSelect,
+  },
+}));
+
+// ── Helper: mock a Drizzle select chain ────────────────────────
+function selectChain(result: unknown) {
+  const chain: any = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    then: vi.fn().mockImplementation((resolve?: Function) => {
+      if (resolve) return Promise.resolve(resolve(result));
+      return Promise.resolve(result);
+    }),
+  };
+  return chain;
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+describe("GET /api/talos/:id/financial-summary — auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: false,
+      response: Response.json(
+        { error: "Missing Authorization header. Use: Bearer <api_key>" },
+        { status: 401 },
+      ),
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-summary",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toContain("Authorization");
+  });
+
+  it("returns 403 when an invalid API key is provided", async () => {
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Invalid API key" }, { status: 403 }),
+    });
+
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-summary",
+      { headers: { Authorization: "Bearer wrong_key_here" } },
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Invalid");
+  });
+
+  it("returns financial summary with valid auth", async () => {
+    // 1. Auth succeeds
+    mocks.mockVerifyAgentApiKey.mockResolvedValue({
+      ok: true,
+      talos: { id: "agent-1", apiKey: "valid-key" },
+    });
+
+    // 2. TALOS lookup succeeds
+    const mockTalos = {
+      id: "agent-1",
+      name: "Test Agent",
+      category: "Development",
+      status: "Active",
+      gtmBudget: "1000",
+      createdAt: new Date(),
+    };
+
+    // The first select is the talos query which uses .limit(1).then(cb)
+    mocks.mockSelect
+      .mockReturnValueOnce(selectChain([mockTalos]))
+      // revenueAllTime
+      .mockReturnValueOnce(selectChain([{ totalRevenue: "500", transactionCount: 5 }]))
+      // revenueLast30
+      .mockReturnValueOnce(selectChain([{ totalRevenue: "200", transactionCount: 2 }]))
+      // revenuePrev30
+      .mockReturnValueOnce(selectChain([{ totalRevenue: "100" }]))
+      // revenueBySource
+      .mockReturnValueOnce(
+        selectChain([
+          { source: "commerce", total: "400", count: 4 },
+          { source: "direct", total: "100", count: 1 },
+        ]),
+      )
+      // monthlyRevenue
+      .mockReturnValueOnce(
+        selectChain([
+          { month: "2026-01", revenue: 150, transactionCount: 3 },
+          { month: "2026-02", revenue: 200, transactionCount: 2 },
+        ]),
+      )
+      // spendingAllTime
+      .mockReturnValueOnce(selectChain([{ totalSpent: "300", spendCount: 3 }]))
+      // spendingLast30
+      .mockReturnValueOnce(selectChain([{ totalSpent: "100", spendCount: 1 }]))
+      // spendingByType
+      .mockReturnValueOnce(
+        selectChain([
+          { type: "marketing", total: "200", count: 2 },
+          { type: "ops", total: "100", count: 1 },
+        ]),
+      )
+      // spendingHistory
+      .mockReturnValueOnce(
+        selectChain([
+          {
+            id: "s1",
+            type: "marketing",
+            title: "Ad campaign",
+            description: "X ads",
+            amount: "200",
+            decidedAt: new Date(),
+            txHash: "0xabc",
+            createdAt: new Date(),
+          },
+        ]),
+      )
+      // playbookRows
+      .mockReturnValueOnce(
+        selectChain([
+          {
+            id: "pb1",
+            title: "Growth Strategy",
+            price: "9.99",
+            currency: "USDC",
+            category: "Channel Strategy",
+            status: "active",
+            purchaseCount: 3,
+            totalSalesAmount: "29.97",
+          },
+        ]),
+      );
+
+    // 3. Execute handler
+    const request = new NextRequest(
+      "http://localhost/api/talos/agent-1/financial-summary",
+      { headers: { Authorization: "Bearer valid-key" } },
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "agent-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.talosId).toBe("agent-1");
+    expect(body.talosName).toBe("Test Agent");
+    expect(body.cashFlow).toBeDefined();
+    expect(body.cashFlow.totalRevenue).toBe(500);
+    expect(body.cashFlow.totalSpending).toBe(300);
+    expect(body.trends).toBeDefined();
+    expect(body.trends.revenueLast30Days).toBe(200);
+    expect(body.budget).toBeDefined();
+    expect(body.budget.gtmBudget).toBe(1000);
+    expect(body.budget.budgetUtilization).toBe(30);
+    expect(body.spendingHistory).toHaveLength(1);
+    expect(body.playbookSales).toBeDefined();
+    expect(body.playbookSales.totalPlaybooks).toBe(1);
+    expect(body.playbookSales.totalSales).toBe(3);
+
+    // Verify auth was called with correct args
+    expect(mocks.mockVerifyAgentApiKey).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      "agent-1",
+    );
+  });
+});

--- a/web/src/app/api/talos/[id]/financial-summary/route.ts
+++ b/web/src/app/api/talos/[id]/financial-summary/route.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { db } from "@/db";
 import {
   tlsTalos,
@@ -7,15 +8,19 @@ import {
   tlsPlaybookPurchases,
 } from "@/db/schema";
 import { and, eq, gte, sql, desc } from "drizzle-orm";
+import { verifyAgentApiKey } from "@/lib/auth";
 
 // GET /api/talos/:id/financial-summary — Aggregated financial analytics
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
 
   try {
+    const auth = await verifyAgentApiKey(request, id);
+    if (!auth.ok) return auth.response;
+
     // ── Verify the TALOS agent exists ─────────────────────────────
     const talos = await db
       .select({

--- a/web/tests/api-e2e.test.ts
+++ b/web/tests/api-e2e.test.ts
@@ -892,8 +892,22 @@ describe("GET /api/talos — pagination", () => {
 // ────────────────────────────────────────────
 
 describe("GET /api/talos/:id/financial-projection", () => {
-  it("returns financial projections with LLM analysis", async () => {
+  it("rejects without auth", async () => {
     const res = await api(`/api/talos/${talosId}/financial-projection`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects with wrong api key", async () => {
+    const res = await api(`/api/talos/${talosId}/financial-projection`, {
+      headers: { Authorization: "Bearer wrong_key_here" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns financial projections with LLM analysis", async () => {
+    const res = await api(`/api/talos/${talosId}/financial-projection`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -922,7 +936,50 @@ describe("GET /api/talos/:id/financial-projection", () => {
   });
 
   it("returns 404 for non-existent talos", async () => {
-    const res = await api("/api/talos/nonexistent_12345/financial-projection");
+    const res = await api("/api/talos/nonexistent_12345/financial-projection", {
+      headers: { Authorization: "Bearer any_token_here" },
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ────────────────────────────────────────────
+// 10. Financial Summary
+// ────────────────────────────────────────────
+
+describe("GET /api/talos/:id/financial-summary", () => {
+  it("rejects without auth", async () => {
+    const res = await api(`/api/talos/${talosId}/financial-summary`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects with wrong api key", async () => {
+    const res = await api(`/api/talos/${talosId}/financial-summary`, {
+      headers: { Authorization: "Bearer wrong_key_here" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns financial summary with valid api key", async () => {
+    const res = await api(`/api/talos/${talosId}/financial-summary`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.talosId).toBe(talosId);
+    expect(body.talosName).toBe("E2E Test Agent");
+    expect(body.cashFlow).toBeDefined();
+    expect(body.trends).toBeDefined();
+    expect(body.budget).toBeDefined();
+    expect(body.spendingHistory).toBeDefined();
+    expect(body.playbookSales).toBeDefined();
+  });
+
+  it("returns 404 for non-existent talos", async () => {
+    const res = await api("/api/talos/nonexistent_12345/financial-summary", {
+      headers: { Authorization: "Bearer any_token_here" },
+    });
     expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

This PR adds authentication to the `GET /api/talos/[id]/financial-projection` and `GET /api/talos/[id]/financial-summary` endpoints. Previously these endpoints were unauthenticated, exposing sensitive financial data (burn rate, runway, spending categories, etc.) to any visitor. Now a valid agent API key (or creator signature) is required, matching the pattern used by other secured routes.

### Changes
- Imported `verifyAgentApiKey` and added an auth guard in both route handlers after extracting the `id` parameter.
- Updated the e2e test suite to include `Authorization: Bearer` headers for happy-path tests and added tests for missing (401) and wrong (403) API keys.
- Created unit test files for both endpoints with full auth failure and happy-path coverage, mocking database and LLM dependencies.
- No changes to rate-limiting; it remains applied at the proxy layer.

## Related Issues

Closes #110

## Test Plan

- [x] Automated tests run: unit tests for both endpoints pass (`npx vitest run web/src/app/api/talos/[id]/financial-projection/__tests__/route.test.ts web/src/app/api/talos/[id]/financial-summary/__tests__/route.test.ts`)
- [x] Manual verification steps performed:
  - 1. Verified that requests without an `Authorization` header return 401.
  - 2. Verified that requests with an invalid API key return 403.
  - 3. Verified that requests with a valid agent API key return 200 and the expected financial data.
  - 4. Ran the full unit test suite to ensure no regressions (excluding pre-existing broken suites and e2e tests that require a running server).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (N/A – no docs changes needed).
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.