### PR TITLE
[codex] fix OpenAI client isolation across agents

### DIFF
--- a/packages/prime-agent/src/talos_agent/agent/loop.py
+++ b/packages/prime-agent/src/talos_agent/agent/loop.py
@@ -20,18 +20,22 @@ if TYPE_CHECKING:
 
 console = Console()
 
-# Module-level singleton — reused across all agent cycles
-_openai_client: AsyncOpenAI | None = None
+# Cache clients by credential scope so concurrent agents in the same process do
+# not share the first agent's API key.
+_openai_clients: dict[tuple[str, str | None], AsyncOpenAI] = {}
 
 
 def get_openai_client(api_key: str, base_url: str | None = None) -> AsyncOpenAI:
-    global _openai_client
-    if _openai_client is None:
+    normalized_base_url = base_url or None
+    cache_key = (api_key, normalized_base_url)
+    client = _openai_clients.get(cache_key)
+    if client is None:
         kwargs: dict = {"api_key": api_key}
-        if base_url:
-            kwargs["base_url"] = base_url
-        _openai_client = AsyncOpenAI(**kwargs)
-    return _openai_client
+        if normalized_base_url:
+            kwargs["base_url"] = normalized_base_url
+        client = AsyncOpenAI(**kwargs)
+        _openai_clients[cache_key] = client
+    return client
 
 
 async def agent_loop(

--- a/packages/prime-agent/tests/test_openai_client_isolation.py
+++ b/packages/prime-agent/tests/test_openai_client_isolation.py
@@ -1,0 +1,67 @@
+"""Regression tests for OpenAI client isolation across in-process agents."""
+
+from __future__ import annotations
+
+import pytest
+
+from talos_agent.agent import loop
+
+
+class FakeAsyncOpenAI:
+    instances: list["FakeAsyncOpenAI"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def fake_openai_client(monkeypatch):
+    FakeAsyncOpenAI.instances = []
+    loop._openai_clients.clear()
+    monkeypatch.setattr(loop, "AsyncOpenAI", FakeAsyncOpenAI)
+    yield
+    loop._openai_clients.clear()
+
+
+def test_openai_client_cache_reuses_matching_credentials():
+    first = loop.get_openai_client("sk-agent-a", "https://llm.example/v1")
+    second = loop.get_openai_client("sk-agent-a", "https://llm.example/v1")
+
+    assert first is second
+    assert len(FakeAsyncOpenAI.instances) == 1
+    assert first.kwargs == {
+        "api_key": "sk-agent-a",
+        "base_url": "https://llm.example/v1",
+    }
+
+
+def test_openai_client_cache_isolates_agents_by_api_key():
+    first_agent = loop.get_openai_client("sk-agent-a")
+    second_agent = loop.get_openai_client("sk-agent-b")
+
+    assert first_agent is not second_agent
+    assert [client.kwargs["api_key"] for client in FakeAsyncOpenAI.instances] == [
+        "sk-agent-a",
+        "sk-agent-b",
+    ]
+
+
+def test_openai_client_cache_isolates_agents_by_base_url():
+    openai_client = loop.get_openai_client("sk-agent-a")
+    groq_client = loop.get_openai_client("sk-agent-a", "https://api.groq.com/openai/v1")
+
+    assert openai_client is not groq_client
+    assert openai_client.kwargs == {"api_key": "sk-agent-a"}
+    assert groq_client.kwargs == {
+        "api_key": "sk-agent-a",
+        "base_url": "https://api.groq.com/openai/v1",
+    }
+
+
+def test_openai_client_cache_normalizes_empty_base_url():
+    no_base_url = loop.get_openai_client("sk-agent-a", None)
+    empty_base_url = loop.get_openai_client("sk-agent-a", "")
+
+    assert no_base_url is empty_base_url
+    assert len(FakeAsyncOpenAI.instances) == 1


### PR DESCRIPTION
﻿## What changed

- Replaced the single module-level `_openai_client` singleton with a cache keyed by `(api_key, base_url)`.
- Normalized empty `base_url` values to `None` so default OpenAI clients reuse correctly.
- Added regression coverage proving same credentials reuse a client while different API keys or base URLs get isolated clients.

Closes #53

## Why

In single-process `run_multi` deployments, multiple agents can run concurrently with different LLM credentials. The old singleton reused the first initialized AsyncOpenAI client for every later agent, which could send subsequent agents' traffic through the first agent's API key.

## Validation

- `PYTHONPATH=src uv run pytest tests/test_openai_client_isolation.py` passed.
- `PYTHONPATH=src uv run ruff check src tests` passed.
- `PYTHONPATH=src uv run --extra dev pytest` passed: 177 tests.
