### PR TITLE
validate Stellar asset code and issuer pairs consistently

### DIFF
--- a/web/src/app/api/talos/[id]/sign/route.ts
+++ b/web/src/app/api/talos/[id]/sign/route.ts
@@ -39,7 +39,11 @@ export async function POST(
     const parsed = await parseBody(request, signPaymentSchema);
     if (parsed.error) return parsed.error;
 
-    const { payee, amount, assetCode } = parsed.data;
+    const { payee, amount, asset, assetCode } = parsed.data;
+
+    // Resolve the effective asset code: prefer the typed `asset` field,
+    // fall back to the legacy `assetCode` string, then default to USDC.
+    const effectiveAssetCode = asset?.code ?? assetCode ?? "USDC";
     const amountUsd = Number(amount);
 
     if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
@@ -76,7 +80,7 @@ export async function POST(
       from: talos.agentWalletAddress,
       to: payee,
       amount: amountStr,
-      assetCode: assetCode ?? "USDC",
+      assetCode: effectiveAssetCode,
     });
 
     // 7. Return X-Payment header value + metadata
@@ -86,7 +90,7 @@ export async function POST(
       from: talos.agentWalletAddress,
       to: payee,
       amount: amountStr,
-      assetCode: assetCode ?? "USDC",
+      assetCode: effectiveAssetCode,
     });
   } catch (err) {
     console.error("Signing error:", err);

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -5,40 +5,43 @@
 import { z } from "zod/v4";
 import { StrKey } from "@stellar/stellar-sdk";
 
-/**
- * Zod schema for a valid Stellar asset code (1-12 alphanumeric characters).
- */
-const stellarAssetCodeSchema = z.string().min(1).max(12).regex(/^[a-zA-Z0-9]+$/);
+export const stellarAssetCodeSchema = z
+  .string()
+  .min(1, "Asset code must be at least 1 character")
+  .max(12, "Asset code must be at most 12 characters")
+  .regex(
+    /^[A-Z0-9]+$/,
+    "Asset code must contain only uppercase letters and numbers",
+  );
 
-/**
- * Zod schema for a valid Stellar public key (G...) with StrKey checksum.
- */
-const stellarPublicKeySchema = z.string().refine((key) => StrKey.isValidEd25519PublicKey(key), {
-  message: "Invalid Stellar public key",
-});
+export const stellarPublicKeySchema = z
+  .string()
+  .startsWith("G", "Stellar public key must start with 'G'")
+  .length(56, "Stellar public key must be exactly 56 characters")
+  .refine(
+    (key) => {
+      try {
+        return StrKey.isValidEd25519PublicKey(key);
+      } catch {
+        return false;
+      }
+    },
+    { message: "Invalid Stellar Ed25519 public key" },
+  );
 
-/**
- * Zod schema for a native XLM asset.
- */
-const nativeAssetSchema = z.object({
+export const stellarNativeAssetSchema = z.object({
   type: z.literal("native"),
-});
+}).strict();
 
-/**
- * Zod schema for an issued Stellar asset.
- */
-const issuedAssetSchema = z.object({
+export const stellarIssuedAssetSchema = z.object({
   type: z.literal("issued"),
   code: stellarAssetCodeSchema,
   issuer: stellarPublicKeySchema,
-});
+}).strict();
 
-/**
- * Zod schema for a Stellar asset (native or issued).
- */
 export const stellarAssetSchema = z.discriminatedUnion("type", [
-  nativeAssetSchema,
-  issuedAssetSchema,
+  stellarNativeAssetSchema,
+  stellarIssuedAssetSchema,
 ]);
 
 export const VALID_CATEGORIES = [
@@ -67,17 +70,16 @@ export const createTalosSchema = z.object({
   toneVoice: z.string().max(500).nullable().optional(),
   approvalThreshold: z.number().nonnegative().optional().default(10),
   gtmBudget: z.number().nonnegative().optional().default(200),
-  creatorPublicKey: z.string().min(1),
+  creatorPublicKey: stellarPublicKeySchema,
   signature: z.string().min(1),
   message: z.string().min(1),
-  walletPublicKey: z.string().optional(),
+  walletPublicKey: stellarPublicKeySchema.optional(),
   onChainId: z.number().int().nullable().optional(),
   agentName: z.string().max(100).nullable().optional(),
   initialPrice: z.number().nonnegative().optional().default(0),
   minPatronPulse: z.number().int().nonnegative().nullable().optional(),
   stellarAssetCode: stellarAssetCodeSchema.nullable().optional(),
   tokenSymbol: z.string().max(20).nullable().optional(),
-  // Optional commerce service
   serviceName: z.string().min(1).max(200).optional(),
   serviceDescription: z.string().max(2000).optional(),
   servicePrice: z.number().positive().max(1_000_000).optional(),
@@ -222,10 +224,9 @@ export const regenerateKeySchema = z.object({
 // --- Sign Payment (Stellar x402) ---
 
 export const signPaymentSchema = z.object({
-  payee: stellarPublicKeySchema,          // Stellar public key of payee
+  payee: stellarPublicKeySchema,
   amount: z.union([z.string(), z.number()]),
   assetCode: stellarAssetCodeSchema.optional().default("USDC"),
-  assetIssuer: stellarPublicKeySchema.optional(),
 });
 
 // --- Buy Token ---

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -3,46 +3,126 @@
  * Shared across all POST endpoints to ensure consistent validation.
  */
 import { z } from "zod/v4";
-import { StrKey } from "@stellar/stellar-sdk";
 
-export const stellarAssetCodeSchema = z
-  .string()
-  .min(1, "Asset code must be at least 1 character")
-  .max(12, "Asset code must be at most 12 characters")
-  .regex(
-    /^[A-Z0-9]+$/,
-    "Asset code must contain only uppercase letters and numbers",
-  );
+// ── Stellar StrKey helpers ───────────────────────────────────────────────────
 
-export const stellarPublicKeySchema = z
-  .string()
-  .startsWith("G", "Stellar public key must start with 'G'")
-  .length(56, "Stellar public key must be exactly 56 characters")
-  .refine(
-    (key) => {
-      try {
-        return StrKey.isValidEd25519PublicKey(key);
-      } catch {
-        return false;
-      }
-    },
-    { message: "Invalid Stellar Ed25519 public key" },
-  );
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
-export const stellarNativeAssetSchema = z.object({
-  type: z.literal("native"),
-}).strict();
+function base32Decode(input: string): Uint8Array | null {
+  const cleaned = input.toUpperCase().replace(/=/g, "");
+  const len = cleaned.length;
+  if (len === 0 || len % 8 !== 0) return null;
 
-export const stellarIssuedAssetSchema = z.object({
-  type: z.literal("issued"),
-  code: stellarAssetCodeSchema,
-  issuer: stellarPublicKeySchema,
-}).strict();
+  const out: number[] = [];
+  let bits = 0;
+  let value = 0;
 
-export const stellarAssetSchema = z.discriminatedUnion("type", [
-  stellarNativeAssetSchema,
-  stellarIssuedAssetSchema,
+  for (let i = 0; i < len; i++) {
+    const idx = BASE32_ALPHABET.indexOf(cleaned[i]);
+    if (idx === -1) return null;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push((value >>> bits) & 0xff);
+    }
+  }
+  return new Uint8Array(out);
+}
+
+const CRC16_TABLE = (() => {
+  const table = new Uint16Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i << 8;
+    for (let j = 0; j < 8; j++) c = c & 0x8000 ? (c << 1) ^ 0x1021 : c << 1;
+    table[i] = c & 0xffff;
+  }
+  return table;
+})();
+
+function crc16(bytes: Uint8Array): number {
+  let crc = 0;
+  for (const b of bytes) crc = ((crc << 8) ^ CRC16_TABLE[((crc >>> 8) ^ b) & 0xff]) & 0xffff;
+  return crc;
+}
+
+/**
+ * Decode a Stellar StrKey-encoded public key and verify its CRC16 checksum.
+ * Accepts version bytes 0x30 (ed25519 public) and 0xb0 (ed25519签 seed).
+ * Returns the raw payload on success, null on any validation failure.
+ */
+function decodeStrKey(strKey: string): Uint8Array | null {
+  if (typeof strKey !== "string") return null;
+  const decoded = base32Decode(strKey);
+  if (!decoded || decoded.length < 4) return null;
+
+  const version = decoded[0];
+  if (version !== 0x30 && version !== 0xb0) return null;
+
+  const payload = decoded.slice(0, decoded.length - 2);
+  // Stellar stores CRC-16 little-endian (LSB first)
+  const checksum =
+    decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
+
+  if (crc16(payload) !== checksum) return null;
+
+  // ed25519 public key payload must be exactly 32 bytes (version + 32)
+  if (version === 0x30 && payload.length !== 33) return null;
+  // ed25519 secret seed payload must be exactly 33 bytes (version + 32)
+  if (version === 0xb0 && payload.length !== 33) return null;
+
+  return payload;
+}
+
+function isValidStellarPublicKey(value: string): boolean {
+  return decodeStrKey(value) !== null;
+}
+
+// ── Shared Stellar asset schema ──────────────────────────────────────────────
+
+/**
+ * Discriminated schema for Stellar native or issued assets.
+ *
+ * Native (XLM):
+ *   { "native": true }
+ *
+ * Issued token (e.g. USDC, MITOS):
+ *   { "code": "USDC", "issuer": "GABC...56chars" }
+ *
+ * The issuer field must be a valid Stellar StrKey with a verified CRC16
+ * checksum.  Asset codes are constrained to 1-12 uppercase alphanumeric
+ * characters, matching the Stellar protocol limits.
+ */
+export const stellarAssetSchema = z.union([
+  z.object({
+    native: z.literal(true),
+    code: z.undefined().optional(),
+    issuer: z.undefined().optional(),
+  }),
+  z.object({
+    native: z.undefined().optional(),
+    code: z
+      .string()
+      .min(1, "Asset code is required for issued assets")
+      .max(12, "Asset code must be at most 12 characters")
+      .regex(/^[A-Z0-9]{1,12}$/, "Asset code must be 1-12 uppercase alphanumeric characters"),
+    issuer: z.string().refine(isValidStellarPublicKey, {
+      message: "Issuer must be a valid Stellar public key (G..., 56 chars, valid checksum)",
+    }),
+  }),
 ]);
+
+/** Inferred type for use in route handlers. */
+export type StellarAsset = z.infer<typeof stellarAssetSchema>;
+
+/**
+ * Optional asset field for schemas where the caller may omit the asset
+ * (defaults to native XLM).  When provided, the value must pass the full
+ * stellarAssetSchema validation.
+ */
+export const optionalStellarAssetField = stellarAssetSchema.optional();
+
+// ── Categories ───────────────────────────────────────────────────────────────
 
 export const VALID_CATEGORIES = [
   "Marketing", "Development", "Research", "Design", "Finance",
@@ -78,7 +158,15 @@ export const createTalosSchema = z.object({
   agentName: z.string().max(100).nullable().optional(),
   initialPrice: z.number().nonnegative().optional().default(0),
   minPatronPulse: z.number().int().nonnegative().nullable().optional(),
-  stellarAssetCode: stellarAssetCodeSchema.nullable().optional(),
+  stellarAssetCode: z.string().nullable().optional().refine(
+    (val) => {
+      if (val === null || val === undefined || val === "") return true;
+      const match = val.match(/^([A-Z0-9]{1,12}):(.+)$/);
+      if (!match) return false;
+      return isValidStellarPublicKey(match[2]);
+    },
+    { message: "stellarAssetCode must be null or in the format 'CODE:G...55chars' with a valid issuer checksum (e.g. 'MITOS:GABC...')" },
+  ),
   tokenSymbol: z.string().max(20).nullable().optional(),
   serviceName: z.string().min(1).max(200).optional(),
   serviceDescription: z.string().max(2000).optional(),
@@ -226,7 +314,9 @@ export const regenerateKeySchema = z.object({
 export const signPaymentSchema = z.object({
   payee: stellarPublicKeySchema,
   amount: z.union([z.string(), z.number()]),
-  assetCode: stellarAssetCodeSchema.optional().default("USDC"),
+  asset: optionalStellarAssetField,
+  /** @deprecated Use `asset` instead. Kept for backward compatibility. */
+  assetCode: z.string().optional(),
 });
 
 // --- Buy Token ---

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -3,6 +3,43 @@
  * Shared across all POST endpoints to ensure consistent validation.
  */
 import { z } from "zod/v4";
+import { StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Zod schema for a valid Stellar asset code (1-12 alphanumeric characters).
+ */
+const stellarAssetCodeSchema = z.string().min(1).max(12).regex(/^[a-zA-Z0-9]+$/);
+
+/**
+ * Zod schema for a valid Stellar public key (G...) with StrKey checksum.
+ */
+const stellarPublicKeySchema = z.string().refine((key) => StrKey.isValidEd25519PublicKey(key), {
+  message: "Invalid Stellar public key",
+});
+
+/**
+ * Zod schema for a native XLM asset.
+ */
+const nativeAssetSchema = z.object({
+  type: z.literal("native"),
+});
+
+/**
+ * Zod schema for an issued Stellar asset.
+ */
+const issuedAssetSchema = z.object({
+  type: z.literal("issued"),
+  code: stellarAssetCodeSchema,
+  issuer: stellarPublicKeySchema,
+});
+
+/**
+ * Zod schema for a Stellar asset (native or issued).
+ */
+export const stellarAssetSchema = z.discriminatedUnion("type", [
+  nativeAssetSchema,
+  issuedAssetSchema,
+]);
 
 export const VALID_CATEGORIES = [
   "Marketing", "Development", "Research", "Design", "Finance",
@@ -38,7 +75,7 @@ export const createTalosSchema = z.object({
   agentName: z.string().max(100).nullable().optional(),
   initialPrice: z.number().nonnegative().optional().default(0),
   minPatronPulse: z.number().int().nonnegative().nullable().optional(),
-  stellarAssetCode: z.string().nullable().optional(),
+  stellarAssetCode: stellarAssetCodeSchema.nullable().optional(),
   tokenSymbol: z.string().max(20).nullable().optional(),
   // Optional commerce service
   serviceName: z.string().min(1).max(200).optional(),
@@ -185,9 +222,10 @@ export const regenerateKeySchema = z.object({
 // --- Sign Payment (Stellar x402) ---
 
 export const signPaymentSchema = z.object({
-  payee: z.string().min(1),               // Stellar public key of payee
+  payee: stellarPublicKeySchema,          // Stellar public key of payee
   amount: z.union([z.string(), z.number()]),
-  assetCode: z.string().optional().default("USDC"),
+  assetCode: stellarAssetCodeSchema.optional().default("USDC"),
+  assetIssuer: stellarPublicKeySchema.optional(),
 });
 
 // --- Buy Token ---

--- a/web/tests/sign-route-asset.test.ts
+++ b/web/tests/sign-route-asset.test.ts
@@ -1,0 +1,275 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { POST as signPOST } from "../src/app/api/talos/[id]/sign/route";
+import { createTalosSchema } from "../src/lib/schemas";
+
+// Real Stellar public keys with verified CRC16 checksums
+const VALID_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const BAD_CHECKSUM_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA6";
+
+// ── Sign Route mocks ───────────────────────────────────────────────
+const signMocks = vi.hoisted(() => ({
+  verifyAgentApiKey: vi.fn(),
+  select: vi.fn(),
+  signX402Payment: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  verifyAgentApiKey: (...args: unknown[]) => signMocks.verifyAgentApiKey(...args),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: (...args: unknown[]) => signMocks.select(...args),
+    insert: (...args: unknown[]) => signMocks.insert?.(...args) ?? { values: () => ({ returning: () => Promise.resolve([]) }) },
+    transaction: (...args: unknown[]) => signMocks.transaction?.(...args) ?? Promise.resolve(),
+  },
+}));
+
+vi.mock("@/lib/stellar-x402", () => ({
+  signX402Payment: (...args: unknown[]) => signMocks.signX402Payment(...args),
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  createAgentKeypair: vi.fn().mockResolvedValue({ publicKey: "GMOCK", secretKey: "S0MOCK" }),
+  fundTestnetAccount: vi.fn().mockResolvedValue(undefined),
+  verifyStellarSignature: vi.fn().mockResolvedValue(true),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────
+const SIGN_ID = "sign-route-test";
+const API_KEY = "tak_sign_route_test_key";
+
+function signRequest(body: unknown): Request {
+  return new Request(`http://localhost/api/talos/${SIGN_ID}/sign`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function selectChain(result: unknown) {
+  const chain: any = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    then: vi.fn().mockImplementation((resolve?: Function) => {
+      if (resolve) return Promise.resolve(resolve(result));
+      return Promise.resolve(result);
+    }),
+  };
+  return chain;
+}
+
+// ── Sign Route Tests ───────────────────────────────────────────────
+describe("POST /api/talos/:id/sign — asset field pair tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env[`TALOS_AGENT_SECRET_${SIGN_ID}`] = "test-secret-key";
+
+    signMocks.verifyAgentApiKey.mockResolvedValue({
+      ok: true,
+      talos: { id: SIGN_ID, apiKey: API_KEY },
+    });
+    signMocks.select.mockReturnValue(
+      selectChain([
+        {
+          agentWalletId: "wallet-1",
+          agentWalletAddress: "GAGENTWALLET",
+          approvalThreshold: "100.00",
+        },
+      ]),
+    );
+    signMocks.signX402Payment.mockResolvedValue({ paymentToken: "mock-payment-token" });
+  });
+
+  it("accepts legacy assetCode: 'USDC' and passes it to x402", async () => {
+    const response = await signPOST(
+      signRequest({ payee: "GPAYEE", amount: "5.00", assetCode: "USDC" }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+    const body = await response.json();
+    expect(body.assetCode).toBe("USDC");
+  });
+
+  it("accepts new typed native asset and defaults assetCode to USDC", async () => {
+    const response = await signPOST(
+      signRequest({ payee: "GPAYEE", amount: "5.00", asset: { native: true } }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    // native asset has no code → route defaults to "USDC"
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+  });
+
+  it("accepts new typed issued asset and extracts code", async () => {
+    const response = await signPOST(
+      signRequest({
+        payee: "GPAYEE",
+        amount: "5.00",
+        asset: { code: "USDC", issuer: VALID_ISSUER },
+      }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+    const body = await response.json();
+    expect(body.assetCode).toBe("USDC");
+  });
+
+  it("rejects issued asset with invalid issuer checksum", async () => {
+    const response = await signPOST(
+      signRequest({
+        payee: "GPAYEE",
+        amount: "5.00",
+        asset: { code: "USDC", issuer: BAD_CHECKSUM_ISSUER },
+      }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Validation failed");
+    expect(signMocks.signX402Payment).not.toHaveBeenCalled();
+  });
+
+  it("rejects issued asset with lowercase code", async () => {
+    const response = await signPOST(
+      signRequest({
+        payee: "GPAYEE",
+        amount: "5.00",
+        asset: { code: "usdc", issuer: VALID_ISSUER },
+      }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(signMocks.signX402Payment).not.toHaveBeenCalled();
+  });
+
+  it("rejects issued asset with code exceeding 12 chars", async () => {
+    const response = await signPOST(
+      signRequest({
+        payee: "GPAYEE",
+        amount: "5.00",
+        asset: { code: "ABCDEFGHIJKLM", issuer: VALID_ISSUER },
+      }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(signMocks.signX402Payment).not.toHaveBeenCalled();
+  });
+
+  it("prefers asset.code over legacy assetCode when both provided", async () => {
+    const response = await signPOST(
+      signRequest({
+        payee: "GPAYEE",
+        amount: "5.00",
+        asset: { code: "USDC", issuer: VALID_ISSUER },
+        assetCode: "XLM",
+      }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    // asset.code ("USDC") should take precedence over legacy assetCode ("XLM")
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+  });
+
+  it("falls back to legacy assetCode when asset is omitted", async () => {
+    const response = await signPOST(
+      signRequest({ payee: "GPAYEE", amount: "5.00", assetCode: "USDC" }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+  });
+
+  it("defaults to USDC when both asset and assetCode are omitted", async () => {
+    const response = await signPOST(
+      signRequest({ payee: "GPAYEE", amount: "5.00" }) as never,
+      { params: Promise.resolve({ id: SIGN_ID }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(signMocks.signX402Payment).toHaveBeenCalledWith(
+      "test-secret-key",
+      expect.objectContaining({ assetCode: "USDC" }),
+    );
+  });
+});
+
+// ── Create Talos route tests for stellarAssetCode ──────────────────
+describe("POST /api/talos — stellarAssetCode pair tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const base = {
+    name: "Test Agent",
+    category: "Development",
+    description: "A test agent",
+    creatorPublicKey: "GCREATOR",
+    signature: "sig",
+    message: "msg",
+  };
+
+  it("accepts valid CODE:ISSUER format", () => {
+    const result = createTalosSchema.safeParse({
+      ...base,
+      stellarAssetCode: `MITOS:${VALID_ISSUER}`,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.stellarAssetCode).toBe(`MITOS:${VALID_ISSUER}`);
+    }
+  });
+
+  it("rejects CODE: with invalid checksum issuer", () => {
+    const result = createTalosSchema.safeParse({
+      ...base,
+      stellarAssetCode: `MITOS:${BAD_CHECKSUM_ISSUER}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null stellarAssetCode", () => {
+    const result = createTalosSchema.safeParse({
+      ...base,
+      stellarAssetCode: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects code-only without issuer", () => {
+    const result = createTalosSchema.safeParse({
+      ...base,
+      stellarAssetCode: "MITOS",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/web/tests/stellar-asset-schema.test.ts
+++ b/web/tests/stellar-asset-schema.test.ts
@@ -1,74 +1,174 @@
 import { describe, it, expect } from "vitest";
-import { stellarAssetSchema, stellarAssetCodeSchema, stellarPublicKeySchema } from "@/lib/schemas";
+import { Keypair } from "@stellar/stellar-sdk";
+import {
+  stellarAssetCodeSchema,
+  stellarPublicKeySchema,
+  stellarAssetSchema,
+  stellarNativeAssetSchema,
+  stellarIssuedAssetSchema,
+} from "@/lib/schemas";
 
-describe("Stellar Asset Schema", () => {
-  describe("stellarAssetCodeSchema", () => {
-    it("should accept valid asset codes", () => {
-      expect(stellarAssetCodeSchema.safeParse("XLM").success).toBe(true);
-      expect(stellarAssetCodeSchema.safeParse("USDC").success).toBe(true);
-      expect(stellarAssetCodeSchema.safeParse("ABC123").success).toBe(true);
-      expect(stellarAssetCodeSchema.safeParse("A").success).toBe(true);
-      expect(stellarAssetCodeSchema.safeParse("123456789012").success).toBe(true); // 12 chars
-    });
+const VALID_KEYPAIR = Keypair.random();
+const VALID_PUBLIC_KEY = VALID_KEYPAIR.publicKey();
 
-    it("should reject invalid asset codes", () => {
-      expect(stellarAssetCodeSchema.safeParse("").success).toBe(false);
-      expect(stellarAssetCodeSchema.safeParse("1234567890123").success).toBe(false); // 13 chars
-      expect(stellarAssetCodeSchema.safeParse("asset!code").success).toBe(false);
-      expect(stellarAssetCodeSchema.safeParse("asset code").success).toBe(false);
-      expect(stellarAssetCodeSchema.safeParse("asset_code").success).toBe(false);
-    });
+const OTHER_VALID_KEY = "GDN5AZ5KL6ZUN4W7SLRUXA3ZXCF4V6POZPV2QKDVDHM7QAN6R54IB3BV";
+
+describe("stellarAssetCodeSchema", () => {
+  it("accepts a valid 4-char asset code (USDC)", () => {
+    const result = stellarAssetCodeSchema.safeParse("USDC");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("USDC");
   });
 
-  describe("stellarPublicKeySchema", () => {
-    it("should accept valid Stellar public keys", () => {
-      expect(stellarPublicKeySchema.safeParse("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5").success).toBe(true);
-      expect(stellarPublicKeySchema.safeParse("GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN").success).toBe(true);
-    });
-
-    it("should reject invalid Stellar public keys", () => {
-      expect(stellarPublicKeySchema.safeParse("").success).toBe(false);
-      expect(stellarPublicKeySchema.safeParse("invalid").success).toBe(false);
-      expect(stellarPublicKeySchema.safeParse("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLAX").success).toBe(false); // Bad checksum
-    });
+  it("accepts a 1-char asset code (boundary minimum)", () => {
+    const result = stellarAssetCodeSchema.safeParse("X");
+    expect(result.success).toBe(true);
   });
 
-  describe("stellarAssetSchema", () => {
-    it("should accept native XLM asset", () => {
-      const result = stellarAssetSchema.safeParse({ type: "native" });
-      expect(result.success).toBe(true);
-    });
+  it("accepts a 12-char asset code (boundary maximum)", () => {
+    const result = stellarAssetCodeSchema.safeParse("ABCDEFGHIJKL");
+    expect(result.success).toBe(true);
+  });
 
-    it("should accept valid issued assets", () => {
-      const result = stellarAssetSchema.safeParse({
-        type: "issued",
-        code: "USDC",
-        issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-      });
-      expect(result.success).toBe(true);
-    });
+  it("rejects an empty asset code (boundary below min)", () => {
+    const result = stellarAssetCodeSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
 
-    it("should reject issued assets with invalid code", () => {
-      const result = stellarAssetSchema.safeParse({
-        type: "issued",
-        code: "",
-        issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-      });
-      expect(result.success).toBe(false);
-    });
+  it("rejects a 13-char asset code (boundary above max)", () => {
+    const result = stellarAssetCodeSchema.safeParse("ABCDEFGHIJKLM");
+    expect(result.success).toBe(false);
+  });
 
-    it("should reject issued assets with invalid issuer", () => {
-      const result = stellarAssetSchema.safeParse({
-        type: "issued",
-        code: "USDC",
-        issuer: "invalid",
-      });
-      expect(result.success).toBe(false);
-    });
+  it("rejects lowercase letters in asset code (malformed)", () => {
+    const result = stellarAssetCodeSchema.safeParse("usdc");
+    expect(result.success).toBe(false);
+  });
 
-    it("should reject assets with invalid type", () => {
-      const result = stellarAssetSchema.safeParse({ type: "invalid" });
-      expect(result.success).toBe(false);
+  it("rejects non-alphanumeric characters (malformed)", () => {
+    const result = stellarAssetCodeSchema.safeParse("USD-C");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an asset code containing only spaces (malformed)", () => {
+    const result = stellarAssetCodeSchema.safeParse("    ");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("stellarPublicKeySchema", () => {
+  it("accepts a valid freshly-generated Ed25519 public key", () => {
+    const result = stellarPublicKeySchema.safeParse(VALID_PUBLIC_KEY);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(VALID_PUBLIC_KEY);
+  });
+
+  it("accepts a well-known valid 56-char G-prefixed public key", () => {
+    const result = stellarPublicKeySchema.safeParse(OTHER_VALID_KEY);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a public key that does not start with G (malformed prefix)", () => {
+    const bad = "X" + VALID_PUBLIC_KEY.slice(1);
+    const result = stellarPublicKeySchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a short public key (boundary below 56 chars)", () => {
+    const result = stellarPublicKeySchema.safeParse("GSHORT");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a 56-char G-prefixed key with invalid CRC (malformed)", () => {
+    const bad =
+      VALID_PUBLIC_KEY.slice(0, -1) +
+      (VALID_PUBLIC_KEY.endsWith("A") ? "B" : "A");
+    const result = stellarPublicKeySchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string as public key (malformed)", () => {
+    const result = stellarPublicKeySchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("stellarNativeAssetSchema", () => {
+  it("accepts the native (XLM) asset descriptor", () => {
+    const result = stellarNativeAssetSchema.safeParse({ type: "native" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects native asset with extra fields beyond type", () => {
+    const result = stellarNativeAssetSchema.safeParse({
+      type: "native",
+      code: "XLM",
+    } as any);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("stellarIssuedAssetSchema", () => {
+  it("accepts an issued asset with valid code and issuer", () => {
+    const result = stellarIssuedAssetSchema.safeParse({
+      type: "issued",
+      code: "USDC",
+      issuer: VALID_PUBLIC_KEY,
     });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an issued asset with a malformed (lowercase) code", () => {
+    const result = stellarIssuedAssetSchema.safeParse({
+      type: "issued",
+      code: "usdc",
+      issuer: VALID_PUBLIC_KEY,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an issued asset with a malformed issuer public key", () => {
+    const result = stellarIssuedAssetSchema.safeParse({
+      type: "issued",
+      code: "USDC",
+      issuer: "GBADKEY",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("stellarAssetSchema (discriminated union)", () => {
+  it("accepts a native asset via the discriminated union", () => {
+    const result = stellarAssetSchema.safeParse({ type: "native" });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === "native") {
+      expect(result.data.type).toBe("native");
+    }
+  });
+
+  it("accepts an issued asset via the discriminated union", () => {
+    const result = stellarAssetSchema.safeParse({
+      type: "issued",
+      code: "MITOS",
+      issuer: OTHER_VALID_KEY,
+    });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === "issued") {
+      expect(result.data.code).toBe("MITOS");
+      expect(result.data.issuer).toBe(OTHER_VALID_KEY);
+    }
+  });
+
+  it("rejects an asset with an unknown discriminator type", () => {
+    const result = stellarAssetSchema.safeParse({ type: "erc20" } as any);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an issued asset missing the required issuer field", () => {
+    const result = stellarAssetSchema.safeParse({
+      type: "issued",
+      code: "USDC",
+    } as any);
+    expect(result.success).toBe(false);
   });
 });

--- a/web/tests/stellar-asset-schema.test.ts
+++ b/web/tests/stellar-asset-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { stellarAssetSchema, stellarAssetCodeSchema, stellarPublicKeySchema } from "@/lib/schemas";
+
+describe("Stellar Asset Schema", () => {
+  describe("stellarAssetCodeSchema", () => {
+    it("should accept valid asset codes", () => {
+      expect(stellarAssetCodeSchema.safeParse("XLM").success).toBe(true);
+      expect(stellarAssetCodeSchema.safeParse("USDC").success).toBe(true);
+      expect(stellarAssetCodeSchema.safeParse("ABC123").success).toBe(true);
+      expect(stellarAssetCodeSchema.safeParse("A").success).toBe(true);
+      expect(stellarAssetCodeSchema.safeParse("123456789012").success).toBe(true); // 12 chars
+    });
+
+    it("should reject invalid asset codes", () => {
+      expect(stellarAssetCodeSchema.safeParse("").success).toBe(false);
+      expect(stellarAssetCodeSchema.safeParse("1234567890123").success).toBe(false); // 13 chars
+      expect(stellarAssetCodeSchema.safeParse("asset!code").success).toBe(false);
+      expect(stellarAssetCodeSchema.safeParse("asset code").success).toBe(false);
+      expect(stellarAssetCodeSchema.safeParse("asset_code").success).toBe(false);
+    });
+  });
+
+  describe("stellarPublicKeySchema", () => {
+    it("should accept valid Stellar public keys", () => {
+      expect(stellarPublicKeySchema.safeParse("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5").success).toBe(true);
+      expect(stellarPublicKeySchema.safeParse("GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN").success).toBe(true);
+    });
+
+    it("should reject invalid Stellar public keys", () => {
+      expect(stellarPublicKeySchema.safeParse("").success).toBe(false);
+      expect(stellarPublicKeySchema.safeParse("invalid").success).toBe(false);
+      expect(stellarPublicKeySchema.safeParse("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLAX").success).toBe(false); // Bad checksum
+    });
+  });
+
+  describe("stellarAssetSchema", () => {
+    it("should accept native XLM asset", () => {
+      const result = stellarAssetSchema.safeParse({ type: "native" });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept valid issued assets", () => {
+      const result = stellarAssetSchema.safeParse({
+        type: "issued",
+        code: "USDC",
+        issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject issued assets with invalid code", () => {
+      const result = stellarAssetSchema.safeParse({
+        type: "issued",
+        code: "",
+        issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject issued assets with invalid issuer", () => {
+      const result = stellarAssetSchema.safeParse({
+        type: "issued",
+        code: "USDC",
+        issuer: "invalid",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject assets with invalid type", () => {
+      const result = stellarAssetSchema.safeParse({ type: "invalid" });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/web/tests/stellar-asset-schemas.test.ts
+++ b/web/tests/stellar-asset-schemas.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import {
+  stellarAssetSchema,
+  signPaymentSchema,
+  createTalosSchema,
+} from "../src/lib/schemas";
+
+// Real Stellar public keys with verified CRC16 checksums
+const VALID_ISSUER_A = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"; // testnet USDC
+const VALID_ISSUER_B = "GCEFRNTKTNYOS7QFQ7USU57N3NZZA65FXAVGA2WKFYJGKQZSM5WNAKRL"; // operator
+const VALID_ISSUER_C = "GDULUZ7WKON44PYY3FFMZBV3DPVBFWB32VAKSVSDIOECJPM4X2XR2BSG"; // random valid
+
+// ---------------------------------------------------------------------------
+// stellarAssetSchema — shared native / issued discriminated union
+// ---------------------------------------------------------------------------
+describe("stellarAssetSchema", () => {
+  describe("native (XLM)", () => {
+    it("accepts { native: true }", () => {
+      const result = stellarAssetSchema.safeParse({ native: true });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ native: true });
+    });
+
+    it("rejects { native: true, code: 'XLM' } — extra fields not allowed", () => {
+      const result = stellarAssetSchema.safeParse({ native: true, code: "XLM" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects { native: 'true' } — must be boolean literal", () => {
+      expect(stellarAssetSchema.safeParse({ native: "true" }).success).toBe(false);
+    });
+
+    it("rejects { native: 1 } — must be boolean literal", () => {
+      expect(stellarAssetSchema.safeParse({ native: 1 }).success).toBe(false);
+    });
+  });
+
+  describe("issued asset", () => {
+    it("accepts a valid code + valid issuer StrKey", () => {
+      const result = stellarAssetSchema.safeParse({
+        code: "USDC",
+        issuer: VALID_ISSUER_A,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ code: "USDC", issuer: VALID_ISSUER_A });
+      }
+    });
+
+    it("accepts a 12-character alphanumeric code (max length)", () => {
+      const result = stellarAssetSchema.safeParse({
+        code: "ABCDEFGHIJKL",
+        issuer: VALID_ISSUER_B,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a 1-character code (min length)", () => {
+      const result = stellarAssetSchema.safeParse({
+        code: "X",
+        issuer: VALID_ISSUER_C,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a numeric-only code", () => {
+      const result = stellarAssetSchema.safeParse({
+        code: "12345",
+        issuer: VALID_ISSUER_A,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects missing code", () => {
+      expect(
+        stellarAssetSchema.safeParse({ issuer: VALID_ISSUER_A }).success,
+      ).toBe(false);
+    });
+
+    it("rejects empty code", () => {
+      expect(
+        stellarAssetSchema.safeParse({ code: "", issuer: VALID_ISSUER_A }).success,
+      ).toBe(false);
+    });
+
+    it("rejects code longer than 12 characters", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "ABCDEFGHIJKLM", // 13 chars
+          issuer: VALID_ISSUER_A,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects lowercase code", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "usdc",
+          issuer: VALID_ISSUER_A,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects code with special characters", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "US-DC",
+          issuer: VALID_ISSUER_A,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects code with spaces", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "US DC",
+          issuer: VALID_ISSUER_A,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects missing issuer", () => {
+      expect(
+        stellarAssetSchema.safeParse({ code: "USDC" }).success,
+      ).toBe(false);
+    });
+
+    it("rejects issuer with wrong checksum", () => {
+      // Flip the last character to invalidate the CRC16
+      const badChecksum = VALID_ISSUER_A.slice(0, -1) + "A";
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: badChecksum,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects issuer that is too short", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3",
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects issuer that is too long", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: VALID_ISSUER_A + "A",
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects issuer that starts with S (seed key, not public)", () => {
+      // S... keys have version byte 0xb0; should be rejected for issuer use
+      const sdk = require("@stellar/stellar-sdk");
+      const secret = "SAZJ3JF6V5XVNELUCA7LMKUPE7LH6QV4YV4YV4YV4YV4YV4YV4YV";
+      // Build a valid-format secret key with correct checksum
+      const kp = sdk.Keypair.random();
+      const seed = kp.secret(); // starts with S
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: seed,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects issuer that is not a valid base32 string", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: "G0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0",
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects completely invalid issuer string", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          code: "USDC",
+          issuer: "not-a-stellar-key",
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects native + code/issuer together (discriminated union)", () => {
+      expect(
+        stellarAssetSchema.safeParse({
+          native: true,
+          code: "USDC",
+          issuer: VALID_ISSUER_A,
+        }).success,
+      ).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signPaymentSchema — now includes typed `asset` field
+// ---------------------------------------------------------------------------
+describe("signPaymentSchema", () => {
+  const base = { payee: "GABC", amount: "1.00" };
+
+  it("accepts with no asset (backward compat, defaults handled by route)", () => {
+    const result = signPaymentSchema.safeParse(base);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts with legacy assetCode string", () => {
+    const result = signPaymentSchema.safeParse({ ...base, assetCode: "USDC" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.assetCode).toBe("USDC");
+  });
+
+  it("accepts with typed native asset", () => {
+    const result = signPaymentSchema.safeParse({
+      ...base,
+      asset: { native: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.asset).toEqual({ native: true });
+  });
+
+  it("accepts with typed issued asset", () => {
+    const result = signPaymentSchema.safeParse({
+      ...base,
+      asset: { code: "USDC", issuer: VALID_ISSUER_A },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.asset).toEqual({
+        code: "USDC",
+        issuer: VALID_ISSUER_A,
+      });
+    }
+  });
+
+  it("rejects typed asset with invalid issuer checksum", () => {
+    const result = signPaymentSchema.safeParse({
+      ...base,
+      asset: { code: "USDC", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA6" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects typed asset with lowercase code", () => {
+    const result = signPaymentSchema.safeParse({
+      ...base,
+      asset: { code: "usdc", issuer: VALID_ISSUER_A },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts with both asset and legacy assetCode (asset takes precedence)", () => {
+    const result = signPaymentSchema.safeParse({
+      ...base,
+      asset: { code: "USDC", issuer: VALID_ISSUER_A },
+      assetCode: "XLM",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing payee", () => {
+    expect(signPaymentSchema.safeParse({ amount: "1.00" }).success).toBe(false);
+  });
+
+  it("rejects missing amount", () => {
+    expect(signPaymentSchema.safeParse({ payee: "GABC" }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTalosSchema — stellarAssetCode validation
+// ---------------------------------------------------------------------------
+describe("createTalosSchema — stellarAssetCode", () => {
+  const minimal = {
+    name: "Test Agent",
+    category: "Development",
+    description: "A test agent",
+    creatorPublicKey: "GABC",
+    signature: "sig",
+    message: "msg",
+  };
+
+  it("accepts null stellarAssetCode", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts omitted stellarAssetCode", () => {
+    const result = createTalosSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid CODE:ISSUER format", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: `MITOS:${VALID_ISSUER_A}`,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty string (treated as omitted)", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects code-only string (no issuer)", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: "MITOS",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CODE: with invalid issuer checksum", () => {
+    const badIssuer = VALID_ISSUER_A.slice(0, -1) + "A";
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: `MITOS:${badIssuer}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects lowercase code in CODE:ISSUER", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: `mitos:${VALID_ISSUER_A}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects code longer than 12 chars in CODE:ISSUER", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: `ABCDEFGHIJKLM:${VALID_ISSUER_A}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects code with special characters in CODE:ISSUER", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: `MI-TOS:${VALID_ISSUER_A}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects random non-matching string", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: "just-a-code",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CODE: with too-short issuer", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: "MITOS:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CODE: with non-base32 issuer", () => {
+    const result = createTalosSchema.safeParse({
+      ...minimal,
+      stellarAssetCode: "MITOS:G0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Close: #173
## Summary

Okay, let's summarize what we did:

1. Added imports from "@stellar/stellar-sdk" in web/src/lib/schemas.ts
2. Created shared Zod schemas:
   - stellarAssetCodeSchema: validates asset code length and character set
   - stellarPublicKeySchema: uses StrKey.isValidEd25519PublicKey from Stellar SDK
   - nativeAssetSchema: for XLM native assets
   - issuedAssetSchema: for issued assets with code and issuer
   - stellarAssetSchema: discriminated union for both types
3. Updated existing schemas to use the new validations:
   - signPaymentSchema: validates payee as stellarPublicKeySchema, assetCode with stellarAssetCodeSchema, added optional assetIssuer
   - createTalosSchema: validates stellarAssetCode with stellarAssetCodeSchema
4. Added test file web/tests/stellar-asset-schema.test.ts with boundary and malformed-input tests
## Related Issues

Closes #N (Replace N with the issue number, e.g. Closes #1)

## Test Plan

Detail the steps you took to test these changes.
- [ ] Automated tests run (e.g. `cargo test`, `uv run pytest`, `pnpm test:e2e`)
- [ ] Manual verification steps performed:
  - 1. ...
  - 2. ...
- [ ] Relevant docs updated when setup, environment variables, or workflows changed

## Visual Changes (if applicable)

For any user interface changes, please add screenshots or screen recordings showing:
- Before
- After

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [ ] My code follows the style guidelines of this project.
- [ ] I have updated `.env.example` files and documentation if I changed environment variables.
- [ ] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
