### PR TITLE
fix(contracts): add caller authorization to TalosNameService.register…

### DIFF
--- a/contracts/talos_name_service/Cargo.toml
+++ b/contracts/talos_name_service/Cargo.toml
@@ -12,4 +12,11 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
+talos-registry = { path = "../talos_registry" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+

--- a/contracts/talos_name_service/src/lib.rs
+++ b/contracts/talos_name_service/src/lib.rs
@@ -8,8 +8,15 @@
 
 #![no_std]
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+extern crate std;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+use std::string::ToString;
+
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    Env, IntoVal, String, Symbol,
 };
 
 // ── Data Types ──────────────────────────────────────────────────────
@@ -17,24 +24,58 @@ use soroban_sdk::{
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    NameRecord(String),  // name → talos_id
-    TalosName(u32),      // talos_id → name
+    NameRecord(String), // name → talos_id
+    TalosName(u32),     // talos_id → name
+    RegistryContract,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    UnauthorizedCaller = 2,
 }
 
 // ── Events ──────────────────────────────────────────────────────────
+//
+// Event schema (topics → data):
+//   name_reg : (symbol, talos_id: u32) → (name: String, owner: Address)
 
-fn emit_name_registered(env: &Env, talos_id: u32, name: String) {
+fn emit_name_registered(env: &Env, talos_id: u32, name: String, owner: Address) {
     let topics = (symbol_short!("name_reg"), talos_id);
-    env.events().publish(topics, name);
+    env.events().publish(topics, (name, owner));
 }
 
 // ── Validation ──────────────────────────────────────────────────────
-// Character-level validation is handled off-chain (Next.js regex).
-// On-chain we only enforce the byte-length bounds.
-
 fn validate_name(name: &String) -> bool {
     let len = name.len();
-    len >= 3 && len <= 32
+    if len < 3 || len > 32 {
+        return false;
+    }
+
+    let name_string = name.to_string();
+    let bytes = name_string.as_bytes();
+    if bytes.first().is_none() || bytes.last().is_none() {
+        return false;
+    }
+
+    let mut prev_hyphen = false;
+    for &b in bytes {
+        if (b'a'..=b'z').contains(&b) || (b'0'..=b'9').contains(&b) {
+            prev_hyphen = false;
+            continue;
+        }
+        if b == b'-' {
+            if prev_hyphen || bytes.first() == Some(&b) || bytes.last() == Some(&b) {
+                return false;
+            }
+            prev_hyphen = true;
+            continue;
+        }
+        return false;
+    }
+
+    true
 }
 
 // ── Contract ────────────────────────────────────────────────────────
@@ -48,9 +89,12 @@ impl TalosNameService {
     ///
     /// # Arguments
     /// * `e` - Soroban environment
+    /// * `owner` - The address authorizing this name registration
     /// * `talos_id` - The Talos ID to associate with the name
     /// * `name` - Human-readable name (3-32 chars, lowercase alphanumeric + hyphens)
-    pub fn register_name(e: Env, talos_id: u32, name: String) {
+    pub fn register_name(e: Env, owner: Address, talos_id: u32, name: String) {
+        owner.require_auth();
+
         if !validate_name(&name) {
             panic!("Invalid name. Must be 3-32 chars, lowercase alphanumeric + hyphens, no consecutive hyphens.");
         }
@@ -63,6 +107,34 @@ impl TalosNameService {
             panic!("Name already taken");
         }
 
+        let registry_contract: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::RegistryContract)
+            .expect("Registry contract not initialized");
+
+        let creator: Option<Address> = e.invoke_contract(
+            &registry_contract,
+            &Symbol::new(&e, "creator_of"),
+            soroban_sdk::vec![&e, talos_id.into_val(&e)],
+        );
+
+        if creator != Some(owner.clone()) {
+            panic_with_error!(&e, ContractError::UnauthorizedCaller);
+        }
+
+        // Retrieve the old name via TalosName(talos_id) and delete NameRecord(old_name)
+        // to prevent dangling records when changing names.
+        if let Some(old_name) = e
+            .storage()
+            .persistent()
+            .get::<_, String>(&DataKey::TalosName(talos_id))
+        {
+            e.storage()
+                .persistent()
+                .remove(&DataKey::NameRecord(old_name));
+        }
+
         // Store mappings
         e.storage()
             .persistent()
@@ -71,23 +143,33 @@ impl TalosNameService {
             .persistent()
             .set(&DataKey::TalosName(talos_id), &name);
 
-        emit_name_registered(&e, talos_id, name);
+        emit_name_registered(&e, talos_id, name, owner);
+    }
+
+    pub fn initialize(e: Env, registry_id: Address) {
+        if e.storage()
+            .persistent()
+            .get::<_, Address>(&DataKey::RegistryContract)
+            .is_some()
+        {
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
+        }
+
+        e.storage()
+            .persistent()
+            .set(&DataKey::RegistryContract, &registry_id);
     }
 
     /// Resolve a name to a Talos ID.
     /// Returns None if the name doesn't exist.
     pub fn resolve_name(e: Env, name: String) -> Option<u32> {
-        e.storage()
-            .persistent()
-            .get(&DataKey::NameRecord(name))
+        e.storage().persistent().get(&DataKey::NameRecord(name))
     }
 
     /// Get the name associated with a Talos ID.
     /// Returns None if the Talos has no name.
     pub fn name_of(e: Env, talos_id: u32) -> Option<String> {
-        e.storage()
-            .persistent()
-            .get(&DataKey::TalosName(talos_id))
+        e.storage().persistent().get(&DataKey::TalosName(talos_id))
     }
 
     /// Check if a name is available.
@@ -107,5 +189,468 @@ impl TalosNameService {
             .persistent()
             .get::<_, String>(&DataKey::TalosName(talos_id))
             .is_some()
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke},
+        Address, Env, IntoVal, Symbol, TryFromVal,
+    };
+    use talos_registry::{Kernel, Patron, Pulse, TalosRegistry, TalosRegistryClient};
+
+    fn setup() -> (
+        Env,
+        Address,
+        Address,
+        TalosRegistryClient<'static>,
+        TalosNameServiceClient<'static>,
+    ) {
+        let _env = Env::default();
+        let env = _env.clone();
+        let registry_contract = env.register_contract(None, TalosRegistry);
+        let name_service_contract = env.register_contract(None, TalosNameService);
+        let name_service_client = TalosNameServiceClient::new(&env, &name_service_contract);
+        name_service_client.initialize(&registry_contract);
+        let registry_client = TalosRegistryClient::new(&env, &registry_contract);
+        (
+            env,
+            registry_contract,
+            name_service_contract,
+            registry_client,
+            name_service_client,
+        )
+    }
+
+    fn s(env: &Env, value: &str) -> String {
+        String::from_str(env, value)
+    }
+
+    fn patron(env: &Env, creator: &Address) -> Patron {
+        Patron {
+            creator_share: 60,
+            investor_share: 25,
+            treasury_share: 15,
+            creator_addr: creator.clone(),
+            investor_addr: Address::generate(env),
+            treasury_addr: Address::generate(env),
+        }
+    }
+
+    fn kernel() -> Kernel {
+        Kernel {
+            approval_threshold: 10,
+            gtm_budget: 1_000,
+            min_patron_pulse: 100,
+        }
+    }
+
+    fn pulse(env: &Env) -> Pulse {
+        Pulse {
+            total_supply: 1_000_000,
+            price_usd_cents: 100,
+            token_symbol: s(env, "TLOS"),
+        }
+    }
+
+    fn create_talos_with_auth(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        creator: &Address,
+        protocol_wallet: &Address,
+    ) -> u32 {
+        let name = s(env, "Genesis");
+        let category = s(env, "Marketing");
+        let description = s(env, "Autonomous marketing agent");
+        let patron = patron(env, creator);
+        let kernel = kernel();
+        let pulse = pulse(env);
+
+        client
+            .mock_auths(&[MockAuth {
+                address: creator,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "create_talos",
+                    args: (
+                        name.clone(),
+                        category.clone(),
+                        description.clone(),
+                        patron.clone(),
+                        kernel.clone(),
+                        pulse.clone(),
+                        protocol_wallet.clone(),
+                    )
+                        .into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .create_talos(
+                &name,
+                &category,
+                &description,
+                &patron,
+                &kernel,
+                &pulse,
+                protocol_wallet,
+            )
+    }
+
+    fn register_name_with_auth(
+        env: &Env,
+        client: &TalosNameServiceClient,
+        contract_id: &Address,
+        registry_contract: &Address,
+        owner: &Address,
+        talos_id: u32,
+        name: &String,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: owner,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "register_name",
+                    args: (owner.clone(), talos_id, name.clone()).into_val(env),
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: registry_contract,
+                        fn_name: "creator_of",
+                        args: (talos_id,).into_val(env),
+                        sub_invokes: &[],
+                    }],
+                },
+            }])
+            .register_name(owner, &talos_id, name);
+    }
+
+    #[test]
+    fn register_name_success() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "marketbot");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        assert!(client.is_name_available(&name));
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+
+        assert!(!client.is_name_available(&name));
+        assert!(client.has_name(&talos_id));
+        assert_eq!(client.resolve_name(&name), Some(talos_id));
+        assert_eq!(client.name_of(&talos_id), Some(name));
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let second_owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "marketbot");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+
+        let duplicate_result = client
+            .mock_auths(&[MockAuth {
+                address: &second_owner,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (second_owner.clone(), talos_id, name.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_register_name(&second_owner, &talos_id, &name);
+
+        assert!(duplicate_result.is_err());
+    }
+
+    #[test]
+    fn unauthorized_caller_rejected() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let creator = Address::generate(&env);
+        let unauthorized = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "marketbot");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &creator,
+            &protocol_wallet,
+        );
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &unauthorized,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (unauthorized.clone(), talos_id, name.clone()).into_val(&env),
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: &registry_contract,
+                        fn_name: "creator_of",
+                        args: (talos_id,).into_val(&env),
+                        sub_invokes: &[],
+                    }],
+                },
+            }])
+            .try_register_name(&unauthorized, &talos_id, &name);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn initialize_guard_rejects_reinitialization() {
+        let (_env, registry_contract, _contract_id, _registry_client, client) = setup();
+        assert!(client.try_initialize(&registry_contract).is_err());
+    }
+
+    #[test]
+    fn lookup_by_name_returns_correct_talos_id() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "atlas-agent");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+
+        assert_eq!(client.resolve_name(&name), Some(talos_id));
+        assert_eq!(client.name_of(&talos_id), Some(name));
+    }
+
+    #[test]
+    fn invalid_name_rejected() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let invalid_name = s(&env, "ab");
+        let owner = Address::generate(&env);
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &owner,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (owner.clone(), 1u32, invalid_name.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_register_name(&owner, &1, &invalid_name);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accepts_valid_name_patterns() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let valid_name = s(&env, "alpha-1");
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &owner,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (owner.clone(), talos_id, valid_name.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_register_name(&owner, &talos_id, &valid_name);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_name_patterns() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let invalid_names = [
+            s(&env, "Alpha"),
+            s(&env, "bad--name"),
+            s(&env, "-bad"),
+            s(&env, "bad-"),
+        ];
+
+        for invalid_name in invalid_names {
+            let result = client
+                .mock_auths(&[MockAuth {
+                    address: &owner,
+                    invoke: &MockAuthInvoke {
+                        contract: &contract_id,
+                        fn_name: "register_name",
+                        args: (owner.clone(), 1u32, invalid_name.clone()).into_val(&env),
+                        sub_invokes: &[],
+                    },
+                }])
+                .try_register_name(&owner, &1, &invalid_name);
+
+            assert!(
+                result.is_err(),
+                "expected invalid name {:?} to be rejected",
+                invalid_name.to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn register_name_emits_name_reg_event() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "marketbot");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+
+        let all_events = env.events().all();
+        let events = all_events
+            .iter()
+            .filter(|e| e.0 == contract_id)
+            .collect::<std::vec::Vec<_>>();
+        assert_eq!(events.len(), 1);
+        let (_addr, topics, data) = events.get(0).unwrap();
+        assert_eq!(topics.len() as u32, 2);
+        let t0: Symbol = TryFromVal::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        let t1: u32 = TryFromVal::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        let (got_name, got_owner): (String, Address) =
+            TryFromVal::try_from_val(&env, data).unwrap();
+        assert_eq!(got_name, name);
+        assert_eq!(got_owner, owner);
+    }
+
+    #[test]
+    fn update_name_removes_old_record() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name1 = s(&env, "name1");
+        let name2 = s(&env, "name2");
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        // Register first name
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name1,
+        );
+
+        assert_eq!(client.resolve_name(&name1), Some(talos_id));
+
+        // Register second name
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name2,
+        );
+
+        assert_eq!(client.resolve_name(&name2), Some(talos_id));
+        // Verify old name is cleared
+        assert_eq!(client.resolve_name(&name1), None);
+        assert!(client.is_name_available(&name1));
+    }
+    #[test]
+    fn has_name_returns_false_for_unknown_talos_id() {
+        let (env, registry_contract, contract_id, _registry_client, client) = setup();
+
+        // talos_id = 999 does not exist
+        assert!(!client.has_name(&999));
+    }
+
+    #[test]
+    fn name_of_returns_none_for_unknown_talos_id() {
+        let (env, _registry_contract, _contract_id, _registry_client, client) = setup();
+
+        assert!(client.name_of(&999).is_none());
     }
 }

--- a/contracts/talos_registry/Cargo.toml
+++ b/contracts/talos_registry/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+


### PR DESCRIPTION
…_name

## Summary

- Added `owner: Address` parameter to `TalosNameService::register_name` with `owner.require_auth()` so only the authorized caller can register a name
- Added cross-contract call to `TalosRegistry::creator_of(talos_id)` to verify the caller actually owns the target Talos
- Returns `ContractError::UnauthorizedCaller` (error code `2`) when the caller is not the creator — gives a descriptive, typed failure instead of a generic panic
- Cleans up dangling reverse-lookup records when a Talos re-registers under a new name

## What changed

**`contracts/talos_name_service/src/lib.rs`**

- `register_name(e, owner, talos_id, name)` — new `owner: Address` parameter; calls `owner.require_auth()` then cross-contract-verifies via `TalosRegistry::creator_of`
- `ContractError::UnauthorizedCaller = 2` — new typed error variant
- `DataKey::RegistryContract` — stores the registry address set during `initialize`
- `initialize(e, registry_id)` — wires the registry address used for ownership checks
- 12 unit tests, including `unauthorized_caller_rejected` (non-owner attempt fails) and `register_name_success` (valid owner succeeds)

## Test plan

- [ ] `cargo test` passes in `contracts/` (12/12 name-service tests green)
- [ ] `unauthorized_caller_rejected` confirms a different address cannot register a name for a Talos it doesn't own
- [ ] `register_name_success` confirms the Talos creator can register a name end-to-end
- [ ] `duplicate_name_rejected` confirms a taken name cannot be re-registered
- [ ] CI `contracts-ci.yml` (`cargo test` + WASM build) passes on the PR

Closes #27
