### PR TITLE
feat(web): split health endpoint into liveness + readiness probes

### DIFF
--- a/web/src/app/api/health/live/route.ts
+++ b/web/src/app/api/health/live/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET /api/health/live — Liveness probe
+ *
+ * Answers the single question: "Is the Node.js process alive?"
+ * It performs NO external I/O — no DB query, no Horizon call.
+ *
+ * Use this probe for:
+ *   - Kubernetes livenessProbe (restart the container when this fails)
+ *   - Docker HEALTHCHECK as a cheap process-alive signal
+ *
+ * A liveness failure means the process itself is broken; the orchestrator
+ * should restart it.  Dependency failures belong in the readiness probe
+ * (GET /api/health/ready) and must NOT affect liveness.
+ *
+ * Response shape:
+ *   200  { status: "ok",   uptime: <seconds>, ts: <ISO-8601> }
+ *
+ * Headers:
+ *   Cache-Control: no-store   (never cache health responses)
+ */
+
+export const runtime = "nodejs";
+
+export function GET() {
+  return Response.json(
+    {
+      status: "ok",
+      uptime: Math.floor(process.uptime()),
+      ts: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}

--- a/web/src/app/api/health/ready/route.ts
+++ b/web/src/app/api/health/ready/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /api/health/ready — Readiness probe
+ *
+ * Answers: "Is the service ready to accept traffic?"
+ * Runs all dependency checks in parallel with bounded timeouts:
+ *   - db      SELECT 1 against Postgres           (2 s timeout)
+ *   - stellar GET to Stellar Horizon RPC           (3 s timeout)
+ *
+ * Use this probe for:
+ *   - Kubernetes readinessProbe (remove pod from load-balancer when degraded)
+ *   - UptimeRobot / Better Uptime monitoring (1-minute interval)
+ *
+ * A readiness failure means a dependency is down; the process stays alive
+ * but should not receive traffic.  The liveness probe (GET /api/health/live)
+ * is unaffected.
+ *
+ * Response shape:
+ *   200  { ok: true,  checks: { db: "ok",    stellar: "ok"    }, ts: <ISO> }
+ *   503  { ok: false, checks: { db: "error", stellar: "ok"    }, ts: <ISO> }
+ *
+ * Headers:
+ *   Cache-Control: no-store   (never cache health responses)
+ */
+
+import { db } from "@/db";
+import { sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import {
+  DEFAULT_HORIZON,
+  DB_TIMEOUT_MS,
+  STELLAR_TIMEOUT_MS,
+  withTimeout,
+} from "../utils";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const checks: { db: "ok" | "error"; stellar: "ok" | "error" } = {
+    db: "error",
+    stellar: "error",
+  };
+
+  await Promise.allSettled([
+    withTimeout(db.execute(sql`SELECT 1`), DB_TIMEOUT_MS).then(() => {
+      checks.db = "ok";
+    }),
+    withTimeout(
+      fetch(process.env.STELLAR_HORIZON_URL ?? DEFAULT_HORIZON).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      }),
+      STELLAR_TIMEOUT_MS,
+    ).then(() => {
+      checks.stellar = "ok";
+    }),
+  ]);
+
+  const ok = checks.db === "ok" && checks.stellar === "ok";
+
+  return NextResponse.json(
+    { ok, checks, ts: new Date().toISOString() },
+    {
+      status: ok ? 200 : 503,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,46 +1,12 @@
-import { db } from "@/db";
-import { sql } from "drizzle-orm";
-import { NextResponse } from "next/server";
+/**
+ * GET /api/health — Backward-compatible alias for the readiness probe.
+ *
+ * Delegates to GET /api/health/ready.  Existing monitors wired to this
+ * URL continue to work without reconfiguration.
+ *
+ * Prefer the explicit sub-paths for new integrations:
+ *   GET /api/health/live   — liveness  (process alive, no I/O)
+ *   GET /api/health/ready  — readiness (DB + Stellar checks)
+ */
 
-export const runtime = "nodejs";
-
-const DEFAULT_HORIZON = "https://horizon-testnet.stellar.org";
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timerId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timerId = setTimeout(() => reject(new Error("timeout")), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timerId));
-}
-
-export async function GET() {
-  const checks: { db: "ok" | "error"; stellar: "ok" | "error" } = {
-    db: "error",
-    stellar: "error",
-  };
-
-  await Promise.allSettled([
-    withTimeout(db.execute(sql`SELECT 1`), 2000).then(() => {
-      checks.db = "ok";
-    }),
-    withTimeout(
-      fetch(process.env.STELLAR_HORIZON_URL ?? DEFAULT_HORIZON).then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      }),
-      3000,
-    ).then(() => {
-      checks.stellar = "ok";
-    }),
-  ]);
-
-  const ok = checks.db === "ok" && checks.stellar === "ok";
-
-  return NextResponse.json(
-    { ok, checks, ts: new Date().toISOString() },
-    {
-      status: ok ? 200 : 503,
-      headers: { "Cache-Control": "no-store" },
-    },
-  );
-}
+export { runtime, GET } from "./ready/route";

--- a/web/src/app/api/health/utils.ts
+++ b/web/src/app/api/health/utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared utilities for health probe routes.
+ *
+ * withTimeout wraps any promise and rejects after `ms` milliseconds.
+ * It clears its own timer on both resolution and rejection so it never
+ * leaks a dangling timer handle.
+ */
+
+export const DEFAULT_HORIZON = "https://horizon-testnet.stellar.org";
+
+/** DB check timeout — 2 s */
+export const DB_TIMEOUT_MS = 2_000;
+
+/** Stellar Horizon check timeout — 3 s */
+export const STELLAR_TIMEOUT_MS = 3_000;
+
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timerId = setTimeout(() => reject(new Error("timeout")), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timerId));
+}

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -83,6 +83,22 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
     },
     schemas: {
+      HealthStatus: {
+        type: "object",
+        required: ["ok", "checks", "ts"],
+        properties: {
+          ok: { type: "boolean", description: "True when all dependency checks pass", example: true },
+          checks: {
+            type: "object",
+            required: ["db", "stellar"],
+            properties: {
+              db: { type: "string", enum: ["ok", "error"], example: "ok" },
+              stellar: { type: "string", enum: ["ok", "error"], example: "ok" },
+            },
+          },
+          ts: { type: "string", format: "date-time", example: "2026-07-23T19:00:00.000Z" },
+        },
+      },
       Error: {
         type: "object",
         required: ["error"],
@@ -2853,6 +2869,112 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
             },
           },
           "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    // ─── HEALTH ───────────────────────────────────────────────────────
+    "/api/health/live": {
+      get: {
+        tags: ["Platform"],
+        summary: "Liveness probe",
+        description: `Returns 200 immediately if the Node.js process is running.
+
+Performs **no external I/O** — no database query, no Stellar Horizon call.
+
+Use for:
+- Kubernetes \`livenessProbe\` — restart the container when this fails.
+- Docker \`HEALTHCHECK\` — cheap process-alive signal.
+
+A failure here means the process itself is broken; the orchestrator should restart it. Dependency failures belong in the readiness probe.`,
+        operationId: "getLiveness",
+        responses: {
+          "200": {
+            description: "Process is alive",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["status", "uptime", "ts"],
+                  properties: {
+                    status: { type: "string", enum: ["ok"], example: "ok" },
+                    uptime: { type: "integer", description: "Process uptime in seconds", example: 3600 },
+                    ts: { type: "string", format: "date-time", example: "2026-07-23T19:00:00.000Z" },
+                  },
+                },
+                example: { status: "ok", uptime: 3600, ts: "2026-07-23T19:00:00.000Z" },
+              },
+            },
+            headers: {
+              "Cache-Control": { schema: { type: "string", enum: ["no-store"] } },
+            },
+          },
+        },
+      },
+    },
+    "/api/health/ready": {
+      get: {
+        tags: ["Platform"],
+        summary: "Readiness probe",
+        description: `Returns 200 when all dependencies are reachable, 503 when any check fails.
+
+Checks run **in parallel** with bounded timeouts:
+- \`db\` — \`SELECT 1\` against Postgres (2 s timeout)
+- \`stellar\` — \`GET\` to Stellar Horizon (\`STELLAR_HORIZON_URL\` env var, or testnet fallback) (3 s timeout)
+
+Use for:
+- Kubernetes \`readinessProbe\` — remove the pod from the load-balancer when degraded.
+- UptimeRobot / Better Uptime monitoring on a 1-minute interval.
+
+The liveness probe (\`GET /api/health/live\`) is unaffected by dependency failures.`,
+        operationId: "getReadiness",
+        responses: {
+          "200": {
+            description: "All dependencies reachable",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthStatus" },
+                example: { ok: true, checks: { db: "ok", stellar: "ok" }, ts: "2026-07-23T19:00:00.000Z" },
+              },
+            },
+            headers: {
+              "Cache-Control": { schema: { type: "string", enum: ["no-store"] } },
+            },
+          },
+          "503": {
+            description: "One or more dependencies unreachable",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthStatus" },
+                example: { ok: false, checks: { db: "error", stellar: "ok" }, ts: "2026-07-23T19:00:00.000Z" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/health": {
+      get: {
+        tags: ["Platform"],
+        summary: "Health check (legacy alias)",
+        description: "Backward-compatible alias for `GET /api/health/ready`. Existing monitors wired to this URL continue to work. Prefer the explicit sub-paths for new integrations.",
+        operationId: "getHealth",
+        responses: {
+          "200": {
+            description: "All dependencies reachable",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthStatus" },
+              },
+            },
+          },
+          "503": {
+            description: "One or more dependencies unreachable",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthStatus" },
+              },
+            },
+          },
         },
       },
     },

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -73,6 +73,51 @@
       }
     },
     "schemas": {
+      "HealthStatus": {
+        "type": "object",
+        "required": [
+          "ok",
+          "checks",
+          "ts"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "description": "True when all dependency checks pass",
+            "example": true
+          },
+          "checks": {
+            "type": "object",
+            "required": [
+              "db",
+              "stellar"
+            ],
+            "properties": {
+              "db": {
+                "type": "string",
+                "enum": [
+                  "ok",
+                  "error"
+                ],
+                "example": "ok"
+              },
+              "stellar": {
+                "type": "string",
+                "enum": [
+                  "ok",
+                  "error"
+                ],
+                "example": "ok"
+              }
+            }
+          },
+          "ts": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-07-23T19:00:00.000Z"
+          }
+        }
+      },
       "Error": {
         "type": "object",
         "required": [
@@ -5169,6 +5214,157 @@
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/health/live": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Liveness probe",
+        "description": "Returns 200 immediately if the Node.js process is running.\n\nPerforms **no external I/O** — no database query, no Stellar Horizon call.\n\nUse for:\n- Kubernetes `livenessProbe` — restart the container when this fails.\n- Docker `HEALTHCHECK` — cheap process-alive signal.\n\nA failure here means the process itself is broken; the orchestrator should restart it. Dependency failures belong in the readiness probe.",
+        "operationId": "getLiveness",
+        "responses": {
+          "200": {
+            "description": "Process is alive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "uptime",
+                    "ts"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ],
+                      "example": "ok"
+                    },
+                    "uptime": {
+                      "type": "integer",
+                      "description": "Process uptime in seconds",
+                      "example": 3600
+                    },
+                    "ts": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2026-07-23T19:00:00.000Z"
+                    }
+                  }
+                },
+                "example": {
+                  "status": "ok",
+                  "uptime": 3600,
+                  "ts": "2026-07-23T19:00:00.000Z"
+                }
+              }
+            },
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "no-store"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health/ready": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Readiness probe",
+        "description": "Returns 200 when all dependencies are reachable, 503 when any check fails.\n\nChecks run **in parallel** with bounded timeouts:\n- `db` — `SELECT 1` against Postgres (2 s timeout)\n- `stellar` — `GET` to Stellar Horizon (`STELLAR_HORIZON_URL` env var, or testnet fallback) (3 s timeout)\n\nUse for:\n- Kubernetes `readinessProbe` — remove the pod from the load-balancer when degraded.\n- UptimeRobot / Better Uptime monitoring on a 1-minute interval.\n\nThe liveness probe (`GET /api/health/live`) is unaffected by dependency failures.",
+        "operationId": "getReadiness",
+        "responses": {
+          "200": {
+            "description": "All dependencies reachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                },
+                "example": {
+                  "ok": true,
+                  "checks": {
+                    "db": "ok",
+                    "stellar": "ok"
+                  },
+                  "ts": "2026-07-23T19:00:00.000Z"
+                }
+              }
+            },
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "no-store"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "One or more dependencies unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                },
+                "example": {
+                  "ok": false,
+                  "checks": {
+                    "db": "error",
+                    "stellar": "ok"
+                  },
+                  "ts": "2026-07-23T19:00:00.000Z"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Health check (legacy alias)",
+        "description": "Backward-compatible alias for `GET /api/health/ready`. Existing monitors wired to this URL continue to work. Prefer the explicit sub-paths for new integrations.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "All dependencies reachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "One or more dependencies unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
           }
         }
       }

--- a/web/tests/health.test.ts
+++ b/web/tests/health.test.ts
@@ -1,15 +1,63 @@
+/**
+ * Tests for GET /api/health/live (liveness probe) and
+ * GET /api/health/ready (readiness probe).
+ *
+ * Coverage:
+ *   - Liveness: always 200, correct shape, no external I/O
+ *   - Readiness: healthy (both deps ok), degraded (one dep down),
+ *                unavailable (both deps down), timeout behaviour,
+ *                Cache-Control header, backward-compat alias
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Liveness probe ───────────────────────────────────────────────────────────
+
+import { GET as getLive } from "@/app/api/health/live/route";
+
+describe("GET /api/health/live", () => {
+  it("returns 200 with status=ok", async () => {
+    const res = getLive();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  it("includes uptime (non-negative integer) and ts (ISO string)", async () => {
+    const res = getLive();
+    const body = await res.json();
+    expect(typeof body.uptime).toBe("number");
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(body.uptime)).toBe(true);
+    expect(typeof body.ts).toBe("string");
+    expect(() => new Date(body.ts)).not.toThrow();
+  });
+
+  it("sets Cache-Control: no-store", () => {
+    const res = getLive();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("never calls fetch or any external service", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    getLive();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── Readiness probe ──────────────────────────────────────────────────────────
 
 vi.mock("@/db", () => ({
   db: { execute: vi.fn() },
 }));
 
-import { GET } from "@/app/api/health/route";
+import { GET as getReady } from "@/app/api/health/ready/route";
 import { db } from "@/db";
 
 const mockExecute = db.execute as ReturnType<typeof vi.fn>;
 
-describe("GET /api/health", () => {
+describe("GET /api/health/ready", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
   });
@@ -19,13 +67,15 @@ describe("GET /api/health", () => {
     vi.clearAllMocks();
   });
 
-  it("returns 200 with ok=true when both checks pass", async () => {
+  // ── Healthy ────────────────────────────────────────────────────────
+
+  it("returns 200 with ok=true when both deps pass", async () => {
     mockExecute.mockResolvedValue([]);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Response(null, { status: 200 }),
     );
 
-    const res = await GET();
+    const res = await getReady();
 
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -35,13 +85,15 @@ describe("GET /api/health", () => {
     expect(typeof body.ts).toBe("string");
   });
 
+  // ── Degraded — one dep down ────────────────────────────────────────
+
   it("returns 503 with checks.db=error when DB is down", async () => {
     mockExecute.mockRejectedValue(new Error("ECONNREFUSED"));
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Response(null, { status: 200 }),
     );
 
-    const res = await GET();
+    const res = await getReady();
 
     expect(res.status).toBe(503);
     const body = await res.json();
@@ -56,7 +108,7 @@ describe("GET /api/health", () => {
       new Error("fetch failed"),
     );
 
-    const res = await GET();
+    const res = await getReady();
 
     expect(res.status).toBe(503);
     const body = await res.json();
@@ -65,14 +117,138 @@ describe("GET /api/health", () => {
     expect(body.checks.stellar).toBe("error");
   });
 
-  it("sets Cache-Control: no-store on all responses", async () => {
+  it("returns 503 with checks.stellar=error when Horizon returns non-2xx", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+
+    const res = await getReady();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.stellar).toBe("error");
+  });
+
+  // ── Unavailable — both deps down ───────────────────────────────────
+
+  it("returns 503 with both checks=error when all deps are down", async () => {
+    mockExecute.mockRejectedValue(new Error("DB offline"));
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("network error"),
+    );
+
+    const res = await getReady();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.db).toBe("error");
+    expect(body.checks.stellar).toBe("error");
+  });
+
+  // ── Timeout behaviour ──────────────────────────────────────────────
+
+  it("returns 503 when DB check times out", async () => {
+    // Never resolves — simulates a hung DB
+    mockExecute.mockReturnValue(new Promise(() => {}));
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await getReady();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.checks.db).toBe("error");
+    expect(body.checks.stellar).toBe("ok");
+  }, 10_000);
+
+  it("returns 503 when Stellar check times out", async () => {
+    mockExecute.mockResolvedValue([]);
+    // Never resolves — simulates a hung Horizon
+    (fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+    const res = await getReady();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.checks.db).toBe("ok");
+    expect(body.checks.stellar).toBe("error");
+  }, 10_000);
+
+  // ── Headers ────────────────────────────────────────────────────────
+
+  it("sets Cache-Control: no-store on 200", async () => {
     mockExecute.mockResolvedValue([]);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Response(null, { status: 200 }),
     );
 
-    const res = await GET();
+    const res = await getReady();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
 
+  it("sets Cache-Control: no-store on 503", async () => {
+    mockExecute.mockRejectedValue(new Error("down"));
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("down"));
+
+    const res = await getReady();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});
+
+// ─── Backward-compat alias /api/health ───────────────────────────────────────
+
+import { GET as getLegacy } from "@/app/api/health/route";
+
+describe("GET /api/health (legacy alias)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with ok=true when both deps pass (same behaviour as /ready)", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await getLegacy();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.checks.db).toBe("ok");
+    expect(body.checks.stellar).toBe("ok");
+  });
+
+  it("returns 503 when DB is down (same behaviour as /ready)", async () => {
+    mockExecute.mockRejectedValue(new Error("ECONNREFUSED"));
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await getLegacy();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.db).toBe("error");
+  });
+
+  it("sets Cache-Control: no-store", async () => {
+    mockExecute.mockResolvedValue([]);
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    const res = await getLegacy();
     expect(res.headers.get("cache-control")).toBe("no-store");
   });
 });


### PR DESCRIPTION
feat(web): split health endpoint into liveness + readiness probes
  
  Summary
  
  A single dependency-aware health endpoint cannot distinguish a running process
  from a service ready to receive traffic. This PR introduces two explicit
  sub-paths and keeps the existing URL as a backward-compatible alias so no
  existing monitors break.
  
  New endpoints
  
  GET /api/health/live — Liveness probe
  
  Answers: "Is the Node.js process alive?"
  
  - Performs no external I/O — no DB query, no Stellar Horizon call
  - Always returns 200 as long as the process is running
  - Use for Kubernetes livenessProbe or Docker HEALTHCHECK
  
  200 OK
  { "status": "ok", "uptime": 3600, "ts": "2026-07-23T19:00:00.000Z" }
  
  GET /api/health/ready — Readiness probe
  
  Answers: "Is the service ready to accept traffic?"
  
  - Runs DB (SELECT 1, 2 s timeout) and Stellar Horizon (GET, 3 s timeout) checks
  in parallel
  - Returns 200 when both pass, 503 when either fails
  - Use for Kubernetes readinessProbe and uptime monitors (UptimeRobot, Better
  Uptime)
  
  // 200 — all deps reachable
  { "ok": true,  "checks": { "db": "ok",    "stellar": "ok"    }, "ts": "..." }
  
  // 503 — one or more deps down
  { "ok": false, "checks": { "db": "error", "stellar": "ok"    }, "ts": "..." }
  
  GET /api/health — Backward-compatible alias
  
  Re-exports the readiness probe. Existing monitors wired to this URL continue to
  work without reconfiguration.
  
  Deployment usage
  
  Kubernetes
  
  livenessProbe:
    httpGet:
      path: /api/health/live
      port: 3000
    initialDelaySeconds: 5
    periodSeconds: 10
  
  readinessProbe:
    httpGet:
      path: /api/health/ready
      port: 3000
    initialDelaySeconds: 10
    periodSeconds: 15
    failureThreshold: 3
  
  Docker
  
  HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
    CMD curl -sf http://localhost:3000/api/health/live || exit 1
  
  Uptime monitors — point to /api/health/ready on a 1-minute interval with alert
  on non-200.
  
  What changed
  
  web/src/app/api/health/utils.ts (new)
  Shared withTimeout<T>() helper, DEFAULT_HORIZON, DB_TIMEOUT_MS (2 s),
  STELLAR_TIMEOUT_MS (3 s). Extracted so both the existing alias and the new
  ready route share identical timeout behaviour.
  
  web/src/app/api/health/live/route.ts (new)
  Pure synchronous probe. Reads process.uptime(), never calls fetch or the DB.
  
  web/src/app/api/health/ready/route.ts (new)
  Full dependency probe — direct extraction of the original route logic, now
  importing from utils.ts.
  
  web/src/app/api/health/route.ts (updated)
  Single re-export: export { runtime, GET } from "./ready/route". Zero logic
  duplication.
  
  web/src/lib/openapi.ts + snapshot (updated)
  Added HealthStatus component schema and three new documented paths:
  /api/health/live, /api/health/ready, /api/health (legacy alias). All responses
  include Cache-Control: no-store header documentation.
  
  Test evidence
  
  ✓ tests/health.test.ts  (16 tests)
  
    GET /api/health/live
      ✓ returns 200 with status=ok
      ✓ includes uptime (non-negative integer) and ts (ISO string)
      ✓ sets Cache-Control: no-store
      ✓ never calls fetch or any external service
  
    GET /api/health/ready
      ✓ returns 200 with ok=true when both deps pass         (healthy)
      ✓ returns 503 with checks.db=error when DB is down     (degraded)
      ✓ returns 503 with checks.stellar=error when Stellar unreachable
      ✓ returns 503 with checks.stellar=error on non-2xx Horizon response
      ✓ returns 503 with both checks=error when all deps down (unavailable)
      ✓ returns 503 when DB check times out                   (timeout)
      ✓ returns 503 when Stellar check times out
      ✓ sets Cache-Control: no-store on 200
      ✓ sets Cache-Control: no-store on 503
  
    GET /api/health (legacy alias)
      ✓ returns 200 when both deps pass
      ✓ returns 503 when DB is down
      ✓ sets Cache-Control: no-store
  
  All 17 other unit tests (openapi snapshot, rate-limit, api-error-envelope,
  dividends, sse, etc.) continue to pass — 78/78 total.
  
  Out of scope
  
  No production deployment, no secret changes, no unrelated refactors. Routes
  outside the health directory are unchanged.
  
  Closes #179
