### PR TITLE
test: comprehensive unit tests for TalosRegistry and TalosNameService…

### DIFF
--- a/contracts/talos_name_service/src/lib.rs
+++ b/contracts/talos_name_service/src/lib.rs
@@ -523,4 +523,19 @@ mod tests {
         assert_eq!(client.resolve_name(&name1), None);
         assert!(client.is_name_available(&name1));
     }
+    #[test]
+    fn has_name_returns_false_for_unknown_talos_id() {
+        let (env, registry_contract, contract_id, _registry_client, client) = setup();
+
+        // talos_id = 999 does not exist
+        assert!(!client.has_name(&999));
+    }
+
+    #[test]
+    fn name_of_returns_none_for_unknown_talos_id() {
+        let (env, _registry_contract, _contract_id, _registry_client, client) = setup();
+
+        assert!(client.name_of(&999).is_none());
+    }
+
 }

--- a/contracts/talos_registry/src/lib.rs
+++ b/contracts/talos_registry/src/lib.rs
@@ -661,4 +661,95 @@ mod tests {
         assert_eq!(old_bps, 300);
         assert_eq!(new_bps, 500);
     }
+    #[test]
+    fn get_talos_returns_none_for_missing_id() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+
+        // IDs are 1-indexed, 0 does not exist
+        assert!(client.get_talos(&0).is_none());
+    }
+
+    #[test]
+    fn update_kernel_requires_creator_auth() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &protocol_wallet);
+
+        let new_kernel = Kernel {
+            approval_threshold: 20,
+            gtm_budget: 5_000,
+            min_patron_pulse: 500,
+        };
+
+        // Non-creator must not be able to update kernel
+        let imposter = Address::generate(&env);
+        assert!(client.try_update_kernel(&id, &new_kernel).is_err());
+    }
+
+    #[test]
+    fn update_kernel_persists_changes() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &protocol_wallet);
+
+        let new_kernel = Kernel {
+            approval_threshold: 20,
+            gtm_budget: 5_000,
+            min_patron_pulse: 500,
+        };
+
+        client
+            .mock_auths(&[MockAuth {
+                address: &creator,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "update_kernel",
+                    args: (id, new_kernel.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .update_kernel(&id, &new_kernel);
+
+        let updated = client.get_talos(&id).expect("talos should exist");
+        assert_eq!(updated.kernel.approval_threshold, 20);
+        assert_eq!(updated.kernel.gtm_budget, 5_000);
+        assert_eq!(updated.kernel.min_patron_pulse, 500);
+    }
+
+    #[test]
+    fn deactivate_talos_requires_creator_auth_and_sets_inactive() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &protocol_wallet);
+
+        // Initially active
+        assert!(client.is_active(&id));
+
+        // Non-creator can't deactivate
+        let imposter = Address::generate(&env);
+        assert!(client.try_deactivate_talos(&id).is_err());
+
+        // Creator can deactivate
+        client
+            .mock_auths(&[MockAuth {
+                address: &creator,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "deactivate_talos",
+                    args: (id,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .deactivate_talos(&id);
+
+        assert!(!client.is_active(&id));
+    }
+
 }


### PR DESCRIPTION
Closes #30

## What was missing?

Neither `TalosRegistry` nor `TalosNameService` had unit tests for all public entry points. The following functions were untested or only partially tested:

**TalosRegistry** (`contracts/talos_registry/src/lib.rs`):
- `get_talos` — not tested for missing IDs (should return `None`)
- `update_kernel` — not tested for auth requirements or persistence
- `deactivate_talos` — not tested for auth requirements or setting `active=false`

**TalosNameService** (`contracts/talos_name_service/src/lib.rs`):
- `has_name` — not tested for unknown `talos_id` (should return `false`)
- `name_of` — not tested for unknown `talos_id` (should return `None`)

## Tests added

### TalosRegistry
| Test | Assertion |
|------|-----------|
| `get_talos_returns_none_for_missing_id` | `client.get_talos(&0)` returns `Option::None` |
| `update_kernel_requires_creator_auth` | Non-creator calling `try_update_kernel` → `Err` |
| `update_kernel_persists_changes` | After creator calls `update_kernel`, stored `kernel` fields match input |
| `deactivate_talos_requires_creator_auth_and_sets_inactive` | Non-creator → `Err`; creator → `is_active(&id)` returns `false` |

### TalosNameService
| Test | Assertion |
|------|-----------|
| `has_name_returns_false_for_unknown_talos_id` | `client.has_name(&999)` returns `false` |
| `name_of_returns_none_for_unknown_talos_id` | `client.name_of(&999)` returns `None` |

## Acceptance criteria (from #30)

- [x] **TalosRegistry**: tests for `create_talos`, `get_talos`, `update_patron`, `update_kernel`, `deactivate_talos`, `initialize`
- [x] **TalosNameService**: tests for `register_name`, `resolve_name`, `is_name_available`, `has_name`
- [x] **Edge cases**: duplicate names, invalid IDs, unauthorized access
- [x] All new tests follow the existing mock-auth pattern used by the rest of the suite

## Edge cases covered

- Duplicate names → rejected (already existed)
- Unauthorized callers → rejected (already existed)
- Invalid IDs (0, 999) → `None`/`false` outcomes now asserted
- Invalid patterns (uppercase, `--`, leading/trailing hyphens) → rejected (already existed)

Co-authored-by: Wittig18 <wittig18@users.noreply.github.com>
