### PR TITLE
fix: harden apply_playbook lookup

### DIFF
--- a/packages/prime-agent/src/talos_agent/db.py
+++ b/packages/prime-agent/src/talos_agent/db.py
@@ -18,6 +18,22 @@ def get_db_path(agent_id: str | None = None) -> Path:
         return APP_DIR / f"agent-{agent_id}.db"
     return DB_PATH
 
+
+def normalize_playbook_name(name: str) -> str:
+    """Validate and normalize a playbook lookup name."""
+    if not isinstance(name, str):
+        raise ValueError("Playbook name must be a string")
+
+    normalized_name = name.strip()
+    if not normalized_name:
+        raise ValueError("Playbook name cannot be empty")
+    if len(normalized_name) > 200:
+        raise ValueError("Playbook name must be 200 characters or fewer")
+    if any(ord(char) < 32 for char in normalized_name):
+        raise ValueError("Playbook name contains invalid control characters")
+
+    return normalized_name
+
 _MIGRATIONS = [
     (
         1,
@@ -385,6 +401,21 @@ class LocalDB:
             (name, json.dumps(data), source_talos),
         )
         self._conn.commit()
+
+    def find_playbook_by_name(self, name: str) -> dict | None:
+        normalized_name = normalize_playbook_name(name)
+        row = self._conn.execute(
+            "SELECT id, name, data FROM playbooks WHERE name = ? "
+            "ORDER BY purchased_at DESC LIMIT 1",
+            (normalized_name,),
+        ).fetchone()
+        if row:
+            return {
+                "id": row["id"],
+                "name": row["name"],
+                "data": json.loads(row["data"]),
+            }
+        return None
 
     def get_active_playbook(self) -> dict | None:
         row = self._conn.execute(

--- a/packages/prime-agent/src/talos_agent/tools/commerce.py
+++ b/packages/prime-agent/src/talos_agent/tools/commerce.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from talos_agent.db import normalize_playbook_name
 from talos_agent.payments import USDC_TESTNET_ISSUER
 from talos_agent.payments.x402_signer import X402Signer
 from talos_agent.tools.registry import tool
@@ -224,15 +225,15 @@ async def poll_service_result(job_id: str) -> dict:
 )
 async def apply_playbook(playbook_name: str) -> dict:
     """Find and activate a playbook by name."""
-    conn = _db._conn
-    rows = conn.execute(
-        "SELECT id, name, data FROM playbooks WHERE name LIKE ?", (f"%{playbook_name}%",)
-    ).fetchall()
+    try:
+        normalized_name = normalize_playbook_name(playbook_name)
+    except ValueError as exc:
+        return {"error": str(exc)}
 
-    if not rows:
-        return {"error": f"No playbook found matching '{playbook_name}'"}
+    row = _db.find_playbook_by_name(normalized_name)
+    if not row:
+        return {"error": f"No playbook found named '{normalized_name}'"}
 
-    row = rows[0]
     _db.apply_playbook(row["id"])
 
     return {

--- a/packages/prime-agent/tests/test_commerce.py
+++ b/packages/prime-agent/tests/test_commerce.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from talos_agent.payments import USDC_TESTNET_ISSUER
-from talos_agent.tools.commerce import price_to_usdc_units, ALL_CATEGORIES, discover_services, purchase_service
+from talos_agent.tools.commerce import (
+    ALL_CATEGORIES,
+    apply_playbook,
+    discover_services,
+    price_to_usdc_units,
+    purchase_service,
+)
 
 
 class TestPriceToUsdcUnits:
@@ -139,3 +145,45 @@ class TestPurchaseServiceSignPayment:
         _, call_kwargs = mock_sign.call_args
         assert "token_address" not in call_kwargs
         assert "chain_id" not in call_kwargs
+
+
+class TestApplyPlaybook:
+    @pytest.mark.asyncio
+    async def test_apply_playbook_uses_exact_lookup_method(self):
+        mock_db = MagicMock()
+        mock_db.find_playbook_by_name.return_value = {
+            "id": 7,
+            "name": "Alpha Playbook",
+            "data": {"stage": "launch"},
+        }
+
+        with patch("talos_agent.tools.commerce._db", mock_db):
+            result = await apply_playbook("  Alpha Playbook  ")
+
+        mock_db.find_playbook_by_name.assert_called_once_with("Alpha Playbook")
+        mock_db.apply_playbook.assert_called_once_with(7)
+        assert result["status"] == "applied"
+        assert result["playbook"] == "Alpha Playbook"
+
+    @pytest.mark.asyncio
+    async def test_apply_playbook_rejects_blank_name(self):
+        mock_db = MagicMock()
+
+        with patch("talos_agent.tools.commerce._db", mock_db):
+            result = await apply_playbook("   ")
+
+        assert result == {"error": "Playbook name cannot be empty"}
+        mock_db.find_playbook_by_name.assert_not_called()
+        mock_db.apply_playbook.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_playbook_returns_not_found_for_exact_lookup_miss(self):
+        mock_db = MagicMock()
+        mock_db.find_playbook_by_name.return_value = None
+
+        with patch("talos_agent.tools.commerce._db", mock_db):
+            result = await apply_playbook("Growth")
+
+        assert result == {"error": "No playbook found named 'Growth'"}
+        mock_db.find_playbook_by_name.assert_called_once_with("Growth")
+        mock_db.apply_playbook.assert_not_called()

--- a/packages/prime-agent/tests/test_db.py
+++ b/packages/prime-agent/tests/test_db.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from talos_agent.db import LocalDB
 
 
@@ -75,6 +77,37 @@ class TestCommerceLifecycle:
         ).fetchall()
         assert len(rows) == 1
         assert rows[0]["talos_id"] == "c1"
+
+
+class TestPlaybookLookup:
+    def test_find_playbook_by_name_returns_exact_match(self, mock_db: LocalDB):
+        mock_db.save_playbook("Growth Engine", {"cadence": "daily"})
+        mock_db.save_playbook("Growth Engine Pro", {"cadence": "weekly"})
+
+        playbook = mock_db.find_playbook_by_name("Growth Engine")
+
+        assert playbook is not None
+        assert playbook["name"] == "Growth Engine"
+        assert playbook["data"] == {"cadence": "daily"}
+
+    def test_find_playbook_by_name_strips_surrounding_whitespace(self, mock_db: LocalDB):
+        mock_db.save_playbook("Launch Plan", {"channel": "email"})
+
+        playbook = mock_db.find_playbook_by_name("  Launch Plan  ")
+
+        assert playbook is not None
+        assert playbook["name"] == "Launch Plan"
+
+    def test_find_playbook_by_name_rejects_blank_input(self, mock_db: LocalDB):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            mock_db.find_playbook_by_name("   ")
+
+    def test_find_playbook_by_name_returns_none_for_partial_match(self, mock_db: LocalDB):
+        mock_db.save_playbook("Growth Engine Pro", {"cadence": "weekly"})
+
+        playbook = mock_db.find_playbook_by_name("Growth")
+
+        assert playbook is None
 
 
 class TestLearningsLifecycle:


### PR DESCRIPTION
Closes #47

---

## Summary
- add a dedicated LocalDB playbook lookup method instead of reaching into the private sqlite connection from apply_playbook
- validate and normalize playbook names before lookup and switch from broad wildcard matching to exact-name matching
- add focused tests for the LocalDB lookup path and apply_playbook tool behavior

## Testing
- Unable to run locally in this environment because python/pytest are not installed on PATH
