### PR TITLE
feat(web): standardise API error response envelope

### DIFF
--- a/web/src/app/api/activity/route.ts
+++ b/web/src/app/api/activity/route.ts
@@ -1,22 +1,27 @@
 import { fetchActivityStats, fetchActivityTransactions } from "./query";
+import { internalError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "25", 10) || 25, 1), 100);
-  const cursor = searchParams.get("cursor");
-  const statsOnly = searchParams.get("statsOnly") === "true";
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "25", 10) || 25, 1), 100);
+    const cursor = searchParams.get("cursor");
+    const statsOnly = searchParams.get("statsOnly") === "true";
 
-  if (statsOnly) {
-    const stats = await fetchActivityStats();
-    return Response.json({ stats });
+    if (statsOnly) {
+      const stats = await fetchActivityStats();
+      return Response.json({ stats });
+    }
+
+    const [stats, { transactions, nextCursor }] = await Promise.all([
+      fetchActivityStats(),
+      fetchActivityTransactions(limit, cursor),
+    ]);
+
+    return Response.json({ stats, transactions, nextCursor });
+  } catch {
+    return internalError(request);
   }
-
-  const [stats, { transactions, nextCursor }] = await Promise.all([
-    fetchActivityStats(),
-    fetchActivityTransactions(limit, cursor),
-  ]);
-
-  return Response.json({ stats, transactions, nextCursor });
 }

--- a/web/src/app/api/leaderboard/route.ts
+++ b/web/src/app/api/leaderboard/route.ts
@@ -2,11 +2,12 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPatrons, tlsActivities, tlsRevenues } from "@/db/schema";
 import { and, desc, eq, sql } from "drizzle-orm";
+import { badRequest, internalError } from "@/lib/api-response";
 
 // GET /api/leaderboard — Ranking data with cursor-based pagination
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = request.nextUrl;
+    const { searchParams } = new URL(request.url);
     const cursor = searchParams.get("cursor");
     const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 1), 100);
 
@@ -50,10 +51,10 @@ export async function GET(request: NextRequest) {
         ) {
           parsedCursor = decoded as [number, string];
         } else {
-          return Response.json({ error: "Invalid cursor format" }, { status: 400 });
+          return badRequest(request, "Invalid cursor format");
         }
       } catch {
-        return Response.json({ error: "Invalid cursor" }, { status: 400 });
+        return badRequest(request, "Invalid cursor");
       }
     }
 
@@ -112,6 +113,6 @@ export async function GET(request: NextRequest) {
 
     return Response.json({ data, nextCursor });
   } catch {
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return internalError(request);
   }
 }

--- a/web/src/app/api/proposals/route.ts
+++ b/web/src/app/api/proposals/route.ts
@@ -2,11 +2,12 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsApprovals, tlsTalos } from "@/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { internalError } from "@/lib/api-response";
 
 // GET /api/proposals — All proposals across all Talos, newest first
 // Optional ?status=pending|approved|rejected filter
 export async function GET(request: NextRequest) {
-  const status = request.nextUrl.searchParams.get("status");
+  const status = new URL(request.url).searchParams.get("status");
 
   try {
     const rows = await db
@@ -31,6 +32,6 @@ export async function GET(request: NextRequest) {
 
     return Response.json(rows);
   } catch {
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return internalError(request);
   }
 }

--- a/web/src/app/api/services/route.ts
+++ b/web/src/app/api/services/route.ts
@@ -2,11 +2,12 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsCommerceServices } from "@/db/schema";
 import { and, desc, eq, ilike, lt, ne, or } from "drizzle-orm";
+import { internalError } from "@/lib/api-response";
 
 // GET /api/services — Discover available services across all TALOS agents
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = request.nextUrl;
+    const { searchParams } = new URL(request.url);
     const category = searchParams.get("category");
     const selfId = searchParams.get("self");
     const cursor = searchParams.get("cursor");
@@ -86,6 +87,6 @@ export async function GET(request: NextRequest) {
 
     return Response.json({ data: results, nextCursor });
   } catch {
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return internalError(request);
   }
 }

--- a/web/src/app/api/talos/[id]/route.ts
+++ b/web/src/app/api/talos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { db } from "@/db";
 import { tlsTalos } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { internalError, notFound } from "@/lib/api-response";
 
 function maskApiKey(key: string | null): string | null {
   if (!key || key.length < 12) return null;
@@ -9,7 +10,7 @@ function maskApiKey(key: string | null): string | null {
 
 // GET /api/talos/:id — TALOS detail + configuration
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
@@ -27,12 +28,12 @@ export async function GET(
     });
 
     if (!talos) {
-      return Response.json({ error: "TALOS not found" }, { status: 404 });
+      return notFound(request, "TALOS not found");
     }
 
     const { apiKey, ...safeTalos } = talos;
     return Response.json({ ...safeTalos, apiKeyMasked: maskApiKey(apiKey) });
   } catch {
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return internalError(request);
   }
 }

--- a/web/src/app/api/talos/check-name/route.ts
+++ b/web/src/app/api/talos/check-name/route.ts
@@ -6,7 +6,7 @@ import { isNameAvailableOnChain } from "@/lib/soroban";
 
 // GET /api/talos/check-name?name=foo
 export async function GET(request: NextRequest) {
-  const name = request.nextUrl.searchParams.get("name")?.toLowerCase().trim();
+  const name = new URL(request.url).searchParams.get("name")?.toLowerCase().trim();
 
   if (!name || name.length < 3) {
     return Response.json({ available: false, reason: "Name must be at least 3 characters" });

--- a/web/src/app/api/talos/route.ts
+++ b/web/src/app/api/talos/route.ts
@@ -5,11 +5,12 @@ import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 import { randomBytes } from "crypto";
 import { createAgentKeypair, fundTestnetAccount, verifyStellarSignature } from "@/lib/stellar";
 import { createTalosSchema, parseBody } from "@/lib/schemas";
+import { badRequest, forbidden, internalError } from "@/lib/api-response";
 
 // GET /api/talos — List TALOS entries with cursor-based pagination
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = request.nextUrl;
+    const { searchParams } = new URL(request.url);
     const cursor = searchParams.get("cursor");
     const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 1), 100);
 
@@ -87,7 +88,7 @@ export async function GET(request: NextRequest) {
 
     return Response.json({ data, nextCursor });
   } catch {
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return internalError(request);
   }
 }
 
@@ -127,15 +128,15 @@ export async function POST(request: NextRequest) {
     // Message includes core immutable fields to prevent parameter tampering.
     const expectedMessage = `talos-genesis:${name}:${onChainId ?? "null"}:${supply}`;
     if (message !== expectedMessage) {
-      return Response.json(
-        { error: `Signature message must be exactly '${expectedMessage}'` },
-        { status: 400 },
+      return badRequest(
+        request,
+        `Signature message must be exactly '${expectedMessage}'`,
       );
     }
 
     const sigOk = await verifyStellarSignature(creatorPublicKey, message, signature);
     if (!sigOk) {
-      return Response.json({ error: "Invalid signature for creatorPublicKey" }, { status: 403 });
+      return forbidden(request, "Invalid signature for creatorPublicKey");
     }
 
     // Generate API key (tak_ prefix = TALOS API Key)
@@ -239,7 +240,6 @@ export async function POST(request: NextRequest) {
       detail: e?.detail,
       constraint: e?.constraint,
     }, null, 2));
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return Response.json({ error: message }, { status: 500 });
+    return internalError(request);
   }
 }

--- a/web/src/lib/api-response.ts
+++ b/web/src/lib/api-response.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared API response helpers.
+ *
+ * Every error returned by the bounded route set is shaped as:
+ *
+ *   { code: string; message: string; requestId: string; issues?: string[] }
+ *
+ * `code`      — machine-readable, stable identifier (e.g. "NOT_FOUND").
+ * `message`   — safe, human-readable description. Internal error details are
+ *               never forwarded to the client.
+ * `requestId` — echoed from the `x-request-id` request header, or a newly
+ *               generated UUID when the header is absent. Also set on the
+ *               response `x-request-id` header for log correlation.
+ * `issues`    — only present on validation errors (HTTP 400).
+ *
+ * Success responses are left unmodified (callers use `ok()` only for
+ * consistency; there is no mandatory success envelope so existing consumers
+ * are not broken).
+ */
+
+import { randomUUID } from "crypto";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ApiErrorBody {
+  code: string;
+  message: string;
+  requestId: string;
+  issues?: string[];
+}
+
+// ─── Request ID extraction ─────────────────────────────────────────────────
+
+/**
+ * Read the request ID from the incoming request header, or generate a fresh
+ * UUID if absent. Always returns a non-empty string.
+ */
+export function getRequestId(request: Request): string {
+  return request.headers.get("x-request-id") ?? randomUUID();
+}
+
+// ─── Error response factory ────────────────────────────────────────────────
+
+/**
+ * Build a standardised JSON error response.
+ *
+ * @param request  The incoming Request (used to echo the request ID).
+ * @param status   HTTP status code (e.g. 400, 404, 500).
+ * @param code     Stable machine-readable error code (SCREAMING_SNAKE_CASE).
+ * @param message  Safe human-readable message. Do NOT pass raw `err.message`
+ *                 here — use the pre-defined constants below instead.
+ * @param issues   Optional array of validation issue strings (400 only).
+ */
+export function errorResponse(
+  request: Request,
+  status: number,
+  code: string,
+  message: string,
+  issues?: string[],
+): Response {
+  const requestId = getRequestId(request);
+  const body: ApiErrorBody = { code, message, requestId };
+  if (issues && issues.length > 0) body.issues = issues;
+
+  return Response.json(body, {
+    status,
+    headers: { "x-request-id": requestId },
+  });
+}
+
+// ─── Convenience shorthands ────────────────────────────────────────────────
+
+/** 400 Bad Request — generic client error */
+export const badRequest = (req: Request, message = "Bad request") =>
+  errorResponse(req, 400, "BAD_REQUEST", message);
+
+/** 400 Bad Request — body is not valid JSON */
+export const invalidJson = (req: Request) =>
+  errorResponse(req, 400, "INVALID_JSON", "Invalid JSON body");
+
+/** 400 Bad Request — Zod schema validation failed */
+export const validationError = (req: Request, issues: string[]) =>
+  errorResponse(req, 400, "VALIDATION_ERROR", "Validation failed", issues);
+
+/** 401 Unauthorized — missing or malformed auth header */
+export const unauthorized = (req: Request, message = "Unauthorized") =>
+  errorResponse(req, 401, "UNAUTHORIZED", message);
+
+/** 403 Forbidden — authenticated but not allowed */
+export const forbidden = (req: Request, message = "Forbidden") =>
+  errorResponse(req, 403, "FORBIDDEN", message);
+
+/** 404 Not Found */
+export const notFound = (req: Request, message = "Not found") =>
+  errorResponse(req, 404, "NOT_FOUND", message);
+
+/** 500 Internal Server Error — never exposes internal detail */
+export const internalError = (req: Request) =>
+  errorResponse(req, 500, "INTERNAL_ERROR", "An unexpected error occurred");

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -85,22 +85,55 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
     schemas: {
       Error: {
         type: "object",
-        required: ["error"],
+        required: ["code", "message", "requestId"],
         properties: {
-          error: { type: "string", example: "TALOS not found" },
+          code: {
+            type: "string",
+            description: "Stable machine-readable error identifier.",
+            example: "NOT_FOUND",
+            enum: [
+              "BAD_REQUEST",
+              "INVALID_JSON",
+              "VALIDATION_ERROR",
+              "UNAUTHORIZED",
+              "FORBIDDEN",
+              "NOT_FOUND",
+              "INTERNAL_ERROR",
+            ],
+          },
+          message: {
+            type: "string",
+            description: "Safe human-readable description. Never contains internal stack traces.",
+            example: "TALOS not found",
+          },
+          requestId: {
+            type: "string",
+            description: "Echoed from the x-request-id request header, or a generated UUID. Use for log correlation.",
+            example: "550e8400-e29b-41d4-a716-446655440000",
+          },
         },
       },
       ValidationError: {
-        type: "object",
-        required: ["error", "issues"],
-        properties: {
-          error: { type: "string", example: "Validation failed" },
-          issues: {
-            type: "array",
-            items: { type: "string" },
-            example: ["name: String must contain at least 1 character(s)"],
+        allOf: [
+          { $ref: "#/components/schemas/Error" },
+          {
+            type: "object",
+            required: ["issues"],
+            properties: {
+              code: {
+                type: "string",
+                enum: ["VALIDATION_ERROR"],
+                example: "VALIDATION_ERROR",
+              },
+              issues: {
+                type: "array",
+                items: { type: "string" },
+                description: "Per-field validation failure messages.",
+                example: ["name: String must contain at least 1 character(s)"],
+              },
+            },
           },
-        },
+        ],
       },
       TalosListItem: {
         type: "object",
@@ -929,7 +962,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Rate limit exceeded" },
+            example: { code: "BAD_REQUEST", message: "Rate limit exceeded", requestId: "550e8400-e29b-41d4-a716-446655440000" },
           },
         },
       },
@@ -938,7 +971,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Missing Authorization header. Use: Bearer <api_key>" },
+            example: { code: "UNAUTHORIZED", message: "Missing Authorization header. Use: Bearer <api_key>", requestId: "550e8400-e29b-41d4-a716-446655440000" },
           },
         },
       },
@@ -947,7 +980,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Invalid API key" },
+            example: { code: "FORBIDDEN", message: "Invalid API key", requestId: "550e8400-e29b-41d4-a716-446655440000" },
           },
         },
       },
@@ -956,7 +989,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "TALOS not found" },
+            example: { code: "NOT_FOUND", message: "TALOS not found", requestId: "550e8400-e29b-41d4-a716-446655440000" },
           },
         },
       },
@@ -973,7 +1006,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Internal server error" },
+            example: { code: "INTERNAL_ERROR", message: "An unexpected error occurred", requestId: "550e8400-e29b-41d4-a716-446655440000" },
           },
         },
       },

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -217,29 +217,27 @@ export const createPlaybookSchema = z.object({
 /**
  * Parse and validate request body with a Zod schema.
  * Returns { data, error } — if error is set, return it as the Response.
+ *
+ * Error responses use the standardised envelope from @/lib/api-response
+ * so callers never need to import that module separately.
  */
 export async function parseBody<T extends z.ZodType>(
   request: Request,
   schema: T,
 ): Promise<{ data: z.infer<T>; error?: undefined } | { data?: undefined; error: Response }> {
+  const { invalidJson, validationError } = await import("@/lib/api-response");
+
   let raw: unknown;
   try {
     raw = await request.json();
   } catch {
-    return {
-      error: Response.json({ error: "Invalid JSON body" }, { status: 400 }),
-    };
+    return { error: invalidJson(request) };
   }
 
   const result = schema.safeParse(raw);
   if (!result.success) {
     const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`);
-    return {
-      error: Response.json(
-        { error: "Validation failed", issues },
-        { status: 400 },
-      ),
-    };
+    return { error: validationError(request, issues) };
   }
 
   return { data: result.data };

--- a/web/tests/api-error-envelope.test.ts
+++ b/web/tests/api-error-envelope.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Tests for the standardised API error response helpers (api-response.ts)
+ * and the bounded route set that uses them.
+ *
+ * Positive paths: success responses are untouched.
+ * Negative paths: every error response carries the envelope
+ *   { code, message, requestId } with no internal leakage.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Unit tests: api-response helpers ────────────────────────────────────────
+
+import {
+  getRequestId,
+  errorResponse,
+  badRequest,
+  invalidJson,
+  validationError,
+  unauthorized,
+  forbidden,
+  notFound,
+  internalError,
+} from "@/lib/api-response";
+
+function makeRequest(opts: { requestId?: string; url?: string } = {}): Request {
+  const url = opts.url ?? "http://localhost/api/test";
+  const headers: Record<string, string> = {};
+  if (opts.requestId) headers["x-request-id"] = opts.requestId;
+  return new Request(url, { headers });
+}
+
+describe("getRequestId()", () => {
+  it("echoes the x-request-id header when present", () => {
+    const req = makeRequest({ requestId: "my-req-id" });
+    expect(getRequestId(req)).toBe("my-req-id");
+  });
+
+  it("generates a UUID when the header is absent", () => {
+    const req = makeRequest();
+    const id = getRequestId(req);
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe("errorResponse()", () => {
+  it("returns a JSON response with the envelope shape", async () => {
+    const req = makeRequest({ requestId: "abc-123" });
+    const res = errorResponse(req, 404, "NOT_FOUND", "Thing not found");
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: "NOT_FOUND",
+      message: "Thing not found",
+      requestId: "abc-123",
+    });
+    expect(body).not.toHaveProperty("error");
+  });
+
+  it("echoes requestId in both body and response header", async () => {
+    const req = makeRequest({ requestId: "xyz-789" });
+    const res = errorResponse(req, 400, "BAD_REQUEST", "oops");
+
+    const body = await res.json();
+    expect(body.requestId).toBe("xyz-789");
+    expect(res.headers.get("x-request-id")).toBe("xyz-789");
+  });
+
+  it("includes issues array on validation errors", async () => {
+    const req = makeRequest();
+    const res = errorResponse(req, 400, "VALIDATION_ERROR", "Validation failed", [
+      "name: Required",
+      "category: Invalid",
+    ]);
+
+    const body = await res.json();
+    expect(body.issues).toEqual(["name: Required", "category: Invalid"]);
+  });
+
+  it("does not include issues when none are provided", async () => {
+    const req = makeRequest();
+    const res = errorResponse(req, 404, "NOT_FOUND", "Not found");
+    const body = await res.json();
+    expect(body).not.toHaveProperty("issues");
+  });
+
+  it("generates a requestId when header is absent", async () => {
+    const req = makeRequest();
+    const res = errorResponse(req, 500, "INTERNAL_ERROR", "An unexpected error occurred");
+    const body = await res.json();
+    expect(typeof body.requestId).toBe("string");
+    expect(body.requestId.length).toBeGreaterThan(0);
+  });
+});
+
+describe("convenience helpers", () => {
+  const req = makeRequest({ requestId: "test-id" });
+
+  it("badRequest → 400 BAD_REQUEST", async () => {
+    const res = badRequest(req, "bad thing");
+    expect(res.status).toBe(400);
+    const b = await res.json();
+    expect(b.code).toBe("BAD_REQUEST");
+    expect(b.message).toBe("bad thing");
+  });
+
+  it("invalidJson → 400 INVALID_JSON", async () => {
+    const res = invalidJson(req);
+    expect(res.status).toBe(400);
+    const b = await res.json();
+    expect(b.code).toBe("INVALID_JSON");
+  });
+
+  it("validationError → 400 VALIDATION_ERROR with issues", async () => {
+    const res = validationError(req, ["field: required"]);
+    expect(res.status).toBe(400);
+    const b = await res.json();
+    expect(b.code).toBe("VALIDATION_ERROR");
+    expect(b.issues).toEqual(["field: required"]);
+  });
+
+  it("unauthorized → 401 UNAUTHORIZED", async () => {
+    const res = unauthorized(req);
+    expect(res.status).toBe(401);
+    const b = await res.json();
+    expect(b.code).toBe("UNAUTHORIZED");
+  });
+
+  it("forbidden → 403 FORBIDDEN", async () => {
+    const res = forbidden(req);
+    expect(res.status).toBe(403);
+    const b = await res.json();
+    expect(b.code).toBe("FORBIDDEN");
+  });
+
+  it("notFound → 404 NOT_FOUND", async () => {
+    const res = notFound(req);
+    expect(res.status).toBe(404);
+    const b = await res.json();
+    expect(b.code).toBe("NOT_FOUND");
+  });
+
+  it("internalError → 500 INTERNAL_ERROR without leaking details", async () => {
+    const res = internalError(req);
+    expect(res.status).toBe(500);
+    const b = await res.json();
+    expect(b.code).toBe("INTERNAL_ERROR");
+    // Must not expose any internal detail
+    expect(b.message).not.toMatch(/stack|trace|sql|postgres/i);
+  });
+});
+
+// ─── Route-level tests ────────────────────────────────────────────────────────
+
+// Build a fully chainable mock that resolves to `rows` when .limit() or
+// .then() is invoked. Uses a Proxy so any method name in the chain is handled.
+function makeChainMock(rows: unknown[]) {
+  const handler: ProxyHandler<object> = {
+    get(_target, prop) {
+      if (prop === "limit") return vi.fn().mockResolvedValue(rows);
+      if (prop === "then") {
+        // Allow the chain itself to be awaited (e.g. proposals route)
+        return (resolve: (v: unknown) => unknown) =>
+          Promise.resolve(rows).then(resolve);
+      }
+      if (prop === "as") return vi.fn().mockReturnValue(proxy);
+      // Every other method returns the same proxy (supports any chain depth)
+      return () => proxy;
+    },
+  };
+  const proxy = new Proxy({}, handler);
+  return vi.fn().mockReturnValue(proxy);
+}
+
+function makeThrowMock(err: Error): ReturnType<typeof vi.fn> {
+  return vi.fn().mockImplementation(() => { throw err; });
+}
+
+// Activity query mocks live outside vi.mock so we can reference them in tests
+const mockFetchStats = vi.fn();
+const mockFetchTxns = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+    query: { tlsTalos: { findFirst: vi.fn() } },
+  },
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  createAgentKeypair: vi.fn(),
+  fundTestnetAccount: vi.fn(),
+  verifyStellarSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/soroban", () => ({
+  isNameAvailableOnChain: vi.fn(),
+}));
+
+vi.mock("@/app/api/activity/query", () => ({
+  fetchActivityStats: () => mockFetchStats(),
+  fetchActivityTransactions: (...args: unknown[]) => mockFetchTxns(...args),
+}));
+
+import { db } from "@/db";
+import { GET as getTalos } from "@/app/api/talos/route";
+import { GET as getTalosById } from "@/app/api/talos/[id]/route";
+import { GET as checkName } from "@/app/api/talos/check-name/route";
+import { GET as getServices } from "@/app/api/services/route";
+import { GET as getLeaderboard } from "@/app/api/leaderboard/route";
+import { GET as getActivity } from "@/app/api/activity/route";
+import { GET as getProposals } from "@/app/api/proposals/route";
+import { isNameAvailableOnChain } from "@/lib/soroban";
+
+// Helper: assert body conforms to error envelope
+async function assertErrorEnvelope(
+  res: Response,
+  expectedStatus: number,
+  expectedCode: string,
+) {
+  expect(res.status).toBe(expectedStatus);
+  const body = await res.json();
+  expect(body).toHaveProperty("code", expectedCode);
+  expect(body).toHaveProperty("message");
+  expect(typeof body.message).toBe("string");
+  expect(body).toHaveProperty("requestId");
+  expect(typeof body.requestId).toBe("string");
+  // Must not have the old "error" string field
+  expect(body).not.toHaveProperty("error");
+  return body;
+}
+
+// ── GET /api/talos ────────────────────────────────────────────────────────────
+
+describe("GET /api/talos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with data on success", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(makeChainMock([]));
+
+    const req = new Request("http://localhost/api/talos") as Parameters<typeof getTalos>[0];
+    const res = await getTalos(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+  });
+
+  it("returns 500 envelope on DB error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(
+      makeThrowMock(new Error("ECONNREFUSED — secret internal detail")),
+    );
+
+    const req = new Request("http://localhost/api/talos") as Parameters<typeof getTalos>[0];
+    const res = await getTalos(req);
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    // Must not leak the raw error message
+    expect(body.message).not.toContain("ECONNREFUSED");
+  });
+
+  it("echoes x-request-id in 500 envelope", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(
+      makeThrowMock(new Error("boom")),
+    );
+
+    const req = new Request("http://localhost/api/talos", {
+      headers: { "x-request-id": "my-rid" },
+    }) as Parameters<typeof getTalos>[0];
+    const res = await getTalos(req);
+    const body = await res.clone().json();
+    expect(body.requestId).toBe("my-rid");
+    expect(res.headers.get("x-request-id")).toBe("my-rid");
+  });
+});
+
+// ── GET /api/talos/:id ────────────────────────────────────────────────────────
+
+describe("GET /api/talos/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 envelope when TALOS is not found", async () => {
+    (db.query.tlsTalos.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const req = new Request("http://localhost/api/talos/nonexistent");
+    const params = Promise.resolve({ id: "nonexistent" });
+    const res = await getTalosById(req, { params });
+    await assertErrorEnvelope(res, 404, "NOT_FOUND");
+  });
+
+  it("returns 200 with masked apiKey on success", async () => {
+    (db.query.tlsTalos.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "t1",
+      name: "TestTalos",
+      apiKey: "tak_abcdefghijklmnop1234",
+      patrons: [],
+      activities: [],
+      approvals: [],
+      revenues: [],
+      commerceServices: [],
+    });
+
+    const req = new Request("http://localhost/api/talos/t1");
+    const params = Promise.resolve({ id: "t1" });
+    const res = await getTalosById(req, { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("apiKey");
+    expect(body).toHaveProperty("apiKeyMasked");
+  });
+
+  it("returns 500 envelope on DB error", async () => {
+    (db.query.tlsTalos.findFirst as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("db exploded — internal detail"),
+    );
+
+    const req = new Request("http://localhost/api/talos/t1");
+    const params = Promise.resolve({ id: "t1" });
+    const res = await getTalosById(req, { params });
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    expect(body.message).not.toContain("internal detail");
+  });
+});
+
+// ── GET /api/talos/check-name ─────────────────────────────────────────────────
+
+describe("GET /api/talos/check-name", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns { available: false, reason } for short names (no envelope)", async () => {
+    const req = new Request("http://localhost/api/talos/check-name?name=ab") as Parameters<typeof checkName>[0];
+    const res = await checkName(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.available).toBe(false);
+    expect(body.reason).toBeDefined();
+  });
+
+  it("returns { available: false, reason } for names taken in DB", async () => {
+    const selectMock = makeChainMock([{ id: "existing-id" }]);
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(selectMock);
+
+    const req = new Request("http://localhost/api/talos/check-name?name=taken") as Parameters<typeof checkName>[0];
+    const res = await checkName(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.available).toBe(false);
+  });
+
+  it("returns { available: true } for free names", async () => {
+    const selectMock = makeChainMock([]);
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(selectMock);
+    (isNameAvailableOnChain as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const req = new Request("http://localhost/api/talos/check-name?name=freename") as Parameters<typeof checkName>[0];
+    const res = await checkName(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.available).toBe(true);
+  });
+});
+
+// ── GET /api/services ─────────────────────────────────────────────────────────
+
+describe("GET /api/services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with data on success", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(makeChainMock([]));
+
+    const req = new Request("http://localhost/api/services") as Parameters<typeof getServices>[0];
+    const res = await getServices(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+  });
+
+  it("returns 500 envelope on DB error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(
+      makeThrowMock(new Error("pg: connection reset")),
+    );
+
+    const req = new Request("http://localhost/api/services") as Parameters<typeof getServices>[0];
+    const res = await getServices(req);
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    expect(body.message).not.toContain("pg:");
+  });
+});
+
+// ── GET /api/leaderboard ──────────────────────────────────────────────────────
+
+describe("GET /api/leaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with data on success", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(makeChainMock([]));
+
+    const req = new Request("http://localhost/api/leaderboard") as Parameters<typeof getLeaderboard>[0];
+    const res = await getLeaderboard(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+  });
+
+  it("returns 400 envelope on invalid cursor JSON shape", async () => {
+    // Valid base64 but wrong structure (not [number, string])
+    const badCursor = Buffer.from(JSON.stringify({ wrong: "shape" })).toString("base64");
+    const req = new Request(`http://localhost/api/leaderboard?cursor=${badCursor}`) as Parameters<typeof getLeaderboard>[0];
+    const res = await getLeaderboard(req);
+    await assertErrorEnvelope(res, 400, "BAD_REQUEST");
+  });
+
+  it("returns 400 envelope on malformed base64 cursor", async () => {
+    // "!!!" is not valid base64, Buffer.from decodes it as garbage → JSON.parse throws → badRequest
+    const req = new Request("http://localhost/api/leaderboard?cursor=!!!") as Parameters<typeof getLeaderboard>[0];
+    const res = await getLeaderboard(req);
+    // Should be 400 (bad cursor) from the catch in the cursor parsing block
+    expect([400, 500]).toContain(res.status);
+    const body = await res.json();
+    expect(body).toHaveProperty("code");
+    expect(body).toHaveProperty("requestId");
+  });
+
+  it("returns 500 envelope on DB error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(
+      makeThrowMock(new Error("db connection lost — secret")),
+    );
+
+    const req = new Request("http://localhost/api/leaderboard") as Parameters<typeof getLeaderboard>[0];
+    const res = await getLeaderboard(req);
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    expect(body.message).not.toContain("secret");
+  });
+});
+
+// ── GET /api/activity ─────────────────────────────────────────────────────────
+
+describe("GET /api/activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchStats.mockReset();
+    mockFetchTxns.mockReset();
+  });
+
+  it("returns 200 with stats and transactions on success", async () => {
+    mockFetchStats.mockResolvedValue({ total: 10 });
+    mockFetchTxns.mockResolvedValue({ transactions: [], nextCursor: null });
+
+    const req = new Request("http://localhost/api/activity");
+    const res = await getActivity(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("stats");
+    expect(body).toHaveProperty("transactions");
+  });
+
+  it("returns 200 with only stats when statsOnly=true", async () => {
+    mockFetchStats.mockResolvedValue({ total: 5 });
+
+    const req = new Request("http://localhost/api/activity?statsOnly=true");
+    const res = await getActivity(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("stats");
+    expect(body).not.toHaveProperty("transactions");
+  });
+
+  it("returns 500 envelope on fetchActivityStats error", async () => {
+    mockFetchStats.mockRejectedValue(new Error("DB secret detail"));
+
+    const req = new Request("http://localhost/api/activity");
+    const res = await getActivity(req);
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    expect(body.message).not.toContain("DB secret");
+  });
+});
+
+// ── GET /api/proposals ────────────────────────────────────────────────────────
+
+describe("GET /api/proposals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with rows on success", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(makeChainMock([]));
+
+    const req = new Request("http://localhost/api/proposals") as Parameters<typeof getProposals>[0];
+    const res = await getProposals(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it("returns 500 envelope on DB error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(
+      makeThrowMock(new Error("fatal db error — internal secret")),
+    );
+
+    const req = new Request("http://localhost/api/proposals") as Parameters<typeof getProposals>[0];
+    const res = await getProposals(req);
+    const body = await assertErrorEnvelope(res, 500, "INTERNAL_ERROR");
+    expect(body.message).not.toContain("internal secret");
+  });
+});
+
+// ─── parseBody integration ────────────────────────────────────────────────────
+
+import { z } from "zod/v4";
+import { parseBody } from "@/lib/schemas";
+
+describe("parseBody() with new envelope", () => {
+  it("returns INVALID_JSON error on non-JSON body", async () => {
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      body: "not json",
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const result = await parseBody(req, z.object({ name: z.string() }));
+    expect(result.error).toBeDefined();
+    const body = await result.error!.json();
+    expect(body.code).toBe("INVALID_JSON");
+    expect(body).toHaveProperty("requestId");
+    expect(body).not.toHaveProperty("error");
+  });
+
+  it("returns VALIDATION_ERROR with issues on schema mismatch", async () => {
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      body: JSON.stringify({ wrongField: 123 }),
+      headers: {
+        "Content-Type": "application/json",
+        "x-request-id": "parse-test",
+      },
+    });
+
+    const result = await parseBody(req, z.object({ name: z.string().min(1) }));
+    expect(result.error).toBeDefined();
+    const body = await result.error!.json();
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.requestId).toBe("parse-test");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("returns data on valid body", async () => {
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      body: JSON.stringify({ name: "hello" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const result = await parseBody(req, z.object({ name: z.string().min(1) }));
+    expect(result.error).toBeUndefined();
+    expect(result.data?.name).toBe("hello");
+  });
+});

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -76,36 +76,68 @@
       "Error": {
         "type": "object",
         "required": [
-          "error"
+          "code",
+          "message",
+          "requestId"
         ],
         "properties": {
-          "error": {
+          "code": {
             "type": "string",
+            "description": "Stable machine-readable error identifier.",
+            "example": "NOT_FOUND",
+            "enum": [
+              "BAD_REQUEST",
+              "INVALID_JSON",
+              "VALIDATION_ERROR",
+              "UNAUTHORIZED",
+              "FORBIDDEN",
+              "NOT_FOUND",
+              "INTERNAL_ERROR"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Safe human-readable description. Never contains internal stack traces.",
             "example": "TALOS not found"
+          },
+          "requestId": {
+            "type": "string",
+            "description": "Echoed from the x-request-id request header, or a generated UUID. Use for log correlation.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
           }
         }
       },
       "ValidationError": {
-        "type": "object",
-        "required": [
-          "error",
-          "issues"
-        ],
-        "properties": {
-          "error": {
-            "type": "string",
-            "example": "Validation failed"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
           },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": [
-              "name: String must contain at least 1 character(s)"
-            ]
+          {
+            "type": "object",
+            "required": [
+              "issues"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "VALIDATION_ERROR"
+                ],
+                "example": "VALIDATION_ERROR"
+              },
+              "issues": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Per-field validation failure messages.",
+                "example": [
+                  "name: String must contain at least 1 character(s)"
+                ]
+              }
+            }
           }
-        }
+        ]
       },
       "TalosListItem": {
         "type": "object",
@@ -2124,7 +2156,9 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Rate limit exceeded"
+              "code": "BAD_REQUEST",
+              "message": "Rate limit exceeded",
+              "requestId": "550e8400-e29b-41d4-a716-446655440000"
             }
           }
         }
@@ -2137,7 +2171,9 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Missing Authorization header. Use: Bearer <api_key>"
+              "code": "UNAUTHORIZED",
+              "message": "Missing Authorization header. Use: Bearer <api_key>",
+              "requestId": "550e8400-e29b-41d4-a716-446655440000"
             }
           }
         }
@@ -2150,7 +2186,9 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Invalid API key"
+              "code": "FORBIDDEN",
+              "message": "Invalid API key",
+              "requestId": "550e8400-e29b-41d4-a716-446655440000"
             }
           }
         }
@@ -2163,7 +2201,9 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "TALOS not found"
+              "code": "NOT_FOUND",
+              "message": "TALOS not found",
+              "requestId": "550e8400-e29b-41d4-a716-446655440000"
             }
           }
         }
@@ -2186,7 +2226,9 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Internal server error"
+              "code": "INTERNAL_ERROR",
+              "message": "An unexpected error occurred",
+              "requestId": "550e8400-e29b-41d4-a716-446655440000"
             }
           }
         }


### PR DESCRIPTION
 feat(web): standardise API error response envelope
  
  Summary
  
  API routes were returning inconsistent error shapes — some { error: string },
  some { error, issues[] }, some leaking raw err.message from internal
  exceptions. This PR introduces a single stable envelope for all errors on a
  bounded, documented route set.
  
  Error envelope
  
  Every error response from the affected routes now looks like:
  
  {
    "code": "NOT_FOUND",
    "message": "TALOS not found",
    "requestId": "550e8400-e29b-41d4-a716-446655440000"
  }
  
  - code — stable, machine-readable identifier (screaming snake case)
  - message — safe human-readable string; internal details are never forwarded
  - requestId — echoed from the x-request-id request header, or a generated UUID;
  also set on the response x-request-id header for log correlation
  - issues — only present on VALIDATION_ERROR (400) responses
  
  What changed
  
  web/src/lib/api-response.ts (new)
  Shared helpers: errorResponse() factory + seven shorthands — badRequest,
  invalidJson, validationError, unauthorized, forbidden, notFound, internalError.
  
  web/src/lib/schemas.ts
  
  parseBody() updated to emit INVALID_JSON and VALIDATION_ERROR envelopes with
  requestId.
  
  Bounded route set (8 routes)
  
  - GET/POST /api/talos
  - GET /api/talos/[id]
  - GET /api/talos/check-name
  - GET /api/services
  - GET /api/leaderboard
  - GET /api/activity
  - GET /api/proposals
  
  All catch blocks replaced with internalError(request). Signature/validation
  error paths use typed helpers. No raw err.message is ever forwarded to the
  client.
  
  web/src/lib/openapi.ts + snapshot
  
  Error and ValidationError schemas updated. All reusable response examples
  (RateLimitError, UnauthorizedError, ForbiddenError, NotFoundError,
  InternalError) updated to match the new shape.
  
  web/tests/api-error-envelope.test.ts (new, 37 tests)
  Unit tests covering all helpers and positive/negative paths for all eight
  bounded routes. Negative tests assert the envelope shape and verify no internal
  detail appears in 500 responses.
  
  Test evidence
  
  ✓ tests/api-error-envelope.test.ts   (37 tests)
  ✓ tests/health.test.ts               (4 tests)
  ✓ tests/openapi-snapshot.test.ts     (1 test)
  ✓ tests/rate-limit.test.ts           (2 tests)
  ✓ tests/dividends.test.ts            (7 tests)
  ✓ tests/cross-chain-webhook.unit.test.ts (4 tests)
  ✓ tests/sse.test.ts                  (8 tests)
  ✓ tests/approval-signature.test.ts   (2 tests)
  ✓ tests/soroban-read-only.test.ts    (1 test)
  
  66 / 66 unit tests passing. Pre-existing failures in api-e2e.test.ts and
  x402-e2e.test.ts require a live server and were failing on main before this PR.
  
  Out of scope
  
  No production deployment, no secret changes, no unrelated refactors. Routes
  outside the bounded set are unchanged.
  
  Closes #175
