### PR TITLE
fix(web): return 400 on malformed leaderboard cursor + tests (#111)

### DIFF
--- a/web/src/app/api/leaderboard/route.ts
+++ b/web/src/app/api/leaderboard/route.ts
@@ -39,17 +39,31 @@ export async function GET(request: NextRequest) {
 
     const conditions: ReturnType<typeof sql>[] = [];
 
+    let parsedCursor: [number, string] | null = null;
     if (cursor) {
-      const [cursorRevenue, cursorId] = JSON.parse(
-        Buffer.from(cursor, "base64").toString(),
-      );
-      if (typeof cursorRevenue === "number" && cursorId) {
-        conditions.push(
-          sql`coalesce(${revenueSum.total}, 0) < ${cursorRevenue}
-              OR (coalesce(${revenueSum.total}, 0) = ${cursorRevenue}
-                  AND ${tlsTalos.id} < ${cursorId})`,
-        );
+      try {
+        const decoded = JSON.parse(Buffer.from(cursor, "base64").toString());
+        if (
+          Array.isArray(decoded) &&
+          typeof decoded[0] === "number" &&
+          typeof decoded[1] === "string"
+        ) {
+          parsedCursor = decoded as [number, string];
+        } else {
+          return Response.json({ error: "Invalid cursor format" }, { status: 400 });
+        }
+      } catch {
+        return Response.json({ error: "Invalid cursor" }, { status: 400 });
       }
+    }
+
+    if (parsedCursor) {
+      const [cursorRevenue, cursorId] = parsedCursor;
+      conditions.push(
+        sql`coalesce(${revenueSum.total}, 0) < ${cursorRevenue}
+            OR (coalesce(${revenueSum.total}, 0) = ${cursorRevenue}
+                AND ${tlsTalos.id} < ${cursorId})`,
+      );
     }
 
     const rows = await db

--- a/web/tests/api-e2e.test.ts
+++ b/web/tests/api-e2e.test.ts
@@ -787,6 +787,23 @@ describe("GET /api/leaderboard", () => {
   });
 });
 
+describe("GET /api/leaderboard — malformed cursor", () => {
+  it("returns 400 for a completely malformed cursor", async () => {
+    const res = await api("/api/leaderboard?cursor=garbage");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty("error");
+  });
+
+  it("returns 400 for valid base64 that decodes to wrong shape", async () => {
+    // eyJub3RfYW5fYXJyYXkiOnRydWV9 == {"not_an_array":true}
+    const res = await api("/api/leaderboard?cursor=eyJub3RfYW5fYXJyYXkiOnRydWV9");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty("error");
+  });
+});
+
 describe("GET /api/leaderboard — cursor traversal", () => {
   it("paginates correctly from page 1 to page 2", async () => {
     // Fetch first page with limit=1


### PR DESCRIPTION
closes #111

## fix(web): return 400 on malformed leaderboard cursor + tests

### Problem

`GET /api/leaderboard` accepted an optional `cursor` query parameter introduced in PR #104. The cursor decode path was:

```ts
const [cursorRevenue, cursorId] = JSON.parse(
  Buffer.from(cursor, "base64").toString(),
);
```

There was no `try/catch` around this block. Any input that is not valid base64 or does not parse as JSON would throw synchronously, fall through to the outer `catch`, and return a generic **500 Internal Server Error**. This creates:

- **Bad ergonomics** — legitimate clients chaining cursors receive a confusing 500 instead of a meaningful 400.
- **Minor error-leak surface** — stack traces can appear in Vercel log surfaces.
- **Trivial DoS vector** — an attacker can repeatedly send malformed cursors and force 500 error paths through the handler.

### Solution

Wrap the decode in a `try/catch` and validate the decoded shape before use:

```ts
let parsedCursor: [number, string] | null = null;
if (cursor) {
  try {
    const decoded = JSON.parse(Buffer.from(cursor, "base64").toString());
    if (
      Array.isArray(decoded) &&
      typeof decoded[0] === "number" &&
      typeof decoded[1] === "string"
    ) {
      parsedCursor = decoded as [number, string];
    } else {
      return Response.json({ error: "Invalid cursor format" }, { status: 400 });
    }
  } catch {
    return Response.json({ error: "Invalid cursor" }, { status: 400 });
  }
}
```

### Changes

| File | Change |
|---|---|
| `web/src/app/api/leaderboard/route.ts` | Wrapped cursor decode in `try/catch`; introduced typed `parsedCursor`; returns `400` on decode error or shape mismatch |
| `web/tests/api-e2e.test.ts` | Added two new vitest cases for the malformed-cursor paths |

### Test cases added

```
GET /api/leaderboard?cursor=garbage
  → 400 { error: "Invalid cursor" }

GET /api/leaderboard?cursor=eyJub3RfYW5fYXJyYXkiOnRydWV9   ({"not_an_array":true})
  → 400 { error: "Invalid cursor format" }
```

Existing valid-cursor traversal test continues to pass.

### Checklist

- [x] Malformed cursor returns 400 with a clear error message
- [x] Wrong-shape cursor (object instead of array) returns 400
- [x] Existing cursor traversal test still works
- [x] Two new vitest cases for the malformed paths
- [x] No other routes or files touched
