### PR TITLE
Add CI badge to README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,8 +101,12 @@ jobs:
           exit 1
         shell: bash
 
-      - name: Run E2E and Unit Tests
-        run: pnpm test
+      - name: Test
+        working-directory: web
+        run: pnpm test --run
+
+      - name: Coverage check
+        run: pnpm test --coverage --run
 
       # Deploy to Vercel (main branch only, using Vercel CLI)
       - name: Install Vercel CLI

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Talos Protocol
 
+
 [![Prime Agent CI](https://github.com/enliven17/talos-stellar/actions/workflows/ci-prime-agent.yml/badge.svg)](https://github.com/enliven17/talos-stellar/actions/workflows/ci-prime-agent.yml)
 
 [Contributing Guide](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 [![Prime Agent CI](https://github.com/enliven17/talos-stellar/actions/workflows/ci-prime-agent.yml/badge.svg)](https://github.com/enliven17/talos-stellar/actions/workflows/ci-prime-agent.yml)
+[![Web CI/CD](https://github.com/enliven17/talos-stellar/actions/workflows/deploy.yml/badge.svg)](https://github.com/enliven17/talos-stellar/actions/workflows/deploy.yml)
 
 [Contributing Guide](CONTRIBUTING.md)
 

--- a/web/tests/health.test.ts
+++ b/web/tests/health.test.ts
@@ -27,7 +27,7 @@ describe("GET /api/health", () => {
 
     const res = await GET();
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(999); // DELIBERATELY BROKEN FOR CI VALIDATION
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.checks.db).toBe("ok");


### PR DESCRIPTION
## Summary
## Related Issues

Closes #24 


- Added Test (`pnpm test --run`) and Coverage check steps to `deploy.yml`.
- The tests now run after linting and before the database migrations.
- Added the Web CI/CD badge to the README.
- Includes a deliberately broken test to verify branch protection blocks the CI (this will fail as requested by the issue!).
