### PR TITLE
 feat(agent): Discord GTM Publishing Adapter

### DIFF
--- a/packages/prime-agent/src/talos_agent/adapters/__init__.py
+++ b/packages/prime-agent/src/talos_agent/adapters/__init__.py
@@ -1,6 +1,13 @@
 """Social channel adapters — modular publishing interface."""
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.adapters.discord import DiscordAdapter
 from talos_agent.adapters.registry import AdapterRegistry
 
-__all__ = ["BaseSocialAdapter", "ChannelCapabilities", "PublishResult", "AdapterRegistry"]
+__all__ = [
+    "BaseSocialAdapter",
+    "ChannelCapabilities",
+    "PublishResult",
+    "AdapterRegistry",
+    "DiscordAdapter",
+]

--- a/packages/prime-agent/src/talos_agent/adapters/discord.py
+++ b/packages/prime-agent/src/talos_agent/adapters/discord.py
@@ -1,0 +1,353 @@
+"""Discord channel adapter — webhook + REST API publishing."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import httpx
+from rich.console import Console
+
+from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+
+if TYPE_CHECKING:
+    from talos_agent.config import Settings
+
+console = Console()
+
+_DISCORD_API = "https://discord.com/api/v10"
+_CHAR_LIMIT = 2000
+_EMBED_DESC_LIMIT = 4096
+
+# Embed accent colours
+_COLOR_DEFAULT = 0x5865F2  # Discord blurple
+_COLOR_GTM = 0x57F287      # Discord green — positive revenue / milestone
+_COLOR_WARN = 0xFEE75C     # Yellow — warnings / alerts
+
+
+class DiscordAdapter(BaseSocialAdapter):
+    """Publishes Talos agent updates to Discord via webhook or bot REST API.
+
+    Posting priority:
+      1. Webhook URL (write-only, no bot token required)
+      2. Bot token + channel ID (full read/write operations)
+
+    GTM messages are formatted as Discord embeds with title, description,
+    auto-detected accent colour, and optional metric fields.
+    """
+
+    channel_name = "Discord"
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._webhook_url: str = settings.discord_webhook_url
+        self._bot_token: str = settings.discord_bot_token
+        self._channel_id: str = settings.discord_channel_id
+        self._guild_id: str = settings.discord_guild_id
+        self._cached_bot_id: str | None = None
+
+    # ── Capabilities ─────────────────────────────────────────
+
+    def get_capabilities(self) -> ChannelCapabilities:
+        return ChannelCapabilities(
+            char_limit=_CHAR_LIMIT,
+            supports_media=True,
+            supports_threads=True,
+            supports_replies=True,
+            supports_search=False,
+            supports_mentions=bool(self._bot_token and self._channel_id),
+            supports_analytics=bool(self._bot_token and self._channel_id),
+        )
+
+    # ── GTM message formatting ────────────────────────────────
+
+    def _build_gtm_embed(self, content: str) -> dict:
+        """Map agent playbook content to a Discord embed for GTM cycle posts."""
+        lines = content.strip().splitlines()
+        title = lines[0][:256] if lines else "Talos Agent Update"
+        body = "\n".join(lines[1:]).strip() if len(lines) > 1 else ""
+
+        lower = content.lower()
+        if any(kw in lower for kw in ("revenue", "earned", "sold", "profit", "milestone", "launched")):
+            color = _COLOR_GTM
+        elif any(kw in lower for kw in ("warn", "fail", "error", "issue", "alert", "blocked")):
+            color = _COLOR_WARN
+        else:
+            color = _COLOR_DEFAULT
+
+        embed: dict = {
+            "title": title,
+            "color": color,
+            "footer": {"text": "Talos Agent · GTM Cycle"},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if body:
+            embed["description"] = body[:_EMBED_DESC_LIMIT]
+
+        # Extract key:value metric pairs as inline fields (max 6)
+        fields = []
+        for m in re.finditer(r"([\w][\w \t]{0,39}?):\s*([\d,.]+[ \t]*%?)\b", content):
+            label, value = m.group(1).strip(), m.group(2).strip()
+            if len(fields) < 6:
+                fields.append({"name": label, "value": value, "inline": True})
+        if fields:
+            embed["fields"] = fields
+
+        return embed
+
+    # ── Bot auth header ───────────────────────────────────────
+
+    @property
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bot {self._bot_token}",
+            "Content-Type": "application/json",
+        }
+
+    # ── Publishing ───────────────────────────────────────────
+
+    async def post(self, content: str, **kwargs) -> PublishResult:
+        valid, error = self.validate_content(content)
+        if not valid:
+            return PublishResult(status="failed", channel=self.channel_name, content=content, error=error)
+
+        embed = self._build_gtm_embed(content)
+        # Include short plain-text fallback for non-embed clients
+        plain = content[:200] if len(content) <= 200 else ""
+        payload: dict = {"embeds": [embed], "content": plain}
+
+        if self._webhook_url:
+            return await self._webhook_post(payload, content)
+
+        if self._bot_token and self._channel_id:
+            return await self._api_post(
+                f"{_DISCORD_API}/channels/{self._channel_id}/messages",
+                payload,
+                content,
+            )
+
+        return PublishResult(
+            status="failed",
+            channel=self.channel_name,
+            content=content,
+            error=(
+                "Discord not configured: set DISCORD_WEBHOOK_URL "
+                "or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID"
+            ),
+        )
+
+    async def _webhook_post(self, payload: dict, content: str) -> PublishResult:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(f"{self._webhook_url}?wait=true", json=payload)
+        if resp.status_code in (200, 204):
+            data: dict = resp.json() if resp.content else {}
+            msg_id = str(data.get("id", ""))
+            channel = data.get("channel_id", "")
+            guild = data.get("guild_id", "@me")
+            return PublishResult(
+                status="posted",
+                channel=self.channel_name,
+                content=content,
+                post_id=msg_id,
+                url=f"https://discord.com/channels/{guild}/{channel}/{msg_id}",
+                metadata={"method": "webhook"},
+            )
+        return PublishResult(
+            status="failed",
+            channel=self.channel_name,
+            content=content,
+            error=f"Webhook POST failed: HTTP {resp.status_code} — {resp.text[:200]}",
+        )
+
+    async def _api_post(self, url: str, payload: dict, content: str) -> PublishResult:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(url, headers=self._auth_headers, json=payload)
+        if resp.status_code == 200:
+            data = resp.json()
+            msg_id = data.get("id", "")
+            guild = data.get("guild_id", self._guild_id or "@me")
+            return PublishResult(
+                status="posted",
+                channel=self.channel_name,
+                content=content,
+                post_id=msg_id,
+                url=f"https://discord.com/channels/{guild}/{self._channel_id}/{msg_id}",
+                metadata={"method": "bot_api"},
+            )
+        return PublishResult(
+            status="failed",
+            channel=self.channel_name,
+            content=content,
+            error=f"API POST failed: HTTP {resp.status_code} — {resp.text[:200]}",
+        )
+
+    async def reply(self, target_url: str, content: str, **kwargs) -> PublishResult:
+        """Reply to a Discord message using its discord.com/channels/... URL."""
+        if not (self._bot_token and self._channel_id):
+            return PublishResult(
+                status="failed",
+                channel=self.channel_name,
+                content=content,
+                error="Replies require DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID",
+            )
+
+        # Parse channel and message IDs from URL
+        m = re.search(r"/channels/\d+/(\d+)/(\d+)$", target_url)
+        channel_id = m.group(1) if m else self._channel_id
+        message_id = m.group(2) if m else None
+
+        payload: dict = {"content": content[:_CHAR_LIMIT]}
+        if message_id:
+            payload["message_reference"] = {"message_id": message_id}
+
+        url = f"{_DISCORD_API}/channels/{channel_id}/messages"
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(url, headers=self._auth_headers, json=payload)
+        if resp.status_code == 200:
+            data = resp.json()
+            return PublishResult(
+                status="posted",
+                channel=self.channel_name,
+                content=content,
+                post_id=data.get("id"),
+                metadata={"target_url": target_url, "reply_to": message_id},
+            )
+        return PublishResult(
+            status="failed",
+            channel=self.channel_name,
+            content=content,
+            error=f"Reply failed: HTTP {resp.status_code} — {resp.text[:200]}",
+        )
+
+    # ── Discovery ────────────────────────────────────────────
+
+    async def get_mentions(self, **kwargs) -> list[dict]:
+        """Fetch recent messages that mention the bot in the configured channel."""
+        if not (self._bot_token and self._channel_id):
+            console.print("[yellow]Discord get_mentions: requires BOT_TOKEN + CHANNEL_ID.[/yellow]")
+            return []
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{_DISCORD_API}/channels/{self._channel_id}/messages",
+                headers=self._auth_headers,
+                params={"limit": 50},
+            )
+        if resp.status_code != 200:
+            return []
+
+        bot_id = await self._get_bot_id()
+        mention_tag = f"<@{bot_id}>" if bot_id else None
+        guild = self._guild_id or "@me"
+
+        return [
+            {
+                "id": msg["id"],
+                "author": msg["author"]["username"],
+                "content": msg["content"],
+                "timestamp": msg["timestamp"],
+                "url": f"https://discord.com/channels/{guild}/{self._channel_id}/{msg['id']}",
+            }
+            for msg in resp.json()
+            if mention_tag and mention_tag in msg.get("content", "")
+        ]
+
+    async def search(self, query: str, **kwargs) -> list[dict]:
+        """Search recent channel messages for a keyword (client-side filter, last 100 msgs)."""
+        if not (self._bot_token and self._channel_id):
+            return []
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{_DISCORD_API}/channels/{self._channel_id}/messages",
+                headers=self._auth_headers,
+                params={"limit": 100},
+            )
+        if resp.status_code != 200:
+            return []
+
+        q = query.lower()
+        return [
+            {
+                "id": msg["id"],
+                "author": msg["author"]["username"],
+                "content": msg["content"],
+                "timestamp": msg["timestamp"],
+            }
+            for msg in resp.json()
+            if q in msg.get("content", "").lower()
+        ]
+
+    # ── Analytics ────────────────────────────────────────────
+
+    async def get_post_performance(self, content_snippet: str, **kwargs) -> dict:
+        """Find a message by content snippet and return its reaction counts."""
+        if not (self._bot_token and self._channel_id):
+            return {"error": "Requires DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID"}
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{_DISCORD_API}/channels/{self._channel_id}/messages",
+                headers=self._auth_headers,
+                params={"limit": 100},
+            )
+        if resp.status_code != 200:
+            return {"found": False, "error": f"HTTP {resp.status_code}"}
+
+        snippet = content_snippet.lower()
+        for msg in resp.json():
+            if snippet in msg.get("content", "").lower():
+                reactions = {
+                    r["emoji"].get("name", "?"): r["count"]
+                    for r in msg.get("reactions", [])
+                }
+                return {
+                    "found": True,
+                    "message_id": msg["id"],
+                    "reactions": reactions,
+                    "total_reactions": sum(reactions.values()),
+                    "timestamp": msg["timestamp"],
+                }
+        return {"found": False}
+
+    async def get_profile_stats(self, **kwargs) -> dict:
+        """Return bot identity and guild member counts."""
+        if not self._bot_token:
+            return {"error": "Requires DISCORD_BOT_TOKEN"}
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            bot_resp = await client.get(f"{_DISCORD_API}/users/@me", headers=self._auth_headers)
+        if bot_resp.status_code != 200:
+            return {"error": f"HTTP {bot_resp.status_code}"}
+
+        bot = bot_resp.json()
+        stats: dict = {"bot_username": bot.get("username"), "bot_id": bot.get("id")}
+
+        if self._guild_id:
+            async with httpx.AsyncClient(timeout=30) as client:
+                guild_resp = await client.get(
+                    f"{_DISCORD_API}/guilds/{self._guild_id}?with_counts=true",
+                    headers=self._auth_headers,
+                )
+            if guild_resp.status_code == 200:
+                guild = guild_resp.json()
+                stats["guild_name"] = guild.get("name")
+                stats["member_count"] = guild.get("approximate_member_count")
+                stats["online_count"] = guild.get("approximate_presence_count")
+
+        return stats
+
+    # ── Internal helpers ──────────────────────────────────────
+
+    async def _get_bot_id(self) -> str | None:
+        if self._cached_bot_id:
+            return self._cached_bot_id
+        if not self._bot_token:
+            return None
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{_DISCORD_API}/users/@me", headers=self._auth_headers)
+        if resp.status_code == 200:
+            self._cached_bot_id = resp.json()["id"]
+            return self._cached_bot_id
+        return None

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -68,6 +68,14 @@ class Settings(BaseSettings):
     x_password: str = ""
     x_email: str = ""
 
+    # Discord
+    # Webhook URL is sufficient for posting. Bot token + channel/guild IDs
+    # unlock replies, mentions, and analytics via the REST API.
+    discord_webhook_url: str = ""
+    discord_bot_token: str = ""
+    discord_channel_id: str = ""
+    discord_guild_id: str = ""
+
     # Per-channel credential configs for additional adapters.
     # Set as JSON in env: CHANNEL_CONFIGS={"linkedin": {"access_token": "..."}}
     channel_configs: dict = Field(default_factory=dict, description="Per-channel credentials map")

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -148,9 +148,12 @@ def build_all_tools(
     # Build the channel adapter registry with all configured adapters
     from talos_agent.adapters.registry import AdapterRegistry
     from talos_agent.adapters.x import XAdapter
+    from talos_agent.adapters.discord import DiscordAdapter
 
     adapter_registry = AdapterRegistry()
     adapter_registry.register(XAdapter(browser, settings))
+    if settings.discord_webhook_url or settings.discord_bot_token:
+        adapter_registry.register(DiscordAdapter(settings))
 
     # Inject dependencies into tool modules
     _internal_mod._db = db

--- a/packages/prime-agent/tests/test_discord_adapter.py
+++ b/packages/prime-agent/tests/test_discord_adapter.py
@@ -1,0 +1,316 @@
+"""Tests for the DiscordAdapter — webhook and bot API paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import respx
+from httpx import Response
+
+from talos_agent.adapters.discord import (
+    DiscordAdapter,
+    _COLOR_DEFAULT,
+    _COLOR_GTM,
+    _COLOR_WARN,
+    _DISCORD_API,
+)
+
+
+def _make_settings(
+    webhook_url: str = "",
+    bot_token: str = "",
+    channel_id: str = "",
+    guild_id: str = "",
+) -> MagicMock:
+    s = MagicMock()
+    s.discord_webhook_url = webhook_url
+    s.discord_bot_token = bot_token
+    s.discord_channel_id = channel_id
+    s.discord_guild_id = guild_id
+    return s
+
+
+# ── Capabilities ─────────────────────────────────────────────────────────────
+
+class TestCapabilities:
+    def test_full_caps_with_bot_credentials(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="123"))
+        caps = adapter.get_capabilities()
+        assert caps.char_limit == 2000
+        assert caps.supports_replies is True
+        assert caps.supports_mentions is True
+        assert caps.supports_analytics is True
+
+    def test_limited_caps_webhook_only(self):
+        adapter = DiscordAdapter(_make_settings(webhook_url="https://discord.com/api/webhooks/x/y"))
+        caps = adapter.get_capabilities()
+        assert caps.supports_mentions is False
+        assert caps.supports_analytics is False
+
+
+# ── GTM embed builder ─────────────────────────────────────────────────────────
+
+class TestBuildGtmEmbed:
+    def setup_method(self):
+        self.adapter = DiscordAdapter(_make_settings())
+
+    def test_single_line_content_becomes_title(self):
+        embed = self.adapter._build_gtm_embed("Launch day!")
+        assert embed["title"] == "Launch day!"
+        assert "description" not in embed
+
+    def test_multiline_splits_title_and_body(self):
+        embed = self.adapter._build_gtm_embed("Q2 GTM Update\nRevenue up 20% this week.")
+        assert embed["title"] == "Q2 GTM Update"
+        assert "Revenue up 20%" in embed["description"]
+
+    def test_revenue_keyword_triggers_gtm_color(self):
+        embed = self.adapter._build_gtm_embed("Revenue milestone hit — earned $500 USDC")
+        assert embed["color"] == _COLOR_GTM
+
+    def test_warning_keyword_triggers_warn_color(self):
+        embed = self.adapter._build_gtm_embed("Alert: posting failed due to rate limit error")
+        assert embed["color"] == _COLOR_WARN
+
+    def test_neutral_content_uses_default_color(self):
+        embed = self.adapter._build_gtm_embed("Weekly check-in from Talos agent")
+        assert embed["color"] == _COLOR_DEFAULT
+
+    def test_metric_pairs_become_inline_fields(self):
+        content = "Stats\nFollowers: 1200\nEngagement: 4.5%"
+        embed = self.adapter._build_gtm_embed(content)
+        assert "fields" in embed
+        names = [f["name"] for f in embed["fields"]]
+        assert "Followers" in names
+
+    def test_footer_and_timestamp_always_present(self):
+        embed = self.adapter._build_gtm_embed("Hello")
+        assert embed["footer"]["text"] == "Talos Agent · GTM Cycle"
+        assert "timestamp" in embed
+
+    def test_title_truncated_at_256(self):
+        long = "A" * 300
+        embed = self.adapter._build_gtm_embed(long)
+        assert len(embed["title"]) == 256
+
+
+# ── post() via webhook ────────────────────────────────────────────────────────
+
+class TestPostWebhook:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_webhook_post_success(self):
+        adapter = DiscordAdapter(_make_settings(webhook_url="https://discord.com/api/webhooks/1/tok"))
+        respx.post("https://discord.com/api/webhooks/1/tok").mock(
+            return_value=Response(
+                200,
+                json={"id": "999", "channel_id": "chan1", "guild_id": "guild1"},
+            )
+        )
+        result = await adapter.post("GTM launch — revenue: 200 USDC")
+        assert result.status == "posted"
+        assert result.post_id == "999"
+        assert "guild1/chan1/999" in result.url
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_webhook_post_http_error(self):
+        adapter = DiscordAdapter(_make_settings(webhook_url="https://discord.com/api/webhooks/1/bad"))
+        respx.post("https://discord.com/api/webhooks/1/bad").mock(
+            return_value=Response(401, json={"message": "401: Unauthorized"})
+        )
+        result = await adapter.post("Test content")
+        assert result.status == "failed"
+        assert "401" in result.error
+
+    @pytest.mark.asyncio
+    async def test_post_returns_failed_when_not_configured(self):
+        adapter = DiscordAdapter(_make_settings())
+        result = await adapter.post("Hello")
+        assert result.status == "failed"
+        assert "not configured" in result.error
+
+    @pytest.mark.asyncio
+    async def test_post_validates_char_limit(self):
+        adapter = DiscordAdapter(_make_settings(webhook_url="https://discord.com/api/webhooks/1/tok"))
+        result = await adapter.post("x" * 2001)
+        assert result.status == "failed"
+        assert "2000" in result.error
+
+
+# ── post() via bot API ────────────────────────────────────────────────────────
+
+class TestPostBotApi:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_bot_api_post_success(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        respx.post(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(
+                200,
+                json={"id": "777", "guild_id": "gld"},
+            )
+        )
+        result = await adapter.post("Weekly GTM update")
+        assert result.status == "posted"
+        assert result.post_id == "777"
+        assert result.metadata["method"] == "bot_api"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_bot_api_post_failure(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        respx.post(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(403, json={"message": "Missing Permissions"})
+        )
+        result = await adapter.post("Test")
+        assert result.status == "failed"
+        assert "403" in result.error
+
+
+# ── reply() ───────────────────────────────────────────────────────────────────
+
+class TestReply:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_reply_parses_url_and_posts(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        target = "https://discord.com/channels/555/42/888"
+        respx.post(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(200, json={"id": "999"})
+        )
+        result = await adapter.reply(target, "Great point!")
+        assert result.status == "posted"
+        assert result.metadata["reply_to"] == "888"
+
+    @pytest.mark.asyncio
+    async def test_reply_fails_without_credentials(self):
+        adapter = DiscordAdapter(_make_settings(webhook_url="https://discord.com/api/webhooks/1/tok"))
+        result = await adapter.reply("https://discord.com/channels/1/2/3", "reply")
+        assert result.status == "failed"
+        assert "BOT_TOKEN" in result.error
+
+
+# ── get_mentions() ────────────────────────────────────────────────────────────
+
+class TestGetMentions:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_filters_messages_containing_bot_mention(self):
+        adapter = DiscordAdapter(
+            _make_settings(bot_token="tok", channel_id="42", guild_id="gld")
+        )
+        adapter._cached_bot_id = "BOT123"
+
+        respx.get(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {"id": "1", "author": {"username": "alice"}, "content": "hi <@BOT123>!", "timestamp": "t1"},
+                    {"id": "2", "author": {"username": "bob"}, "content": "no mention here", "timestamp": "t2"},
+                ],
+            )
+        )
+        mentions = await adapter.get_mentions()
+        assert len(mentions) == 1
+        assert mentions[0]["author"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_credentials(self):
+        adapter = DiscordAdapter(_make_settings())
+        result = await adapter.get_mentions()
+        assert result == []
+
+
+# ── search() ─────────────────────────────────────────────────────────────────
+
+class TestSearch:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_client_side_keyword_filter(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        respx.get(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {"id": "1", "author": {"username": "u1"}, "content": "Stellar blockchain launch", "timestamp": "t1"},
+                    {"id": "2", "author": {"username": "u2"}, "content": "random chat", "timestamp": "t2"},
+                ],
+            )
+        )
+        results = await adapter.search("stellar")
+        assert len(results) == 1
+        assert "Stellar" in results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_credentials(self):
+        adapter = DiscordAdapter(_make_settings())
+        result = await adapter.search("test")
+        assert result == []
+
+
+# ── get_post_performance() ────────────────────────────────────────────────────
+
+class TestGetPostPerformance:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_reaction_counts_on_match(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        respx.get(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": "1",
+                        "content": "GTM launch milestone hit",
+                        "timestamp": "t1",
+                        "reactions": [
+                            {"emoji": {"name": "🚀"}, "count": 5},
+                            {"emoji": {"name": "❤️"}, "count": 3},
+                        ],
+                    }
+                ],
+            )
+        )
+        perf = await adapter.get_post_performance("milestone hit")
+        assert perf["found"] is True
+        assert perf["total_reactions"] == 8
+        assert perf["reactions"]["🚀"] == 5
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_not_found_on_miss(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", channel_id="42"))
+        respx.get(f"{_DISCORD_API}/channels/42/messages").mock(
+            return_value=Response(200, json=[{"id": "1", "content": "unrelated", "timestamp": "t", "reactions": []}])
+        )
+        perf = await adapter.get_post_performance("xyzzy")
+        assert perf["found"] is False
+
+
+# ── get_profile_stats() ───────────────────────────────────────────────────────
+
+class TestGetProfileStats:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_bot_and_guild_stats(self):
+        adapter = DiscordAdapter(_make_settings(bot_token="tok", guild_id="gld"))
+        respx.get(f"{_DISCORD_API}/users/@me").mock(
+            return_value=Response(200, json={"id": "BOT123", "username": "TalosBot"})
+        )
+        respx.get(f"{_DISCORD_API}/guilds/gld").mock(
+            return_value=Response(
+                200,
+                json={"name": "Talos Community", "approximate_member_count": 800, "approximate_presence_count": 50},
+            )
+        )
+        stats = await adapter.get_profile_stats()
+        assert stats["bot_username"] == "TalosBot"
+        assert stats["member_count"] == 800
+
+    @pytest.mark.asyncio
+    async def test_returns_error_without_bot_token(self):
+        adapter = DiscordAdapter(_make_settings())
+        stats = await adapter.get_profile_stats()
+        assert "error" in stats


### PR DESCRIPTION
Adds a `DiscordAdapter` to the Talos prime-agent that lets the autonomous GTM agent publish formatted updates to Discord during every agent cycle — the same way it already posts to X.

---

## Motivation

The Talos agent runs a continuous GTM loop (OODA cycle) and currently only publishes to X. Discord is a primary community channel for crypto/Web3 projects, and connecting the agent there closes a gap in the GTM surface area. The adapter plugs into the existing `BaseSocialAdapter` interface and `AdapterRegistry`, so no changes to the agent loop or publishing tools were needed.

---

## What Changed

### New file — `adapters/discord.py`

The core `DiscordAdapter` class. Key design decisions:

**Dual-mode auth**  
Supports two configuration modes so teams can start simple and upgrade:

| Mode | Env vars needed | Capabilities |
|---|---|---|
| Webhook | `DISCORD_WEBHOOK_URL` | Post only |
| Bot API | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` | Post, reply, mentions, search, analytics |

Webhook takes priority for posts; bot token unlocks the read/engagement operations.

**GTM embed formatter (`_build_gtm_embed`)**  
Agent content is mapped to a Discord rich embed rather than plain text:

- First line → embed **title** (truncated to Discord's 256-char limit)
- Remaining lines → embed **description**
- Accent colour auto-selected from content keywords:
  - Green (`0x57F287`) — revenue, earned, milestone, launched, profit
  - Yellow (`0xFEE75C`) — error, warn, fail, alert, blocked
  - Blurple (`0x5865F2`) — everything else (default)
- `key: numeric_value` pairs in the content are extracted as **inline embed fields** (up to 6), surfacing metrics at a glance
- Footer is always `"Talos Agent · GTM Cycle"` with a UTC ISO timestamp

**Full `BaseSocialAdapter` surface**

| Method | Implementation |
|---|---|
| `post()` | Webhook POST or bot API to channel, always as embed |
| `reply()` | Parses `discord.com/channels/…` URL to extract message ID, posts with `message_reference` |
| `get_mentions()` | Fetches last 50 channel messages, filters to those containing `<@BOT_ID>` |
| `search()` | Fetches last 100 messages, client-side keyword filter |
| `get_post_performance()` | Finds message by content snippet, returns per-emoji reaction counts |
| `get_profile_stats()` | Bot identity + guild member / online counts |

Bot ID is fetched once and cached on the instance to avoid repeated `GET /users/@me` calls.

No new dependencies — uses `httpx` which is already in `pyproject.toml`.

---

### `config.py` — four new settings fields

```
DISCORD_WEBHOOK_URL    # Webhook URL — sufficient for posting
DISCORD_BOT_TOKEN      # Bot token — required for read operations
DISCORD_CHANNEL_ID     # Target channel for bot API calls
DISCORD_GUILD_ID       # Guild ID — used in message URLs and guild stats
```

All default to `""` so existing configurations are unaffected.

---

### `tools/registry.py` — conditional registration

```python
from talos_agent.adapters.discord import DiscordAdapter

if settings.discord_webhook_url or settings.discord_bot_token:
    adapter_registry.register(DiscordAdapter(settings))
```

The adapter only joins the registry when at least one credential is set, keeping the zero-config startup path clean.

---

### `adapters/__init__.py` — public export

`DiscordAdapter` is now part of the package's public surface:

```python
from talos_agent.adapters import DiscordAdapter
```

---

### `tests/test_discord_adapter.py` — 26 tests, 0 failures

Coverage across all code paths using `respx` to mock HTTP without hitting Discord:

- `TestCapabilities` — capability flags vary correctly by credential mode
- `TestBuildGtmEmbed` — title splitting, colour selection, metric field extraction, truncation
- `TestPostWebhook` — success path, HTTP error, missing config, char limit guard
- `TestPostBotApi` — success path, permission error
- `TestReply` — URL parsing, message reference, missing credentials guard
- `TestGetMentions` — bot-mention filter, no-credentials short-circuit
- `TestSearch` — keyword match, no-credentials short-circuit
- `TestGetPostPerformance` — reaction aggregation, not-found case
- `TestGetProfileStats` — bot + guild stats, missing token guard

---

## How to Configure

Minimum (webhook only — just posting):
```env
DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/<id>/<token>
```

Full (webhook + bot API for all operations):
```env
DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/<id>/<token>
DISCORD_BOT_TOKEN=Bot <token>
DISCORD_CHANNEL_ID=<channel_snowflake>
DISCORD_GUILD_ID=<guild_snowflake>
```

Once credentials are set the agent can use Discord via the existing `publish_content` tool:

```
publish_content(content="...", channel="Discord")
```

---

## Files Changed

```
packages/prime-agent/src/talos_agent/adapters/discord.py     (new)
packages/prime-agent/tests/test_discord_adapter.py           (new)
packages/prime-agent/src/talos_agent/adapters/__init__.py    (updated)
packages/prime-agent/src/talos_agent/config.py               (updated)
packages/prime-agent/src/talos_agent/tools/registry.py       (updated)
```

---



closes #71 
