### PR TITLE
security: add signature verification to PATCH approvals endpoint

### DIFF
--- a/web/src/app/api/talos/[id]/approvals/[approvalId]/route.ts
+++ b/web/src/app/api/talos/[id]/approvals/[approvalId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsApprovals, tlsPatrons } from "@/db/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { recordApprovalOnChain } from "@/lib/stellar";
+import { recordApprovalOnChain, verifyStellarSignature } from "@/lib/stellar";
 
 // PATCH /api/talos/:id/approvals/:approvalId — Approve/reject
 export async function PATCH(
@@ -35,7 +35,7 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { status, decidedBy } = body;
+    const { status, decidedBy, signature, message } = body;
 
     if (!status || !["approved", "rejected"].includes(status)) {
       return Response.json(
@@ -47,6 +47,13 @@ export async function PATCH(
     if (!decidedBy) {
       return Response.json(
         { error: "decidedBy (Stellar public key) is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!signature || !message) {
+      return Response.json(
+        { error: "signature and message are required" },
         { status: 400 }
       );
     }
@@ -68,6 +75,14 @@ export async function PATCH(
     if (!patron) {
       return Response.json(
         { error: "Only active Patrons can approve or reject decisions" },
+        { status: 403 }
+      );
+    }
+
+    const signatureIsValid = await verifyStellarSignature(decidedBy, message, signature);
+    if (!signatureIsValid) {
+      return Response.json(
+        { error: "Signature verification failed for the deciding patron" },
         { status: 403 }
       );
     }

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -67,6 +67,8 @@ export const createApprovalSchema = z.object({
 export const decideApprovalSchema = z.object({
   status: z.enum(["approved", "rejected"]),
   decidedBy: z.string().min(1),
+  signature: z.string().min(1),
+  message: z.string().min(1),
   txHash: z.string().optional(),
 });
 

--- a/web/tests/approval-signature.test.ts
+++ b/web/tests/approval-signature.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PATCH } from "../src/app/api/talos/[id]/approvals/[approvalId]/route";
+import { tlsApprovals, tlsPatrons, tlsTalos } from "../src/db/schema";
+
+const mocks = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockVerifySignature: vi.fn(),
+  mockRecordApprovalOnChain: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: (...args: any[]) => mocks.mockSelect(...args),
+    update: (...args: any[]) => mocks.mockUpdate(...args),
+  },
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  recordApprovalOnChain: (...args: any[]) => mocks.mockRecordApprovalOnChain(...args),
+  verifyStellarSignature: (...args: any[]) => mocks.mockVerifySignature(...args),
+}));
+
+describe("PATCH /api/talos/:id/approvals/:approvalId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockVerifySignature.mockResolvedValue(true);
+    mocks.mockRecordApprovalOnChain.mockResolvedValue({ txHash: "tx-123" });
+  });
+
+  it("approves the request when the patron signature is valid", async () => {
+    const approval = { id: "approval-1", talosId: "talos-1", status: "pending" };
+    const patron = { talosId: "talos-1", stellarPublicKey: "GABC1234567890", status: "active" };
+
+    mocks.mockSelect.mockImplementation(() => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === tlsTalos) return [{ id: "talos-1" }];
+            if (table === tlsApprovals) return [approval];
+            if (table === tlsPatrons) return [patron];
+            return [];
+          },
+        }),
+      }),
+    }));
+
+    mocks.mockUpdate.mockReturnValue({
+      set: () => ({
+        where: () => ({
+          returning: async () => [{ ...approval, status: "approved", decidedBy: patron.stellarPublicKey, txHash: "tx-123" }],
+        }),
+      }),
+    });
+
+    const request = new Request("http://localhost/api/talos/talos-1/approvals/approval-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "approved",
+        decidedBy: patron.stellarPublicKey,
+        signature: "sig",
+        message: "decision-message",
+      }),
+    });
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "talos-1", approvalId: "approval-1" }),
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(mocks.mockVerifySignature).toHaveBeenCalledWith(
+      patron.stellarPublicKey,
+      "decision-message",
+      "sig"
+    );
+  });
+
+  it("rejects the request when no active patron matches the supplied public key", async () => {
+    mocks.mockSelect.mockImplementation(() => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === tlsTalos) return [{ id: "talos-1" }];
+            if (table === tlsApprovals) return [{ id: "approval-1", talosId: "talos-1", status: "pending" }];
+            if (table === tlsPatrons) return [];
+            return [];
+          },
+        }),
+      }),
+    }));
+
+    const request = new Request("http://localhost/api/talos/talos-1/approvals/approval-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "approved",
+        decidedBy: "GABC1234567890",
+        signature: "sig",
+        message: "decision-message",
+      }),
+    });
+
+    const response = await PATCH(request as any, {
+      params: Promise.resolve({ id: "talos-1", approvalId: "approval-1" }),
+    } as any);
+
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("active Patrons");
+    expect(mocks.mockVerifySignature).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #48

## What was the vulnerability?

The `PATCH /api/talos/[id]/approvals/[approvalId]` endpoint accepted a `decidedBy` field (Stellar public key) in the request body with no cryptographic proof that the request came from the owner of that key. Any user could approve or reject any approval on behalf of any active Patron by simply passing the Patron's public key in the body.

## What changed?

- **`web/src/app/api/talos/[id]/approvals/[approvalId]/route.ts`**: Added `signature` and `message` extraction from the request body. A call to `verifyStellarSignature(decidedBy, message, signature)` is now made via the `@stellar/stellar-sdk` `Keypair.verify()` API **before** the DB update. The endpoint returns `400` when signature/message are missing and `403` when verification fails.
- **`web/src/lib/schemas.ts`**: Added `signature: z.string().min(1)` and `message: z.string().min(1)` to `decideApprovalSchema`.
- **`web/tests/approval-signature.test.ts`** (new): Unit tests covering:
  - Happy path: active Patron with valid signature → `200 OK`
  - Rejection: no matching Patron / invalid key → `403`, signature verification skipped

## Verification

Tests pass:
