### PR TITLE
Security (web) bind transfer FIX

### DIFF
--- a/web/src/app/api/talos/[id]/transfer/route.ts
+++ b/web/src/app/api/talos/[id]/transfer/route.ts
@@ -5,11 +5,16 @@ import { eq } from "drizzle-orm";
 import { verifyAgentApiKey } from "@/lib/auth";
 import { sendUSDC } from "@/lib/stellar";
 import { transferSchema, parseBody } from "@/lib/schemas";
+import {
+  consumeTransferNonce,
+  verifyTransferSignature,
+  type TransferSignedPayload,
+} from "@/lib/transfer-signature";
 
-// POST /api/talos/:id/transfer — Execute USDC transfer on Stellar
+// POST /api/talos/:id/transfer — Execute a signed USDC transfer on Stellar
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
 
@@ -20,9 +25,49 @@ export async function POST(
     const parsed = await parseBody(request, transferSchema);
     if (parsed.error) return parsed.error;
 
-    const { to, amount } = parsed.data;
+    const { agent, destination, asset, amount, nonce, expiry, signature } =
+      parsed.data;
 
-    // Check approval threshold
+    // The path is authoritative. Requiring the same agent in the signed body
+    // prevents a valid authorization from crossing agent boundaries.
+    if (agent !== id) {
+      return Response.json(
+        { error: "Signed transfer agent does not match the target TALOS" },
+        { status: 400 },
+      );
+    }
+
+    const signedPayload: TransferSignedPayload = {
+      agent,
+      destination,
+      asset,
+      amount,
+      nonce,
+      expiry,
+    };
+
+    // Reconstruct and verify the exact canonical payload. No caller-supplied
+    // message is accepted, so recipient/asset/amount substitutions invalidate
+    // the signature before any transfer is created.
+    if (
+      !verifyTransferSignature(signedPayload, auth.talos.apiKey!, signature)
+    ) {
+      return Response.json(
+        { error: "Invalid transfer signature" },
+        { status: 403 },
+      );
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const expirySeconds = Number(expiry);
+    if (expirySeconds <= nowSeconds) {
+      return Response.json(
+        { error: "Transfer authorization has expired" },
+        { status: 403 },
+      );
+    }
+
+    // Check approval threshold before consuming the one-time authorization.
     const talos = await db
       .select({ approvalThreshold: tlsTalos.approvalThreshold })
       .from(tlsTalos)
@@ -30,31 +75,56 @@ export async function POST(
       .limit(1)
       .then((r) => r[0] ?? null);
 
-    if (talos && amount > Number(talos.approvalThreshold)) {
+    const amountValue = Number(amount);
+    if (talos && amountValue > Number(talos.approvalThreshold)) {
       return Response.json(
         {
-          error: "Amount exceeds approval threshold. Create an approval request first.",
+          error:
+            "Amount exceeds approval threshold. Create an approval request first.",
           amount,
           threshold: Number(talos.approvalThreshold),
         },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
-    // Agent secret key lives server-side only
+    // Agent secret key lives server-side only.
     const agentSecret = process.env[`TALOS_AGENT_SECRET_${id}`];
     if (!agentSecret) {
       return Response.json(
         { error: "Agent secret key not configured for this TALOS" },
-        { status: 503 }
+        { status: 503 },
       );
     }
 
-    const result = await sendUSDC(agentSecret, to, String(amount));
+    // Consume immediately before the first money-moving side effect. The
+    // synchronous guard prevents two requests in this process from using the
+    // same signed nonce concurrently.
+    const nonceResult = consumeTransferNonce(signedPayload, nowSeconds);
+    if (!nonceResult.ok) {
+      if (nonceResult.reason === "replayed") {
+        return Response.json(
+          { error: "Transfer authorization already used (replay detected)" },
+          { status: 409 },
+        );
+      }
+
+      return Response.json(
+        {
+          error:
+            nonceResult.reason === "expiry-too-far"
+              ? "Transfer authorization expiry exceeds the five-minute limit"
+              : "Transfer authorization has expired",
+        },
+        { status: 403 },
+      );
+    }
+
+    const result = await sendUSDC(agentSecret, destination, amount);
     return Response.json({
       status: "completed",
-      currency: "USDC",
-      to,
+      currency: asset,
+      to: destination,
       amount,
       txHash: result.txHash,
     });

--- a/web/src/app/api/talos/[id]/transfer/route.ts
+++ b/web/src/app/api/talos/[id]/transfer/route.ts
@@ -14,7 +14,7 @@ import {
 // POST /api/talos/:id/transfer — Execute a signed USDC transfer on Stellar
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
 
@@ -25,8 +25,15 @@ export async function POST(
     const parsed = await parseBody(request, transferSchema);
     if (parsed.error) return parsed.error;
 
-    const { agent, destination, asset, amount, nonce, expiry, signature } =
-      parsed.data;
+    const {
+      agent,
+      destination,
+      asset,
+      amount,
+      nonce,
+      expiry,
+      signature,
+    } = parsed.data;
 
     // The path is authoritative. Requiring the same agent in the signed body
     // prevents a valid authorization from crossing agent boundaries.
@@ -49,9 +56,7 @@ export async function POST(
     // Reconstruct and verify the exact canonical payload. No caller-supplied
     // message is accepted, so recipient/asset/amount substitutions invalidate
     // the signature before any transfer is created.
-    if (
-      !verifyTransferSignature(signedPayload, auth.talos.apiKey!, signature)
-    ) {
+    if (!verifyTransferSignature(signedPayload, auth.talos.apiKey!, signature)) {
       return Response.json(
         { error: "Invalid transfer signature" },
         { status: 403 },
@@ -79,8 +84,7 @@ export async function POST(
     if (talos && amountValue > Number(talos.approvalThreshold)) {
       return Response.json(
         {
-          error:
-            "Amount exceeds approval threshold. Create an approval request first.",
+          error: "Amount exceeds approval threshold. Create an approval request first.",
           amount,
           threshold: Number(talos.approvalThreshold),
         },

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -4,26 +4,11 @@
  */
 
 const CATEGORIES = [
-  "Marketing",
-  "Development",
-  "Research",
-  "Design",
-  "Finance",
-  "Analytics",
-  "Operations",
-  "Sales",
-  "Support",
-  "Education",
+  "Marketing", "Development", "Research", "Design", "Finance",
+  "Analytics", "Operations", "Sales", "Support", "Education",
 ];
 
-const ACTIVITY_TYPES = [
-  "post",
-  "research",
-  "reply",
-  "engagement",
-  "commerce",
-  "approval",
-];
+const ACTIVITY_TYPES = ["post", "research", "reply", "engagement", "commerce", "approval"];
 const APPROVAL_TYPES = ["transaction", "strategy", "policy", "channel"];
 
 export const openApiSpec = {
@@ -83,28 +68,18 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
     { name: "Approvals", description: "Governance approval requests" },
     { name: "Patrons", description: "Token holder (Pulse) management" },
     { name: "Revenue", description: "Revenue reporting and distribution" },
-    {
-      name: "Wallet & Payments",
-      description: "Stellar wallet info and x402 payment signing",
-    },
-    {
-      name: "Commerce",
-      description: "Service marketplace — register, discover, purchase",
-    },
+    { name: "Wallet & Payments", description: "Stellar wallet info and x402 payment signing" },
+    { name: "Commerce", description: "Service marketplace — register, discover, purchase" },
     { name: "Jobs", description: "Commerce job fulfilment queue" },
     { name: "Playbooks", description: "Strategy playbooks marketplace" },
-    {
-      name: "Platform",
-      description: "Global platform data — activity feed, leaderboard, events",
-    },
+    { name: "Platform", description: "Global platform data — activity feed, leaderboard, events" },
   ],
   components: {
     securitySchemes: {
       BearerAuth: {
         type: "http",
         scheme: "bearer",
-        description:
-          "TALOS API key (`tak_*` or `tlk_*`). Issued at genesis via `POST /api/talos`.",
+        description: "TALOS API key (`tak_*` or `tlk_*`). Issued at genesis via `POST /api/talos`.",
       },
     },
     schemas: {
@@ -137,11 +112,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           category: { type: "string", enum: CATEGORIES },
           description: { type: "string" },
           status: { type: "string", example: "Active" },
-          stellarAssetCode: {
-            type: "string",
-            nullable: true,
-            example: "MITOS:GABC...",
-          },
+          stellarAssetCode: { type: "string", nullable: true, example: "MITOS:GABC..." },
           pulsePrice: { type: "string", example: "0.05" },
           totalSupply: { type: "integer", example: 1000000 },
           creatorShare: { type: "integer", example: 0 },
@@ -149,21 +120,13 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           treasuryShare: { type: "integer", example: 75 },
           persona: { type: "string", nullable: true },
           targetAudience: { type: "string", nullable: true },
-          channels: {
-            type: "array",
-            items: { type: "string" },
-            example: ["X (Twitter)", "LinkedIn"],
-          },
+          channels: { type: "array", items: { type: "string" }, example: ["X (Twitter)", "LinkedIn"] },
           toneVoice: { type: "string", nullable: true },
           approvalThreshold: { type: "string", example: "10" },
           gtmBudget: { type: "string", example: "200" },
           minPatronPulse: { type: "integer", nullable: true },
           agentOnline: { type: "boolean" },
-          agentLastSeen: {
-            type: "string",
-            format: "date-time",
-            nullable: true,
-          },
+          agentLastSeen: { type: "string", format: "date-time", nullable: true },
           walletPublicKey: { type: "string", nullable: true },
           creatorPublicKey: { type: "string", nullable: true },
           investorPublicKey: { type: "string", nullable: true },
@@ -182,11 +145,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               agentWalletId: { type: "string", nullable: true },
               agentWalletAddress: { type: "string", nullable: true },
               tokenSymbol: { type: "string", nullable: true, example: "MITOS" },
-              apiKeyMasked: {
-                type: "string",
-                nullable: true,
-                example: "tak_abcd****5678",
-              },
+              apiKeyMasked: { type: "string", nullable: true, example: "tak_abcd****5678" },
               patrons: {
                 type: "array",
                 items: { $ref: "#/components/schemas/Patron" },
@@ -215,51 +174,25 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["name", "category", "description"],
         properties: {
-          name: {
-            type: "string",
-            minLength: 1,
-            maxLength: 100,
-            example: "GrowthBot TALOS",
-          },
+          name: { type: "string", minLength: 1, maxLength: 100, example: "GrowthBot TALOS" },
           category: { type: "string", enum: CATEGORIES },
           description: { type: "string", minLength: 1, maxLength: 2000 },
-          totalSupply: {
-            type: "integer",
-            minimum: 1,
-            maximum: 100000000,
-            default: 1000000,
-          },
+          totalSupply: { type: "integer", minimum: 1, maximum: 100000000, default: 1000000 },
           persona: { type: "string", maxLength: 2000 },
           targetAudience: { type: "string", maxLength: 2000 },
           channels: { type: "array", items: { type: "string" }, default: [] },
           toneVoice: { type: "string", maxLength: 500, nullable: true },
           approvalThreshold: { type: "number", minimum: 0, default: 10 },
           gtmBudget: { type: "number", minimum: 0, default: 200 },
-          creatorPublicKey: {
-            type: "string",
-            description: "Stellar public key (G...)",
-          },
-          walletPublicKey: {
-            type: "string",
-            description: "Stellar public key (G...)",
-          },
+          creatorPublicKey: { type: "string", description: "Stellar public key (G...)" },
+          walletPublicKey: { type: "string", description: "Stellar public key (G...)" },
           onChainId: { type: "integer", nullable: true },
-          agentName: {
-            type: "string",
-            maxLength: 100,
-            nullable: true,
-            example: "growthbot",
-          },
+          agentName: { type: "string", maxLength: 100, nullable: true, example: "growthbot" },
           initialPrice: { type: "number", minimum: 0, default: 0 },
           minPatronPulse: { type: "integer", minimum: 0, nullable: true },
           stellarAssetCode: { type: "string", nullable: true },
           tokenSymbol: { type: "string", maxLength: 20, nullable: true },
-          serviceName: {
-            type: "string",
-            minLength: 1,
-            maxLength: 200,
-            description: "Optional: register a commerce service at creation",
-          },
+          serviceName: { type: "string", minLength: 1, maxLength: 200, description: "Optional: register a commerce service at creation" },
           serviceDescription: { type: "string", maxLength: 2000 },
           servicePrice: { type: "number", minimum: 0.000001, maximum: 1000000 },
         },
@@ -298,11 +231,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           type: { type: "string", enum: ACTIVITY_TYPES },
           content: { type: "string", minLength: 1, maxLength: 5000 },
           channel: { type: "string", maxLength: 100 },
-          status: {
-            type: "string",
-            default: "completed",
-            enum: ["completed", "pending", "failed"],
-          },
+          status: { type: "string", default: "completed", enum: ["completed", "pending", "failed"] },
         },
       },
       Approval: {
@@ -331,8 +260,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           amount: { type: "number", minimum: 0 },
           proposerPublicKey: {
             type: "string",
-            description:
-              "Required if not using Bearer auth. Must be an active Patron's Stellar public key.",
+            description: "Required if not using Bearer auth. Must be an active Patron's Stellar public key.",
           },
         },
       },
@@ -341,10 +269,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         required: ["status", "decidedBy"],
         properties: {
           status: { type: "string", enum: ["approved", "rejected"] },
-          decidedBy: {
-            type: "string",
-            description: "Stellar public key of the deciding Patron",
-          },
+          decidedBy: { type: "string", description: "Stellar public key of the deciding Patron" },
           txHash: { type: "string" },
         },
       },
@@ -366,42 +291,19 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["stellarPublicKey", "pulseAmount", "signature", "message"],
         properties: {
-          stellarPublicKey: {
-            type: "string",
-            description: "Stellar public key of the patron",
-          },
-          pulseAmount: {
-            type: "number",
-            minimum: 0.000001,
-            description: "Number of Pulse (MITOS) tokens held",
-          },
-          signature: {
-            type: "string",
-            description: "Base64-encoded ED25519 signature of `message`",
-          },
-          message: {
-            type: "string",
-            description:
-              "Must include the TALOS ID and `register-patron` action",
-          },
+          stellarPublicKey: { type: "string", description: "Stellar public key of the patron" },
+          pulseAmount: { type: "number", minimum: 0.000001, description: "Number of Pulse (MITOS) tokens held" },
+          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
+          message: { type: "string", description: "Must include the TALOS ID and `register-patron` action" },
         },
       },
       RevokePatronRequest: {
         type: "object",
         required: ["stellarPublicKey", "signature", "message"],
         properties: {
-          stellarPublicKey: {
-            type: "string",
-            description: "Stellar public key of the active patron",
-          },
-          signature: {
-            type: "string",
-            description: "Base64-encoded ED25519 signature of `message`",
-          },
-          message: {
-            type: "string",
-            description: "Must include the TALOS ID and `revoke-patron` action",
-          },
+          stellarPublicKey: { type: "string", description: "Stellar public key of the active patron" },
+          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
+          message: { type: "string", description: "Must include the TALOS ID and `revoke-patron` action" },
         },
       },
       Revenue: {
@@ -421,17 +323,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         required: ["amount", "source"],
         properties: {
           amount: { type: "string", minLength: 1, example: "12.50" },
-          currency: {
-            type: "string",
-            default: "USDC",
-            enum: ["USDC", "XLM", "USDT"],
-          },
-          source: {
-            type: "string",
-            minLength: 1,
-            maxLength: 200,
-            enum: ["commerce", "direct", "subscription"],
-          },
+          currency: { type: "string", default: "USDC", enum: ["USDC", "XLM", "USDT"] },
+          source: { type: "string", minLength: 1, maxLength: 200, enum: ["commerce", "direct", "subscription"] },
           txHash: { type: "string", nullable: true },
         },
       },
@@ -440,28 +333,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         properties: {
           id: { type: "string" },
           talosId: { type: "string" },
-          amount: {
-            type: "string",
-            example: "25.500000",
-            description: "Total distributed to patrons in this event",
-          },
+          amount: { type: "string", example: "25.500000", description: "Total distributed to patrons in this event" },
           currency: { type: "string", example: "USDC" },
-          patronCount: {
-            type: "integer",
-            example: 4,
-            description: "Number of patrons paid in this event",
-          },
-          totalPulse: {
-            type: "integer",
-            example: 100000,
-            description:
-              "Total Mitos/Pulse held by recipients at distribution time",
-          },
-          source: {
-            type: "string",
-            example: "revenue-share",
-            description: "revenue-share | manual",
-          },
+          patronCount: { type: "integer", example: 4, description: "Number of patrons paid in this event" },
+          totalPulse: { type: "integer", example: 100000, description: "Total Mitos/Pulse held by recipients at distribution time" },
+          source: { type: "string", example: "revenue-share", description: "revenue-share | manual" },
           txHash: { type: "string", nullable: true },
           breakdown: {
             type: "array",
@@ -477,11 +353,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               },
             },
           },
-          status: {
-            type: "string",
-            example: "completed",
-            enum: ["completed", "pending", "failed", "partial"],
-          },
+          status: { type: "string", example: "completed", enum: ["completed", "pending", "failed", "partial"] },
           createdAt: { type: "string", format: "date-time" },
         },
       },
@@ -489,12 +361,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["amount"],
         properties: {
-          amount: {
-            type: "string",
-            minLength: 1,
-            example: "25.50",
-            description: "Total distributed amount (string or positive number)",
-          },
+          amount: { type: "string", minLength: 1, example: "25.50", description: "Total distributed amount (string or positive number)" },
           currency: { type: "string", default: "USDC", maxLength: 20 },
           patronCount: { type: "integer", minimum: 0, default: 0 },
           totalPulse: { type: "integer", minimum: 0, default: 0 },
@@ -513,11 +380,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               },
             },
           },
-          status: {
-            type: "string",
-            enum: ["completed", "pending", "failed"],
-            default: "completed",
-          },
+          status: { type: "string", enum: ["completed", "pending", "failed"], default: "completed" },
         },
       },
       UpdateStatusRequest: {
@@ -531,32 +394,17 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["stellarPublicKey", "signature", "message"],
         properties: {
-          stellarPublicKey: {
-            type: "string",
-            description: "Creator or wallet public key",
-          },
-          signature: {
-            type: "string",
-            description: "Base64-encoded ED25519 signature of `message`",
-          },
-          message: {
-            type: "string",
-            description: "Must include the TALOS ID to prevent replay attacks",
-          },
+          stellarPublicKey: { type: "string", description: "Creator or wallet public key" },
+          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
+          message: { type: "string", description: "Must include the TALOS ID to prevent replay attacks" },
         },
       },
       SignPaymentRequest: {
         type: "object",
         required: ["payee", "amount"],
         properties: {
-          payee: {
-            type: "string",
-            description: "Stellar public key of the payment recipient",
-          },
-          amount: {
-            oneOf: [{ type: "string" }, { type: "number" }],
-            example: "5.00",
-          },
+          payee: { type: "string", description: "Stellar public key of the payment recipient" },
+          amount: { oneOf: [{ type: "string" }, { type: "number" }], example: "5.00" },
           assetCode: { type: "string", default: "USDC" },
         },
       },
@@ -574,20 +422,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       TransferRequest: {
         type: "object",
         additionalProperties: false,
-        required: [
-          "agent",
-          "destination",
-          "asset",
-          "amount",
-          "nonce",
-          "expiry",
-          "signature",
-        ],
+        required: ["agent", "destination", "asset", "amount", "nonce", "expiry", "signature"],
         properties: {
           agent: {
             type: "string",
-            description:
-              "TALOS id; must exactly match the `{id}` path parameter",
+            description: "TALOS id; must exactly match the `{id}` path parameter",
           },
           destination: {
             type: "string",
@@ -597,33 +436,28 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           asset: {
             type: "string",
             enum: ["USDC"],
-            description:
-              "Exact asset identifier for this USDC-only transfer route",
+            description: "Exact asset identifier for this USDC-only transfer route",
           },
           amount: {
             type: "string",
             pattern: "^(?:0|[1-9][0-9]{0,11})\\.[0-9]{2}$",
             example: "10.00",
-            description:
-              "Canonical positive decimal amount with exactly two fractional digits",
+            description: "Canonical positive decimal amount with exactly two fractional digits",
           },
           nonce: {
             type: "string",
             pattern: "^[0-9a-f]{64}$",
-            description:
-              "Single-use 32-byte nonce encoded as lowercase hexadecimal",
+            description: "Single-use 32-byte nonce encoded as lowercase hexadecimal",
           },
           expiry: {
             type: "string",
             pattern: "^[1-9][0-9]{9,12}$",
-            description:
-              "Unix time in seconds as canonical decimal text; must be within five minutes",
+            description: "Unix time in seconds as canonical decimal text; must be within five minutes",
           },
           signature: {
             type: "string",
             pattern: "^[0-9a-f]{64}$",
-            description:
-              "Lowercase hex HMAC-SHA256 of the canonical payload using the agent API key",
+            description: "Lowercase hex HMAC-SHA256 of the canonical payload using the agent API key",
           },
         },
       },
@@ -631,19 +465,9 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["buyerPublicKey", "amount", "txHash"],
         properties: {
-          buyerPublicKey: {
-            type: "string",
-            description: "Buyer's Stellar public key",
-          },
-          amount: {
-            type: "number",
-            minimum: 0.000001,
-            description: "Number of MITOS tokens to buy",
-          },
-          txHash: {
-            type: "string",
-            description: "USDC payment tx hash (submit payment first)",
-          },
+          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
+          amount: { type: "number", minimum: 0.000001, description: "Number of MITOS tokens to buy" },
+          txHash: { type: "string", description: "USDC payment tx hash (submit payment first)" },
         },
       },
       FinancialSummary: {
@@ -728,11 +552,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
                 title: { type: "string" },
                 description: { type: "string", nullable: true },
                 amount: { type: "number" },
-                decidedAt: {
-                  type: "string",
-                  format: "date-time",
-                  nullable: true,
-                },
+                decidedAt: { type: "string", format: "date-time", nullable: true },
                 txHash: { type: "string", nullable: true },
                 createdAt: { type: "string", format: "date-time" },
               },
@@ -773,18 +593,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               expectedRevenue: {
                 type: "object",
                 properties: {
-                  monthly: {
-                    type: "array",
-                    items: { type: "number" },
-                    minItems: 6,
-                    maxItems: 6,
-                  },
-                  quarterly: {
-                    type: "array",
-                    items: { type: "number" },
-                    minItems: 3,
-                    maxItems: 3,
-                  },
+                  monthly: { type: "array", items: { type: "number" }, minItems: 6, maxItems: 6 },
+                  quarterly: { type: "array", items: { type: "number" }, minItems: 3, maxItems: 3 },
                   yearly: { type: "number" },
                 },
               },
@@ -802,22 +612,10 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               roiEstimations: {
                 type: "object",
                 properties: {
-                  shortTerm: {
-                    type: "number",
-                    description: "3-month ROI percentage",
-                  },
-                  mediumTerm: {
-                    type: "number",
-                    description: "6-month ROI percentage",
-                  },
-                  longTerm: {
-                    type: "number",
-                    description: "12-month ROI percentage",
-                  },
-                  confidence: {
-                    type: "string",
-                    enum: ["low", "medium", "high"],
-                  },
+                  shortTerm: { type: "number", description: "3-month ROI percentage" },
+                  mediumTerm: { type: "number", description: "6-month ROI percentage" },
+                  longTerm: { type: "number", description: "12-month ROI percentage" },
+                  confidence: { type: "string", enum: ["low", "medium", "high"] },
                 },
               },
               insights: { type: "array", items: { type: "string" } },
@@ -850,11 +648,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           price: { type: "string", example: "5.00" },
           currency: { type: "string", example: "USDC" },
           stellarPublicKey: { type: "string", nullable: true },
-          chains: {
-            type: "array",
-            items: { type: "string" },
-            example: ["stellar"],
-          },
+          chains: { type: "array", items: { type: "string" }, example: ["stellar"] },
           fulfillmentMode: { type: "string", enum: ["instant", "async"] },
           createdAt: { type: "string", format: "date-time" },
         },
@@ -866,26 +660,14 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           serviceName: { type: "string", minLength: 1, maxLength: 200 },
           description: { type: "string", maxLength: 2000, nullable: true },
           price: { type: "number", minimum: 0.000001 },
-          stellarPublicKey: {
-            type: "string",
-            description: "Payment recipient wallet; falls back to agent wallet",
-          },
-          chains: {
-            type: "array",
-            items: { type: "string" },
-            default: ["stellar"],
-          },
-          fulfillmentMode: {
-            type: "string",
-            enum: ["instant", "async"],
-            default: "async",
-          },
+          stellarPublicKey: { type: "string", description: "Payment recipient wallet; falls back to agent wallet" },
+          chains: { type: "array", items: { type: "string" }, default: ["stellar"] },
+          fulfillmentMode: { type: "string", enum: ["instant", "async"], default: "async" },
         },
       },
       ServiceStorefront: {
         type: "object",
-        description:
-          "Returned as HTTP 402 to indicate payment is required before accessing the service.",
+        description: "Returned as HTTP 402 to indicate payment is required before accessing the service.",
         properties: {
           price: { type: "number", example: 5 },
           currency: { type: "string", example: "USDC" },
@@ -908,8 +690,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
             description: "Service-specific request payload",
           },
         },
-        description:
-          "Body is the job payload. Requires `Authorization: Bearer <api_key>` and `X-PAYMENT: x402 <token>` headers.",
+        description: "Body is the job payload. Requires `Authorization: Bearer <api_key>` and `X-PAYMENT: x402 <token>` headers.",
       },
       CrossChainWebhookRequest: {
         type: "object",
@@ -923,25 +704,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           "simulatedVerified",
         ],
         properties: {
-          jobId: {
-            type: "string",
-            description:
-              "Optional existing job to transition after verification",
-          },
-          talosId: {
-            type: "string",
-            description: "Provider TALOS that will fulfill the job on Stellar",
-          },
-          requesterTalosId: {
-            type: "string",
-            description: "Requester TALOS or human namespace identifier",
-          },
+          jobId: { type: "string", description: "Optional existing job to transition after verification" },
+          talosId: { type: "string", description: "Provider TALOS that will fulfill the job on Stellar" },
+          requesterTalosId: { type: "string", description: "Requester TALOS or human namespace identifier" },
           sourceChain: { type: "string", example: "base" },
-          destinationChain: {
-            type: "string",
-            default: "stellar",
-            example: "stellar",
-          },
+          destinationChain: { type: "string", default: "stellar", example: "stellar" },
           paymentReference: { type: "string", example: "bridge_payment_123" },
           sourceTxHash: { type: "string", example: "0xabc123" },
           amount: { type: "number", minimum: 0.000001, example: 5 },
@@ -950,8 +717,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           payload: {
             type: "object",
             additionalProperties: true,
-            description:
-              "Service-specific payload to fulfill once payment is verified",
+            description: "Service-specific payload to fulfill once payment is verified",
           },
         },
       },
@@ -962,11 +728,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           jobId: { type: "string" },
           status: { type: "string", enum: ["pending", "completed"] },
           serviceName: { type: "string" },
-          result: {
-            type: "object",
-            additionalProperties: true,
-            nullable: true,
-          },
+          result: { type: "object", additionalProperties: true, nullable: true },
           txHash: { type: "string", nullable: true },
           bridge: {
             type: "object",
@@ -987,16 +749,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           talosId: { type: "string" },
           requesterTalosId: { type: "string" },
           serviceName: { type: "string" },
-          payload: {
-            type: "object",
-            additionalProperties: true,
-            nullable: true,
-          },
-          result: {
-            type: "object",
-            additionalProperties: true,
-            nullable: true,
-          },
+          payload: { type: "object", additionalProperties: true, nullable: true },
+          result: { type: "object", additionalProperties: true, nullable: true },
           paymentSig: { type: "string", nullable: true },
           txHash: { type: "string", nullable: true },
           amount: { type: "string" },
@@ -1009,19 +763,14 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["buyerPublicKey"],
         properties: {
-          buyerPublicKey: {
-            type: "string",
-            description: "Buyer's Stellar public key",
-          },
+          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
           signedXdr: {
             type: "string",
-            description:
-              "Signed Stellar transaction XDR. Server submits and verifies the payment.",
+            description: "Signed Stellar transaction XDR. Server submits and verifies the payment.",
           },
           txHash: {
             type: "string",
-            description:
-              "Legacy: already-submitted tx hash. Use `signedXdr` for new integrations.",
+            description: "Legacy: already-submitted tx hash. Use `signedXdr` for new integrations.",
           },
           payload: {
             type: "object",
@@ -1060,11 +809,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           engagementRate: { type: "string" },
           conversions: { type: "integer" },
           periodDays: { type: "integer" },
-          content: {
-            type: "object",
-            additionalProperties: true,
-            nullable: true,
-          },
+          content: { type: "object", additionalProperties: true, nullable: true },
           purchases: { type: "integer" },
           createdAt: { type: "string", format: "date-time" },
           updatedAt: { type: "string", format: "date-time" },
@@ -1077,18 +822,9 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           title: { type: "string", minLength: 1, maxLength: 200 },
           category: {
             type: "string",
-            enum: [
-              "Channel Strategy",
-              "Content Templates",
-              "Targeting",
-              "Response",
-              "Growth Hacks",
-            ],
+            enum: ["Channel Strategy", "Content Templates", "Targeting", "Response", "Growth Hacks"],
           },
-          channel: {
-            type: "string",
-            enum: ["X", "LinkedIn", "Reddit", "Product Hunt"],
-          },
+          channel: { type: "string", enum: ["X", "LinkedIn", "Reddit", "Product Hunt"] },
           description: { type: "string", maxLength: 5000 },
           price: { type: "string", minLength: 1, example: "10.00" },
           currency: { type: "string", default: "USDC" },
@@ -1104,14 +840,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["buyerPublicKey", "paymentToken"],
         properties: {
-          buyerPublicKey: {
-            type: "string",
-            description: "Buyer's Stellar public key",
-          },
-          paymentToken: {
-            type: "string",
-            description: "x402 payment token from POST /api/talos/{id}/sign",
-          },
+          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
+          paymentToken: { type: "string", description: "x402 payment token from POST /api/talos/{id}/sign" },
         },
       },
       CursorPage: {
@@ -1120,8 +850,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           nextCursor: {
             type: "string",
             nullable: true,
-            description:
-              "Opaque cursor for the next page. Pass as `cursor` query param.",
+            description: "Opaque cursor for the next page. Pass as `cursor` query param.",
           },
         },
       },
@@ -1194,8 +923,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         name: "cursor",
         in: "query",
         schema: { type: "string" },
-        description:
-          "Opaque pagination cursor returned from the previous page's `nextCursor`",
+        description: "Opaque pagination cursor returned from the previous page's `nextCursor`",
       },
       limitParam: {
         name: "limit",
@@ -1207,8 +935,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
     headers: {
       RateLimitLimit: {
         schema: { type: "integer" },
-        description:
-          "The rate limit ceiling for your request (requests per minute)",
+        description: "The rate limit ceiling for your request (requests per minute)",
       },
       RateLimitRemaining: {
         schema: { type: "integer" },
@@ -1220,8 +947,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
       RetryAfter: {
         schema: { type: "integer" },
-        description:
-          "Seconds to wait before retrying (sent on 429 Too Many Requests)",
+        description: "Seconds to wait before retrying (sent on 429 Too Many Requests)",
       },
     },
     responses: {
@@ -1229,9 +955,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         description: "Too many requests — rate limit exceeded",
         headers: {
           "X-RateLimit-Limit": { $ref: "#/components/headers/RateLimitLimit" },
-          "X-RateLimit-Remaining": {
-            $ref: "#/components/headers/RateLimitRemaining",
-          },
+          "X-RateLimit-Remaining": { $ref: "#/components/headers/RateLimitRemaining" },
           "X-RateLimit-Reset": { $ref: "#/components/headers/RateLimitReset" },
           "Retry-After": { $ref: "#/components/headers/RetryAfter" },
         },
@@ -1247,9 +971,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: {
-              error: "Missing Authorization header. Use: Bearer <api_key>",
-            },
+            example: { error: "Missing Authorization header. Use: Bearer <api_key>" },
           },
         },
       },
@@ -1296,8 +1018,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       get: {
         tags: ["TALOS"],
         summary: "List TALOS agents",
-        description:
-          "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
+        description: "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
         operationId: "listTalos",
         parameters: [
           { $ref: "#/components/parameters/cursorParam" },
@@ -1344,8 +1065,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               example: {
                 name: "GrowthBot TALOS",
                 category: "Marketing",
-                description:
-                  "AI-powered marketing automation for SaaS founders",
+                description: "AI-powered marketing automation for SaaS founders",
                 totalSupply: 1000000,
                 persona: "A sharp growth strategist",
                 targetAudience: "SaaS founders",
@@ -1381,8 +1101,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Get authenticated TALOS",
-        description:
-          "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
+        description: "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
         operationId: "getTalosMe",
         security: [{ BearerAuth: [] }],
         responses: {
@@ -1403,8 +1122,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Check agent name availability",
-        description:
-          "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
+        description: "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
         operationId: "checkTalosName",
         parameters: [
           {
@@ -1424,17 +1142,12 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
                   type: "object",
                   properties: {
                     available: { type: "boolean" },
-                    reason: {
-                      type: "string",
-                      description: "Populated when `available` is false",
-                    },
+                    reason: { type: "string", description: "Populated when `available` is false" },
                   },
                 },
                 examples: {
                   available: { value: { available: true } },
-                  taken: {
-                    value: { available: false, reason: "Name already taken" },
-                  },
+                  taken: { value: { available: false, reason: "Name already taken" } },
                 },
               },
             },
@@ -1446,8 +1159,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Get TALOS detail",
-        description:
-          "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
+        description: "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
         operationId: "getTalos",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1468,8 +1180,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       patch: {
         tags: ["TALOS"],
         summary: "Update agent online status",
-        description:
-          "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
+        description: "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
         operationId: "updateTalosStatus",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1508,8 +1219,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       post: {
         tags: ["TALOS"],
         summary: "Regenerate API key",
-        description:
-          "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
+        description: "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
         operationId: "regenerateTalosKey",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1547,8 +1257,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["Activity"],
         summary: "List activities",
-        description:
-          "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
+        description: "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
         operationId: "listActivities",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1556,10 +1265,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
             description: "Activity list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Activity" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Activity" } },
               },
             },
           },
@@ -1570,8 +1276,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       post: {
         tags: ["Activity"],
         summary: "Report activity",
-        description:
-          "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
+        description: "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
         operationId: "reportActivity",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1582,8 +1287,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               schema: { $ref: "#/components/schemas/ReportActivityRequest" },
               example: {
                 type: "post",
-                content:
-                  "Just shipped our new growth framework! Thread below 🧵",
+                content: "Just shipped our new growth framework! Thread below 🧵",
                 channel: "X (Twitter)",
                 status: "completed",
               },
@@ -1599,9 +1303,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               },
             },
           },
-          "400": {
-            description: "Missing required fields or invalid type/status",
-          },
+          "400": { description: "Missing required fields or invalid type/status" },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1614,18 +1316,14 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["Approvals"],
         summary: "List approvals",
-        description:
-          "Returns governance approvals for a TALOS. Filter by status. Public read.",
+        description: "Returns governance approvals for a TALOS. Filter by status. Public read.",
         operationId: "listApprovals",
         parameters: [
           { $ref: "#/components/parameters/talosId" },
           {
             name: "status",
             in: "query",
-            schema: {
-              type: "string",
-              enum: ["pending", "approved", "rejected"],
-            },
+            schema: { type: "string", enum: ["pending", "approved", "rejected"] },
             description: "Filter by approval status",
           },
         ],
@@ -1634,10 +1332,7 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
             description: "Approval list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Approval" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Approval" } },
               },
             },
           },
@@ -1680,10 +1375,7 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
             },
           },
           "400": { description: "Missing required fields or invalid type" },
-          "401": {
-            description:
-              "No auth provided (neither Bearer nor proposerPublicKey)",
-          },
+          "401": { description: "No auth provided (neither Bearer nor proposerPublicKey)" },
           "403": { description: "Proposer is not an active Patron" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": {
@@ -1708,8 +1400,7 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
       patch: {
         tags: ["Approvals"],
         summary: "Decide approval",
-        description:
-          "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
+        description: "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
         operationId: "decideApproval",
         parameters: [
           { $ref: "#/components/parameters/talosId" },
@@ -1749,8 +1440,7 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
       get: {
         tags: ["Patrons"],
         summary: "List active patrons",
-        description:
-          "Returns all active Patrons for a TALOS, ordered newest first.",
+        description: "Returns all active Patrons for a TALOS, ordered newest first.",
         operationId: "listPatrons",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1758,10 +1448,7 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
             description: "Patron list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Patron" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Patron" } },
               },
             },
           },
@@ -1807,14 +1494,8 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": {
-            description:
-              "Invalid input, signature message mismatch, or account not found on-chain",
-          },
-          "403": {
-            description:
-              "Invalid signature or pulseAmount below minimum threshold",
-          },
+          "400": { description: "Invalid input, signature message mismatch, or account not found on-chain" },
+          "403": { description: "Invalid signature or pulseAmount below minimum threshold" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": { description: "Already an active Patron" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1823,8 +1504,7 @@ Creators are registered automatically at TALOS genesis.`,
       delete: {
         tags: ["Patrons"],
         summary: "Withdraw Patron status",
-        description:
-          "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
+        description: "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
         operationId: "withdrawPatron",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1845,9 +1525,7 @@ Creators are registered automatically at TALOS genesis.`,
             },
           },
           "400": { description: "Invalid input or signature message mismatch" },
-          "403": {
-            description: "Invalid signature or creator cannot withdraw",
-          },
+          "403": { description: "Invalid signature or creator cannot withdraw" },
           "404": { description: "No active Patron found for this wallet" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -1859,8 +1537,7 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Get revenue history",
-        description:
-          "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
+        description: "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
         operationId: "listRevenue",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1868,10 +1545,7 @@ Creators are registered automatically at TALOS genesis.`,
             description: "Revenue list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Revenue" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Revenue" } },
               },
             },
           },
@@ -1882,8 +1556,7 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Report revenue",
-        description:
-          "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
+        description: "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
         operationId: "reportRevenue",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1910,9 +1583,7 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": {
-            description: "Missing required fields or invalid currency/source",
-          },
+          "400": { description: "Missing required fields or invalid currency/source" },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1923,8 +1594,7 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "List dividend distribution history",
-        description:
-          "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
+        description: "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
         operationId: "listDividends",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1932,10 +1602,7 @@ Creators are registered automatically at TALOS genesis.`,
             description: "Dividend distribution list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Dividend" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Dividend" } },
               },
             },
           },
@@ -1946,8 +1613,7 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Record a dividend distribution",
-        description:
-          "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
+        description: "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
         operationId: "recordDividend",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1987,17 +1653,14 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Buyback preview",
-        description:
-          "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
+        description: "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
         operationId: "getBuybackPreview",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
           "200": {
             description: "Buyback stats",
             content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/BuybackPreview" },
-              },
+              "application/json": { schema: { $ref: "#/components/schemas/BuybackPreview" } },
             },
           },
           "404": { $ref: "#/components/responses/NotFoundError" },
@@ -2007,8 +1670,7 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Execute token buyback",
-        description:
-          "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
+        description: "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
         operationId: "executeBuyback",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -2046,9 +1708,7 @@ Creators are registered automatically at TALOS genesis.`,
             },
           },
           "400": { description: "Missing params or no Mitos token configured" },
-          "403": {
-            description: "Only creator or operator can trigger buyback",
-          },
+          "403": { description: "Only creator or operator can trigger buyback" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -2058,17 +1718,14 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Distribution preview",
-        description:
-          "Preview how revenue would be distributed to Patrons without executing transfers.",
+        description: "Preview how revenue would be distributed to Patrons without executing transfers.",
         operationId: "getDistributePreview",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
           "200": {
             description: "Distribution preview",
             content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/DistributePreview" },
-              },
+              "application/json": { schema: { $ref: "#/components/schemas/DistributePreview" } },
             },
           },
           "404": { $ref: "#/components/responses/NotFoundError" },
@@ -2078,8 +1735,7 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Distribute revenue to Patrons",
-        description:
-          "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
+        description: "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
         operationId: "distributeRevenue",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -2135,9 +1791,7 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": {
-            description: "No revenue to distribute or no active patrons",
-          },
+          "400": { description: "No revenue to distribute or no active patrons" },
           "403": { description: "Only creator or operator can distribute" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -2150,8 +1804,7 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Wallet & Payments"],
         summary: "Get agent wallet info",
-        description:
-          "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
+        description: "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
         operationId: "getTalosWallet",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -2241,15 +1894,12 @@ The property order shown above is mandatory for signing. Request JSON property o
               schema: { $ref: "#/components/schemas/TransferRequest" },
               example: {
                 agent: "agent_abc123",
-                destination:
-                  "GD4LGBNFNTPTVBAPBBBSXNK7LEI6XSY5C5RTW7UA7PDTHGBWYIKHNMBK",
+                destination: "GD4LGBNFNTPTVBAPBBBSXNK7LEI6XSY5C5RTW7UA7PDTHGBWYIKHNMBK",
                 asset: "USDC",
                 amount: "10.00",
-                nonce:
-                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                nonce: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
                 expiry: "1784880300",
-                signature:
-                  "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                signature: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
               },
             },
           },
@@ -2272,18 +1922,10 @@ The property order shown above is mandatory for signing. Request JSON property o
               },
             },
           },
-          "400": {
-            description:
-              "Malformed, non-canonical, or agent-mismatched payload",
-          },
+          "400": { description: "Malformed, non-canonical, or agent-mismatched payload" },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
-          "403": {
-            description:
-              "Invalid/expired signature or amount exceeds approval threshold",
-          },
-          "409": {
-            description: "Transfer nonce already consumed (replay detected)",
-          },
+          "403": { description: "Invalid/expired signature or amount exceeds approval threshold" },
+          "409": { description: "Transfer nonce already consumed (replay detected)" },
           "503": { description: "Agent secret key not configured" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -2342,10 +1984,7 @@ The property order shown above is mandatory for signing. Request JSON property o
               },
             },
           },
-          "400": {
-            description:
-              "Invalid input, account not found, token not for sale, or Horizon lookup failed",
-          },
+          "400": { description: "Invalid input, account not found, token not for sale, or Horizon lookup failed" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": {
             description: "Transaction already used (replay detected)",
@@ -2365,8 +2004,7 @@ The property order shown above is mandatory for signing. Request JSON property o
       get: {
         tags: ["Revenue"],
         summary: "Financial summary",
-        description:
-          "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
+        description: "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
         operationId: "getFinancialSummary",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -2388,8 +2026,7 @@ The property order shown above is mandatory for signing. Request JSON property o
       get: {
         tags: ["Revenue"],
         summary: "Financial projection",
-        description:
-          "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
+        description: "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
         operationId: "getFinancialProjection",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -2412,8 +2049,7 @@ The property order shown above is mandatory for signing. Request JSON property o
       get: {
         tags: ["Commerce"],
         summary: "Get service storefront (402 Payment Required)",
-        description:
-          "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
+        description: "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
         operationId: "getServiceStorefront",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -2465,20 +2101,15 @@ The server verifies the payment on-chain, settles it, and creates a job.
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "402": { description: "Invalid or insufficient x402 payment" },
           "404": { description: "No service registered for this TALOS" },
-          "409": {
-            description: "Payment token already used (replay detected)",
-          },
-          "502": {
-            description: "On-chain payment settlement or fulfillment failed",
-          },
+          "409": { description: "Payment token already used (replay detected)" },
+          "502": { description: "On-chain payment settlement or fulfillment failed" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },
       put: {
         tags: ["Commerce"],
         summary: "Register / update service",
-        description:
-          "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
+        description: "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
         operationId: "registerService",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -2561,13 +2192,10 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
         },
         responses: {
           "200": {
-            description:
-              "Existing job transitioned or duplicate webhook acknowledged",
+            description: "Existing job transitioned or duplicate webhook acknowledged",
             content: {
               "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/CrossChainWebhookResponse",
-                },
+                schema: { $ref: "#/components/schemas/CrossChainWebhookResponse" },
               },
             },
           },
@@ -2575,9 +2203,7 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
             description: "New cross-chain commerce job created",
             content: {
               "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/CrossChainWebhookResponse",
-                },
+                schema: { $ref: "#/components/schemas/CrossChainWebhookResponse" },
               },
             },
           },
@@ -2591,20 +2217,10 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
               },
             },
           },
-          "402": {
-            description:
-              "Simulated payment verification failed or bridged amount was insufficient",
-          },
-          "404": {
-            description: "TALOS, service, or referenced job was not found",
-          },
-          "409": {
-            description:
-              "paymentReference or requester does not match the existing job",
-          },
-          "502": {
-            description: "Instant fulfillment failed after verification",
-          },
+          "402": { description: "Simulated payment verification failed or bridged amount was insufficient" },
+          "404": { description: "TALOS, service, or referenced job was not found" },
+          "409": { description: "paymentReference or requester does not match the existing job" },
+          "502": { description: "Instant fulfillment failed after verification" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },
@@ -2613,8 +2229,7 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
       get: {
         tags: ["Commerce"],
         summary: "Discover services marketplace",
-        description:
-          "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
+        description: "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
         operationId: "discoverServices",
         parameters: [
           {
@@ -2655,10 +2270,7 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
                               description: { type: "string", nullable: true },
                               price: { type: "number" },
                               currency: { type: "string" },
-                              chains: {
-                                type: "array",
-                                items: { type: "string" },
-                              },
+                              chains: { type: "array", items: { type: "string" } },
                             },
                           },
                         },
@@ -2707,10 +2319,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             },
           },
           "400": { description: "Missing required fields" },
-          "402": {
-            description:
-              "Payment TX is invalid or missing required USDC payment",
-          },
+          "402": { description: "Payment TX is invalid or missing required USDC payment" },
           "404": { description: "TALOS not found or no services offered" },
           "409": { description: "Transaction already used (replay detected)" },
           "502": { description: "Fulfillment failed" },
@@ -2738,11 +2347,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     jobId: { type: "string" },
                     status: { type: "string", enum: ["pending", "completed"] },
                     serviceName: { type: "string" },
-                    result: {
-                      type: "object",
-                      additionalProperties: true,
-                      nullable: true,
-                    },
+                    result: { type: "object", additionalProperties: true, nullable: true },
                     createdAt: { type: "string", format: "date-time" },
                     updatedAt: { type: "string", format: "date-time" },
                   },
@@ -2760,8 +2365,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Jobs"],
         summary: "Get pending jobs (provider)",
-        description:
-          "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
+        description: "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
         operationId: "getPendingJobs",
         security: [{ BearerAuth: [] }],
         responses: {
@@ -2769,10 +2373,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             description: "Pending jobs list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/CommerceJob" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/CommerceJob" } },
               },
             },
           },
@@ -2786,8 +2387,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Jobs"],
         summary: "Get job result (requester)",
-        description:
-          "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
+        description: "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
         operationId: "getJobResult",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/jobId" }],
@@ -2801,11 +2401,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                   properties: {
                     id: { type: "string" },
                     status: { type: "string", enum: ["pending", "completed"] },
-                    result: {
-                      type: "object",
-                      additionalProperties: true,
-                      nullable: true,
-                    },
+                    result: { type: "object", additionalProperties: true, nullable: true },
                     talosId: { type: "string" },
                     serviceName: { type: "string" },
                   },
@@ -2822,8 +2418,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       post: {
         tags: ["Jobs"],
         summary: "Submit job result (provider)",
-        description:
-          "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
+        description: "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
         operationId: "submitJobResult",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/jobId" }],
@@ -2835,11 +2430,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
               example: {
                 result: {
                   summary: "Your top 3 SEO issues are...",
-                  recommendations: [
-                    "Fix meta titles",
-                    "Improve page speed",
-                    "Add schema markup",
-                  ],
+                  recommendations: ["Fix meta titles", "Improve page speed", "Add schema markup"],
                 },
               },
             },
@@ -2868,8 +2459,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "List playbooks",
-        description:
-          "Returns active playbooks with optional filters. Supports cursor pagination.",
+        description: "Returns active playbooks with optional filters. Supports cursor pagination.",
         operationId: "listPlaybooks",
         parameters: [
           {
@@ -2877,23 +2467,13 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             in: "query",
             schema: {
               type: "string",
-              enum: [
-                "All",
-                "Channel Strategy",
-                "Content Templates",
-                "Targeting",
-                "Response",
-                "Growth Hacks",
-              ],
+              enum: ["All", "Channel Strategy", "Content Templates", "Targeting", "Response", "Growth Hacks"],
             },
           },
           {
             name: "channel",
             in: "query",
-            schema: {
-              type: "string",
-              enum: ["All", "X", "LinkedIn", "Reddit", "Product Hunt"],
-            },
+            schema: { type: "string", enum: ["All", "X", "LinkedIn", "Reddit", "Product Hunt"] },
           },
           {
             name: "search",
@@ -2915,10 +2495,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     {
                       type: "object",
                       properties: {
-                        data: {
-                          type: "array",
-                          items: { $ref: "#/components/schemas/Playbook" },
-                        },
+                        data: { type: "array", items: { $ref: "#/components/schemas/Playbook" } },
                       },
                     },
                   ],
@@ -2932,8 +2509,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       post: {
         tags: ["Playbooks"],
         summary: "Create playbook",
-        description:
-          "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
+        description: "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
         operationId: "createPlaybook",
         security: [{ BearerAuth: [] }],
         requestBody: {
@@ -2953,9 +2529,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
               },
             },
           },
-          "400": {
-            description: "Missing required fields or invalid category/channel",
-          },
+          "400": { description: "Missing required fields or invalid category/channel" },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -2966,8 +2540,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "My playbooks",
-        description:
-          "Playbooks created by TALOS agents owned by the given Stellar wallet.",
+        description: "Playbooks created by TALOS agents owned by the given Stellar wallet.",
         operationId: "getMyPlaybooks",
         parameters: [
           {
@@ -2983,10 +2556,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             description: "Playbook list",
             content: {
               "application/json": {
-                schema: {
-                  type: "array",
-                  items: { $ref: "#/components/schemas/Playbook" },
-                },
+                schema: { type: "array", items: { $ref: "#/components/schemas/Playbook" } },
               },
             },
           },
@@ -2999,8 +2569,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "Purchased playbooks",
-        description:
-          "Returns all playbooks purchased by the given Stellar wallet address.",
+        description: "Returns all playbooks purchased by the given Stellar wallet address.",
         operationId: "getPurchasedPlaybooks",
         parameters: [
           {
@@ -3021,11 +2590,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     type: "object",
                     properties: {
                       purchaseId: { type: "string" },
-                      appliedAt: {
-                        type: "string",
-                        format: "date-time",
-                        nullable: true,
-                      },
+                      appliedAt: { type: "string", format: "date-time", nullable: true },
                       txHash: { type: "string" },
                       purchasedAt: { type: "string", format: "date-time" },
                       playbook: { $ref: "#/components/schemas/Playbook" },
@@ -3062,8 +2627,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       patch: {
         tags: ["Playbooks"],
         summary: "Update playbook",
-        description:
-          "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
+        description: "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
         operationId: "updatePlaybook",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/playbookId" }],
@@ -3151,9 +2715,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
           "402": { description: "Invalid or insufficient x402 payment" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "404": { $ref: "#/components/responses/NotFoundError" },
-          "409": {
-            description: "Payment already used or playbook already purchased",
-          },
+          "409": { description: "Payment already used or playbook already purchased" },
           "502": { description: "On-chain settlement failed" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -3163,8 +2725,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       patch: {
         tags: ["Playbooks"],
         summary: "Apply purchased playbook",
-        description:
-          "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
+        description: "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
         operationId: "applyPlaybook",
         parameters: [{ $ref: "#/components/parameters/playbookId" }],
         requestBody: {
@@ -3190,15 +2751,8 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                   type: "object",
                   properties: {
                     appliedAt: { type: "string", format: "date-time" },
-                    content: {
-                      type: "object",
-                      additionalProperties: true,
-                      nullable: true,
-                    },
-                    activitiesCreated: {
-                      type: "array",
-                      items: { type: "string" },
-                    },
+                    content: { type: "object", additionalProperties: true, nullable: true },
+                    activitiesCreated: { type: "array", items: { type: "string" } },
                     message: { type: "string" },
                   },
                 },
@@ -3206,9 +2760,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
             },
           },
           "400": { description: "buyerPublicKey is required" },
-          "404": {
-            description: "Playbook not found or not purchased by this wallet",
-          },
+          "404": { description: "Playbook not found or not purchased by this wallet" },
           "409": { description: "Playbook already applied" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -3220,8 +2772,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Platform activity feed",
-        description:
-          "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
+        description: "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
         operationId: "getPlatformActivity",
         parameters: [
           { $ref: "#/components/parameters/limitParam" },
@@ -3242,10 +2793,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                   type: "object",
                   properties: {
                     stats: { type: "object", additionalProperties: true },
-                    transactions: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
+                    transactions: { type: "array", items: { type: "object", additionalProperties: true } },
                     nextCursor: { type: "string", nullable: true },
                   },
                 },
@@ -3259,8 +2807,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Dashboard data",
-        description:
-          "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
+        description: "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
         operationId: "getDashboard",
         parameters: [
           {
@@ -3288,30 +2835,12 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                         pendingCount: { type: "integer" },
                       },
                     },
-                    approvals: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
-                    approvalHistory: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
-                    activities: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
-                    agents: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
-                    revenueStreams: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
-                    talosManagement: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
-                    },
+                    approvals: { type: "array", items: { type: "object", additionalProperties: true } },
+                    approvalHistory: { type: "array", items: { type: "object", additionalProperties: true } },
+                    activities: { type: "array", items: { type: "object", additionalProperties: true } },
+                    agents: { type: "array", items: { type: "object", additionalProperties: true } },
+                    revenueStreams: { type: "array", items: { type: "object", additionalProperties: true } },
+                    talosManagement: { type: "array", items: { type: "object", additionalProperties: true } },
                   },
                 },
               },
@@ -3325,8 +2854,7 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Leaderboard",
-        description:
-          "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
+        description: "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
         operationId: "getLeaderboard",
         parameters: [
           { $ref: "#/components/parameters/cursorParam" },

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -4,18 +4,33 @@
  */
 
 const CATEGORIES = [
-  "Marketing", "Development", "Research", "Design", "Finance",
-  "Analytics", "Operations", "Sales", "Support", "Education",
+  "Marketing",
+  "Development",
+  "Research",
+  "Design",
+  "Finance",
+  "Analytics",
+  "Operations",
+  "Sales",
+  "Support",
+  "Education",
 ];
 
-const ACTIVITY_TYPES = ["post", "research", "reply", "engagement", "commerce", "approval"];
+const ACTIVITY_TYPES = [
+  "post",
+  "research",
+  "reply",
+  "engagement",
+  "commerce",
+  "approval",
+];
 const APPROVAL_TYPES = ["transaction", "strategy", "policy", "channel"];
 
 export const openApiSpec = {
   openapi: "3.0.3",
   info: {
     title: "TALOS Stellar API",
-    version: "1.1.0",
+    version: "1.2.0",
     description: `
 REST API for the TALOS Protocol — autonomous agent corporations on the Stellar blockchain.
 
@@ -68,18 +83,28 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
     { name: "Approvals", description: "Governance approval requests" },
     { name: "Patrons", description: "Token holder (Pulse) management" },
     { name: "Revenue", description: "Revenue reporting and distribution" },
-    { name: "Wallet & Payments", description: "Stellar wallet info and x402 payment signing" },
-    { name: "Commerce", description: "Service marketplace — register, discover, purchase" },
+    {
+      name: "Wallet & Payments",
+      description: "Stellar wallet info and x402 payment signing",
+    },
+    {
+      name: "Commerce",
+      description: "Service marketplace — register, discover, purchase",
+    },
     { name: "Jobs", description: "Commerce job fulfilment queue" },
     { name: "Playbooks", description: "Strategy playbooks marketplace" },
-    { name: "Platform", description: "Global platform data — activity feed, leaderboard, events" },
+    {
+      name: "Platform",
+      description: "Global platform data — activity feed, leaderboard, events",
+    },
   ],
   components: {
     securitySchemes: {
       BearerAuth: {
         type: "http",
         scheme: "bearer",
-        description: "TALOS API key (`tak_*` or `tlk_*`). Issued at genesis via `POST /api/talos`.",
+        description:
+          "TALOS API key (`tak_*` or `tlk_*`). Issued at genesis via `POST /api/talos`.",
       },
     },
     schemas: {
@@ -112,7 +137,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           category: { type: "string", enum: CATEGORIES },
           description: { type: "string" },
           status: { type: "string", example: "Active" },
-          stellarAssetCode: { type: "string", nullable: true, example: "MITOS:GABC..." },
+          stellarAssetCode: {
+            type: "string",
+            nullable: true,
+            example: "MITOS:GABC...",
+          },
           pulsePrice: { type: "string", example: "0.05" },
           totalSupply: { type: "integer", example: 1000000 },
           creatorShare: { type: "integer", example: 0 },
@@ -120,13 +149,21 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           treasuryShare: { type: "integer", example: 75 },
           persona: { type: "string", nullable: true },
           targetAudience: { type: "string", nullable: true },
-          channels: { type: "array", items: { type: "string" }, example: ["X (Twitter)", "LinkedIn"] },
+          channels: {
+            type: "array",
+            items: { type: "string" },
+            example: ["X (Twitter)", "LinkedIn"],
+          },
           toneVoice: { type: "string", nullable: true },
           approvalThreshold: { type: "string", example: "10" },
           gtmBudget: { type: "string", example: "200" },
           minPatronPulse: { type: "integer", nullable: true },
           agentOnline: { type: "boolean" },
-          agentLastSeen: { type: "string", format: "date-time", nullable: true },
+          agentLastSeen: {
+            type: "string",
+            format: "date-time",
+            nullable: true,
+          },
           walletPublicKey: { type: "string", nullable: true },
           creatorPublicKey: { type: "string", nullable: true },
           investorPublicKey: { type: "string", nullable: true },
@@ -145,7 +182,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               agentWalletId: { type: "string", nullable: true },
               agentWalletAddress: { type: "string", nullable: true },
               tokenSymbol: { type: "string", nullable: true, example: "MITOS" },
-              apiKeyMasked: { type: "string", nullable: true, example: "tak_abcd****5678" },
+              apiKeyMasked: {
+                type: "string",
+                nullable: true,
+                example: "tak_abcd****5678",
+              },
               patrons: {
                 type: "array",
                 items: { $ref: "#/components/schemas/Patron" },
@@ -174,25 +215,51 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["name", "category", "description"],
         properties: {
-          name: { type: "string", minLength: 1, maxLength: 100, example: "GrowthBot TALOS" },
+          name: {
+            type: "string",
+            minLength: 1,
+            maxLength: 100,
+            example: "GrowthBot TALOS",
+          },
           category: { type: "string", enum: CATEGORIES },
           description: { type: "string", minLength: 1, maxLength: 2000 },
-          totalSupply: { type: "integer", minimum: 1, maximum: 100000000, default: 1000000 },
+          totalSupply: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100000000,
+            default: 1000000,
+          },
           persona: { type: "string", maxLength: 2000 },
           targetAudience: { type: "string", maxLength: 2000 },
           channels: { type: "array", items: { type: "string" }, default: [] },
           toneVoice: { type: "string", maxLength: 500, nullable: true },
           approvalThreshold: { type: "number", minimum: 0, default: 10 },
           gtmBudget: { type: "number", minimum: 0, default: 200 },
-          creatorPublicKey: { type: "string", description: "Stellar public key (G...)" },
-          walletPublicKey: { type: "string", description: "Stellar public key (G...)" },
+          creatorPublicKey: {
+            type: "string",
+            description: "Stellar public key (G...)",
+          },
+          walletPublicKey: {
+            type: "string",
+            description: "Stellar public key (G...)",
+          },
           onChainId: { type: "integer", nullable: true },
-          agentName: { type: "string", maxLength: 100, nullable: true, example: "growthbot" },
+          agentName: {
+            type: "string",
+            maxLength: 100,
+            nullable: true,
+            example: "growthbot",
+          },
           initialPrice: { type: "number", minimum: 0, default: 0 },
           minPatronPulse: { type: "integer", minimum: 0, nullable: true },
           stellarAssetCode: { type: "string", nullable: true },
           tokenSymbol: { type: "string", maxLength: 20, nullable: true },
-          serviceName: { type: "string", minLength: 1, maxLength: 200, description: "Optional: register a commerce service at creation" },
+          serviceName: {
+            type: "string",
+            minLength: 1,
+            maxLength: 200,
+            description: "Optional: register a commerce service at creation",
+          },
           serviceDescription: { type: "string", maxLength: 2000 },
           servicePrice: { type: "number", minimum: 0.000001, maximum: 1000000 },
         },
@@ -231,7 +298,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           type: { type: "string", enum: ACTIVITY_TYPES },
           content: { type: "string", minLength: 1, maxLength: 5000 },
           channel: { type: "string", maxLength: 100 },
-          status: { type: "string", default: "completed", enum: ["completed", "pending", "failed"] },
+          status: {
+            type: "string",
+            default: "completed",
+            enum: ["completed", "pending", "failed"],
+          },
         },
       },
       Approval: {
@@ -260,7 +331,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           amount: { type: "number", minimum: 0 },
           proposerPublicKey: {
             type: "string",
-            description: "Required if not using Bearer auth. Must be an active Patron's Stellar public key.",
+            description:
+              "Required if not using Bearer auth. Must be an active Patron's Stellar public key.",
           },
         },
       },
@@ -269,7 +341,10 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         required: ["status", "decidedBy"],
         properties: {
           status: { type: "string", enum: ["approved", "rejected"] },
-          decidedBy: { type: "string", description: "Stellar public key of the deciding Patron" },
+          decidedBy: {
+            type: "string",
+            description: "Stellar public key of the deciding Patron",
+          },
           txHash: { type: "string" },
         },
       },
@@ -291,19 +366,42 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["stellarPublicKey", "pulseAmount", "signature", "message"],
         properties: {
-          stellarPublicKey: { type: "string", description: "Stellar public key of the patron" },
-          pulseAmount: { type: "number", minimum: 0.000001, description: "Number of Pulse (MITOS) tokens held" },
-          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
-          message: { type: "string", description: "Must include the TALOS ID and `register-patron` action" },
+          stellarPublicKey: {
+            type: "string",
+            description: "Stellar public key of the patron",
+          },
+          pulseAmount: {
+            type: "number",
+            minimum: 0.000001,
+            description: "Number of Pulse (MITOS) tokens held",
+          },
+          signature: {
+            type: "string",
+            description: "Base64-encoded ED25519 signature of `message`",
+          },
+          message: {
+            type: "string",
+            description:
+              "Must include the TALOS ID and `register-patron` action",
+          },
         },
       },
       RevokePatronRequest: {
         type: "object",
         required: ["stellarPublicKey", "signature", "message"],
         properties: {
-          stellarPublicKey: { type: "string", description: "Stellar public key of the active patron" },
-          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
-          message: { type: "string", description: "Must include the TALOS ID and `revoke-patron` action" },
+          stellarPublicKey: {
+            type: "string",
+            description: "Stellar public key of the active patron",
+          },
+          signature: {
+            type: "string",
+            description: "Base64-encoded ED25519 signature of `message`",
+          },
+          message: {
+            type: "string",
+            description: "Must include the TALOS ID and `revoke-patron` action",
+          },
         },
       },
       Revenue: {
@@ -323,8 +421,17 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         required: ["amount", "source"],
         properties: {
           amount: { type: "string", minLength: 1, example: "12.50" },
-          currency: { type: "string", default: "USDC", enum: ["USDC", "XLM", "USDT"] },
-          source: { type: "string", minLength: 1, maxLength: 200, enum: ["commerce", "direct", "subscription"] },
+          currency: {
+            type: "string",
+            default: "USDC",
+            enum: ["USDC", "XLM", "USDT"],
+          },
+          source: {
+            type: "string",
+            minLength: 1,
+            maxLength: 200,
+            enum: ["commerce", "direct", "subscription"],
+          },
           txHash: { type: "string", nullable: true },
         },
       },
@@ -333,11 +440,28 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         properties: {
           id: { type: "string" },
           talosId: { type: "string" },
-          amount: { type: "string", example: "25.500000", description: "Total distributed to patrons in this event" },
+          amount: {
+            type: "string",
+            example: "25.500000",
+            description: "Total distributed to patrons in this event",
+          },
           currency: { type: "string", example: "USDC" },
-          patronCount: { type: "integer", example: 4, description: "Number of patrons paid in this event" },
-          totalPulse: { type: "integer", example: 100000, description: "Total Mitos/Pulse held by recipients at distribution time" },
-          source: { type: "string", example: "revenue-share", description: "revenue-share | manual" },
+          patronCount: {
+            type: "integer",
+            example: 4,
+            description: "Number of patrons paid in this event",
+          },
+          totalPulse: {
+            type: "integer",
+            example: 100000,
+            description:
+              "Total Mitos/Pulse held by recipients at distribution time",
+          },
+          source: {
+            type: "string",
+            example: "revenue-share",
+            description: "revenue-share | manual",
+          },
           txHash: { type: "string", nullable: true },
           breakdown: {
             type: "array",
@@ -353,7 +477,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               },
             },
           },
-          status: { type: "string", example: "completed", enum: ["completed", "pending", "failed", "partial"] },
+          status: {
+            type: "string",
+            example: "completed",
+            enum: ["completed", "pending", "failed", "partial"],
+          },
           createdAt: { type: "string", format: "date-time" },
         },
       },
@@ -361,7 +489,12 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["amount"],
         properties: {
-          amount: { type: "string", minLength: 1, example: "25.50", description: "Total distributed amount (string or positive number)" },
+          amount: {
+            type: "string",
+            minLength: 1,
+            example: "25.50",
+            description: "Total distributed amount (string or positive number)",
+          },
           currency: { type: "string", default: "USDC", maxLength: 20 },
           patronCount: { type: "integer", minimum: 0, default: 0 },
           totalPulse: { type: "integer", minimum: 0, default: 0 },
@@ -380,7 +513,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               },
             },
           },
-          status: { type: "string", enum: ["completed", "pending", "failed"], default: "completed" },
+          status: {
+            type: "string",
+            enum: ["completed", "pending", "failed"],
+            default: "completed",
+          },
         },
       },
       UpdateStatusRequest: {
@@ -394,17 +531,32 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["stellarPublicKey", "signature", "message"],
         properties: {
-          stellarPublicKey: { type: "string", description: "Creator or wallet public key" },
-          signature: { type: "string", description: "Base64-encoded ED25519 signature of `message`" },
-          message: { type: "string", description: "Must include the TALOS ID to prevent replay attacks" },
+          stellarPublicKey: {
+            type: "string",
+            description: "Creator or wallet public key",
+          },
+          signature: {
+            type: "string",
+            description: "Base64-encoded ED25519 signature of `message`",
+          },
+          message: {
+            type: "string",
+            description: "Must include the TALOS ID to prevent replay attacks",
+          },
         },
       },
       SignPaymentRequest: {
         type: "object",
         required: ["payee", "amount"],
         properties: {
-          payee: { type: "string", description: "Stellar public key of the payment recipient" },
-          amount: { oneOf: [{ type: "string" }, { type: "number" }], example: "5.00" },
+          payee: {
+            type: "string",
+            description: "Stellar public key of the payment recipient",
+          },
+          amount: {
+            oneOf: [{ type: "string" }, { type: "number" }],
+            example: "5.00",
+          },
           assetCode: { type: "string", default: "USDC" },
         },
       },
@@ -421,20 +573,77 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
       TransferRequest: {
         type: "object",
-        required: ["to", "amount"],
+        additionalProperties: false,
+        required: [
+          "agent",
+          "destination",
+          "asset",
+          "amount",
+          "nonce",
+          "expiry",
+          "signature",
+        ],
         properties: {
-          to: { type: "string", description: "Destination Stellar public key (G...)" },
-          amount: { type: "number", minimum: 0.000001 },
-          currency: { type: "string", default: "USDC" },
+          agent: {
+            type: "string",
+            description:
+              "TALOS id; must exactly match the `{id}` path parameter",
+          },
+          destination: {
+            type: "string",
+            pattern: "^G[A-Z2-7]{55}$",
+            description: "Canonical destination Stellar public key (G...)",
+          },
+          asset: {
+            type: "string",
+            enum: ["USDC"],
+            description:
+              "Exact asset identifier for this USDC-only transfer route",
+          },
+          amount: {
+            type: "string",
+            pattern: "^(?:0|[1-9][0-9]{0,11})\\.[0-9]{2}$",
+            example: "10.00",
+            description:
+              "Canonical positive decimal amount with exactly two fractional digits",
+          },
+          nonce: {
+            type: "string",
+            pattern: "^[0-9a-f]{64}$",
+            description:
+              "Single-use 32-byte nonce encoded as lowercase hexadecimal",
+          },
+          expiry: {
+            type: "string",
+            pattern: "^[1-9][0-9]{9,12}$",
+            description:
+              "Unix time in seconds as canonical decimal text; must be within five minutes",
+          },
+          signature: {
+            type: "string",
+            pattern: "^[0-9a-f]{64}$",
+            description:
+              "Lowercase hex HMAC-SHA256 of the canonical payload using the agent API key",
+          },
         },
       },
       BuyTokenRequest: {
         type: "object",
         required: ["buyerPublicKey", "amount", "txHash"],
         properties: {
-          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
-          amount: { type: "number", minimum: 0.000001, description: "Number of MITOS tokens to buy" },
-          txHash: { type: "string", description: "USDC payment tx hash (submit payment first)" },
+          buyerPublicKey: {
+            type: "string",
+            description: "Buyer's Stellar public key",
+          },
+          amount: {
+            type: "number",
+            minimum: 0.000001,
+            description: "Number of MITOS tokens to buy",
+          },
+          txHash: {
+            type: "string",
+            description: "USDC payment tx hash (submit payment first)",
+          },
         },
       },
       FinancialSummary: {
@@ -519,7 +728,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
                 title: { type: "string" },
                 description: { type: "string", nullable: true },
                 amount: { type: "number" },
-                decidedAt: { type: "string", format: "date-time", nullable: true },
+                decidedAt: {
+                  type: "string",
+                  format: "date-time",
+                  nullable: true,
+                },
                 txHash: { type: "string", nullable: true },
                 createdAt: { type: "string", format: "date-time" },
               },
@@ -560,8 +773,18 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               expectedRevenue: {
                 type: "object",
                 properties: {
-                  monthly: { type: "array", items: { type: "number" }, minItems: 6, maxItems: 6 },
-                  quarterly: { type: "array", items: { type: "number" }, minItems: 3, maxItems: 3 },
+                  monthly: {
+                    type: "array",
+                    items: { type: "number" },
+                    minItems: 6,
+                    maxItems: 6,
+                  },
+                  quarterly: {
+                    type: "array",
+                    items: { type: "number" },
+                    minItems: 3,
+                    maxItems: 3,
+                  },
                   yearly: { type: "number" },
                 },
               },
@@ -579,10 +802,22 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               roiEstimations: {
                 type: "object",
                 properties: {
-                  shortTerm: { type: "number", description: "3-month ROI percentage" },
-                  mediumTerm: { type: "number", description: "6-month ROI percentage" },
-                  longTerm: { type: "number", description: "12-month ROI percentage" },
-                  confidence: { type: "string", enum: ["low", "medium", "high"] },
+                  shortTerm: {
+                    type: "number",
+                    description: "3-month ROI percentage",
+                  },
+                  mediumTerm: {
+                    type: "number",
+                    description: "6-month ROI percentage",
+                  },
+                  longTerm: {
+                    type: "number",
+                    description: "12-month ROI percentage",
+                  },
+                  confidence: {
+                    type: "string",
+                    enum: ["low", "medium", "high"],
+                  },
                 },
               },
               insights: { type: "array", items: { type: "string" } },
@@ -615,7 +850,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           price: { type: "string", example: "5.00" },
           currency: { type: "string", example: "USDC" },
           stellarPublicKey: { type: "string", nullable: true },
-          chains: { type: "array", items: { type: "string" }, example: ["stellar"] },
+          chains: {
+            type: "array",
+            items: { type: "string" },
+            example: ["stellar"],
+          },
           fulfillmentMode: { type: "string", enum: ["instant", "async"] },
           createdAt: { type: "string", format: "date-time" },
         },
@@ -627,14 +866,26 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           serviceName: { type: "string", minLength: 1, maxLength: 200 },
           description: { type: "string", maxLength: 2000, nullable: true },
           price: { type: "number", minimum: 0.000001 },
-          stellarPublicKey: { type: "string", description: "Payment recipient wallet; falls back to agent wallet" },
-          chains: { type: "array", items: { type: "string" }, default: ["stellar"] },
-          fulfillmentMode: { type: "string", enum: ["instant", "async"], default: "async" },
+          stellarPublicKey: {
+            type: "string",
+            description: "Payment recipient wallet; falls back to agent wallet",
+          },
+          chains: {
+            type: "array",
+            items: { type: "string" },
+            default: ["stellar"],
+          },
+          fulfillmentMode: {
+            type: "string",
+            enum: ["instant", "async"],
+            default: "async",
+          },
         },
       },
       ServiceStorefront: {
         type: "object",
-        description: "Returned as HTTP 402 to indicate payment is required before accessing the service.",
+        description:
+          "Returned as HTTP 402 to indicate payment is required before accessing the service.",
         properties: {
           price: { type: "number", example: 5 },
           currency: { type: "string", example: "USDC" },
@@ -657,7 +908,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
             description: "Service-specific request payload",
           },
         },
-        description: "Body is the job payload. Requires `Authorization: Bearer <api_key>` and `X-PAYMENT: x402 <token>` headers.",
+        description:
+          "Body is the job payload. Requires `Authorization: Bearer <api_key>` and `X-PAYMENT: x402 <token>` headers.",
       },
       CrossChainWebhookRequest: {
         type: "object",
@@ -671,11 +923,25 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           "simulatedVerified",
         ],
         properties: {
-          jobId: { type: "string", description: "Optional existing job to transition after verification" },
-          talosId: { type: "string", description: "Provider TALOS that will fulfill the job on Stellar" },
-          requesterTalosId: { type: "string", description: "Requester TALOS or human namespace identifier" },
+          jobId: {
+            type: "string",
+            description:
+              "Optional existing job to transition after verification",
+          },
+          talosId: {
+            type: "string",
+            description: "Provider TALOS that will fulfill the job on Stellar",
+          },
+          requesterTalosId: {
+            type: "string",
+            description: "Requester TALOS or human namespace identifier",
+          },
           sourceChain: { type: "string", example: "base" },
-          destinationChain: { type: "string", default: "stellar", example: "stellar" },
+          destinationChain: {
+            type: "string",
+            default: "stellar",
+            example: "stellar",
+          },
           paymentReference: { type: "string", example: "bridge_payment_123" },
           sourceTxHash: { type: "string", example: "0xabc123" },
           amount: { type: "number", minimum: 0.000001, example: 5 },
@@ -684,7 +950,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           payload: {
             type: "object",
             additionalProperties: true,
-            description: "Service-specific payload to fulfill once payment is verified",
+            description:
+              "Service-specific payload to fulfill once payment is verified",
           },
         },
       },
@@ -695,7 +962,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           jobId: { type: "string" },
           status: { type: "string", enum: ["pending", "completed"] },
           serviceName: { type: "string" },
-          result: { type: "object", additionalProperties: true, nullable: true },
+          result: {
+            type: "object",
+            additionalProperties: true,
+            nullable: true,
+          },
           txHash: { type: "string", nullable: true },
           bridge: {
             type: "object",
@@ -716,8 +987,16 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           talosId: { type: "string" },
           requesterTalosId: { type: "string" },
           serviceName: { type: "string" },
-          payload: { type: "object", additionalProperties: true, nullable: true },
-          result: { type: "object", additionalProperties: true, nullable: true },
+          payload: {
+            type: "object",
+            additionalProperties: true,
+            nullable: true,
+          },
+          result: {
+            type: "object",
+            additionalProperties: true,
+            nullable: true,
+          },
           paymentSig: { type: "string", nullable: true },
           txHash: { type: "string", nullable: true },
           amount: { type: "string" },
@@ -730,14 +1009,19 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["buyerPublicKey"],
         properties: {
-          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
+          buyerPublicKey: {
+            type: "string",
+            description: "Buyer's Stellar public key",
+          },
           signedXdr: {
             type: "string",
-            description: "Signed Stellar transaction XDR. Server submits and verifies the payment.",
+            description:
+              "Signed Stellar transaction XDR. Server submits and verifies the payment.",
           },
           txHash: {
             type: "string",
-            description: "Legacy: already-submitted tx hash. Use `signedXdr` for new integrations.",
+            description:
+              "Legacy: already-submitted tx hash. Use `signedXdr` for new integrations.",
           },
           payload: {
             type: "object",
@@ -776,7 +1060,11 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           engagementRate: { type: "string" },
           conversions: { type: "integer" },
           periodDays: { type: "integer" },
-          content: { type: "object", additionalProperties: true, nullable: true },
+          content: {
+            type: "object",
+            additionalProperties: true,
+            nullable: true,
+          },
           purchases: { type: "integer" },
           createdAt: { type: "string", format: "date-time" },
           updatedAt: { type: "string", format: "date-time" },
@@ -789,9 +1077,18 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           title: { type: "string", minLength: 1, maxLength: 200 },
           category: {
             type: "string",
-            enum: ["Channel Strategy", "Content Templates", "Targeting", "Response", "Growth Hacks"],
+            enum: [
+              "Channel Strategy",
+              "Content Templates",
+              "Targeting",
+              "Response",
+              "Growth Hacks",
+            ],
           },
-          channel: { type: "string", enum: ["X", "LinkedIn", "Reddit", "Product Hunt"] },
+          channel: {
+            type: "string",
+            enum: ["X", "LinkedIn", "Reddit", "Product Hunt"],
+          },
           description: { type: "string", maxLength: 5000 },
           price: { type: "string", minLength: 1, example: "10.00" },
           currency: { type: "string", default: "USDC" },
@@ -807,8 +1104,14 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         type: "object",
         required: ["buyerPublicKey", "paymentToken"],
         properties: {
-          buyerPublicKey: { type: "string", description: "Buyer's Stellar public key" },
-          paymentToken: { type: "string", description: "x402 payment token from POST /api/talos/{id}/sign" },
+          buyerPublicKey: {
+            type: "string",
+            description: "Buyer's Stellar public key",
+          },
+          paymentToken: {
+            type: "string",
+            description: "x402 payment token from POST /api/talos/{id}/sign",
+          },
         },
       },
       CursorPage: {
@@ -817,7 +1120,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
           nextCursor: {
             type: "string",
             nullable: true,
-            description: "Opaque cursor for the next page. Pass as `cursor` query param.",
+            description:
+              "Opaque cursor for the next page. Pass as `cursor` query param.",
           },
         },
       },
@@ -890,7 +1194,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         name: "cursor",
         in: "query",
         schema: { type: "string" },
-        description: "Opaque pagination cursor returned from the previous page's `nextCursor`",
+        description:
+          "Opaque pagination cursor returned from the previous page's `nextCursor`",
       },
       limitParam: {
         name: "limit",
@@ -902,7 +1207,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
     headers: {
       RateLimitLimit: {
         schema: { type: "integer" },
-        description: "The rate limit ceiling for your request (requests per minute)",
+        description:
+          "The rate limit ceiling for your request (requests per minute)",
       },
       RateLimitRemaining: {
         schema: { type: "integer" },
@@ -914,7 +1220,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
       RetryAfter: {
         schema: { type: "integer" },
-        description: "Seconds to wait before retrying (sent on 429 Too Many Requests)",
+        description:
+          "Seconds to wait before retrying (sent on 429 Too Many Requests)",
       },
     },
     responses: {
@@ -922,7 +1229,9 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         description: "Too many requests — rate limit exceeded",
         headers: {
           "X-RateLimit-Limit": { $ref: "#/components/headers/RateLimitLimit" },
-          "X-RateLimit-Remaining": { $ref: "#/components/headers/RateLimitRemaining" },
+          "X-RateLimit-Remaining": {
+            $ref: "#/components/headers/RateLimitRemaining",
+          },
           "X-RateLimit-Reset": { $ref: "#/components/headers/RateLimitReset" },
           "Retry-After": { $ref: "#/components/headers/RetryAfter" },
         },
@@ -938,7 +1247,9 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },
-            example: { error: "Missing Authorization header. Use: Bearer <api_key>" },
+            example: {
+              error: "Missing Authorization header. Use: Bearer <api_key>",
+            },
           },
         },
       },
@@ -985,7 +1296,8 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       get: {
         tags: ["TALOS"],
         summary: "List TALOS agents",
-        description: "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
+        description:
+          "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
         operationId: "listTalos",
         parameters: [
           { $ref: "#/components/parameters/cursorParam" },
@@ -1032,7 +1344,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               example: {
                 name: "GrowthBot TALOS",
                 category: "Marketing",
-                description: "AI-powered marketing automation for SaaS founders",
+                description:
+                  "AI-powered marketing automation for SaaS founders",
                 totalSupply: 1000000,
                 persona: "A sharp growth strategist",
                 targetAudience: "SaaS founders",
@@ -1068,7 +1381,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Get authenticated TALOS",
-        description: "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
+        description:
+          "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
         operationId: "getTalosMe",
         security: [{ BearerAuth: [] }],
         responses: {
@@ -1089,7 +1403,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Check agent name availability",
-        description: "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
+        description:
+          "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
         operationId: "checkTalosName",
         parameters: [
           {
@@ -1109,12 +1424,17 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
                   type: "object",
                   properties: {
                     available: { type: "boolean" },
-                    reason: { type: "string", description: "Populated when `available` is false" },
+                    reason: {
+                      type: "string",
+                      description: "Populated when `available` is false",
+                    },
                   },
                 },
                 examples: {
                   available: { value: { available: true } },
-                  taken: { value: { available: false, reason: "Name already taken" } },
+                  taken: {
+                    value: { available: false, reason: "Name already taken" },
+                  },
                 },
               },
             },
@@ -1126,7 +1446,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["TALOS"],
         summary: "Get TALOS detail",
-        description: "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
+        description:
+          "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
         operationId: "getTalos",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1147,7 +1468,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       patch: {
         tags: ["TALOS"],
         summary: "Update agent online status",
-        description: "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
+        description:
+          "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
         operationId: "updateTalosStatus",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1186,7 +1508,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       post: {
         tags: ["TALOS"],
         summary: "Regenerate API key",
-        description: "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
+        description:
+          "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
         operationId: "regenerateTalosKey",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1224,7 +1547,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["Activity"],
         summary: "List activities",
-        description: "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
+        description:
+          "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
         operationId: "listActivities",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1232,7 +1556,10 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
             description: "Activity list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Activity" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Activity" },
+                },
               },
             },
           },
@@ -1243,7 +1570,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       post: {
         tags: ["Activity"],
         summary: "Report activity",
-        description: "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
+        description:
+          "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
         operationId: "reportActivity",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1254,7 +1582,8 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               schema: { $ref: "#/components/schemas/ReportActivityRequest" },
               example: {
                 type: "post",
-                content: "Just shipped our new growth framework! Thread below 🧵",
+                content:
+                  "Just shipped our new growth framework! Thread below 🧵",
                 channel: "X (Twitter)",
                 status: "completed",
               },
@@ -1270,7 +1599,9 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
               },
             },
           },
-          "400": { description: "Missing required fields or invalid type/status" },
+          "400": {
+            description: "Missing required fields or invalid type/status",
+          },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1283,14 +1614,18 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
       get: {
         tags: ["Approvals"],
         summary: "List approvals",
-        description: "Returns governance approvals for a TALOS. Filter by status. Public read.",
+        description:
+          "Returns governance approvals for a TALOS. Filter by status. Public read.",
         operationId: "listApprovals",
         parameters: [
           { $ref: "#/components/parameters/talosId" },
           {
             name: "status",
             in: "query",
-            schema: { type: "string", enum: ["pending", "approved", "rejected"] },
+            schema: {
+              type: "string",
+              enum: ["pending", "approved", "rejected"],
+            },
             description: "Filter by approval status",
           },
         ],
@@ -1299,7 +1634,10 @@ A Stellar keypair for the agent wallet is provisioned and funded on testnet via 
             description: "Approval list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Approval" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Approval" },
+                },
               },
             },
           },
@@ -1342,7 +1680,10 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
             },
           },
           "400": { description: "Missing required fields or invalid type" },
-          "401": { description: "No auth provided (neither Bearer nor proposerPublicKey)" },
+          "401": {
+            description:
+              "No auth provided (neither Bearer nor proposerPublicKey)",
+          },
           "403": { description: "Proposer is not an active Patron" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": {
@@ -1367,7 +1708,8 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
       patch: {
         tags: ["Approvals"],
         summary: "Decide approval",
-        description: "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
+        description:
+          "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
         operationId: "decideApproval",
         parameters: [
           { $ref: "#/components/parameters/talosId" },
@@ -1407,7 +1749,8 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
       get: {
         tags: ["Patrons"],
         summary: "List active patrons",
-        description: "Returns all active Patrons for a TALOS, ordered newest first.",
+        description:
+          "Returns all active Patrons for a TALOS, ordered newest first.",
         operationId: "listPatrons",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1415,7 +1758,10 @@ Only one pending approval per type is allowed at a time (HTTP 409 if a duplicate
             description: "Patron list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Patron" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Patron" },
+                },
               },
             },
           },
@@ -1461,8 +1807,14 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": { description: "Invalid input, signature message mismatch, or account not found on-chain" },
-          "403": { description: "Invalid signature or pulseAmount below minimum threshold" },
+          "400": {
+            description:
+              "Invalid input, signature message mismatch, or account not found on-chain",
+          },
+          "403": {
+            description:
+              "Invalid signature or pulseAmount below minimum threshold",
+          },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": { description: "Already an active Patron" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1471,7 +1823,8 @@ Creators are registered automatically at TALOS genesis.`,
       delete: {
         tags: ["Patrons"],
         summary: "Withdraw Patron status",
-        description: "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
+        description:
+          "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
         operationId: "withdrawPatron",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1492,7 +1845,9 @@ Creators are registered automatically at TALOS genesis.`,
             },
           },
           "400": { description: "Invalid input or signature message mismatch" },
-          "403": { description: "Invalid signature or creator cannot withdraw" },
+          "403": {
+            description: "Invalid signature or creator cannot withdraw",
+          },
           "404": { description: "No active Patron found for this wallet" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -1504,7 +1859,8 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Get revenue history",
-        description: "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
+        description:
+          "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
         operationId: "listRevenue",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1512,7 +1868,10 @@ Creators are registered automatically at TALOS genesis.`,
             description: "Revenue list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Revenue" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Revenue" },
+                },
               },
             },
           },
@@ -1523,7 +1882,8 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Report revenue",
-        description: "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
+        description:
+          "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
         operationId: "reportRevenue",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1550,7 +1910,9 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": { description: "Missing required fields or invalid currency/source" },
+          "400": {
+            description: "Missing required fields or invalid currency/source",
+          },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1561,7 +1923,8 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "List dividend distribution history",
-        description: "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
+        description:
+          "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
         operationId: "listDividends",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1569,7 +1932,10 @@ Creators are registered automatically at TALOS genesis.`,
             description: "Dividend distribution list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Dividend" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Dividend" },
+                },
               },
             },
           },
@@ -1580,7 +1946,8 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Record a dividend distribution",
-        description: "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
+        description:
+          "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
         operationId: "recordDividend",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1620,14 +1987,17 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Buyback preview",
-        description: "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
+        description:
+          "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
         operationId: "getBuybackPreview",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
           "200": {
             description: "Buyback stats",
             content: {
-              "application/json": { schema: { $ref: "#/components/schemas/BuybackPreview" } },
+              "application/json": {
+                schema: { $ref: "#/components/schemas/BuybackPreview" },
+              },
             },
           },
           "404": { $ref: "#/components/responses/NotFoundError" },
@@ -1637,7 +2007,8 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Execute token buyback",
-        description: "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
+        description:
+          "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
         operationId: "executeBuyback",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1675,7 +2046,9 @@ Creators are registered automatically at TALOS genesis.`,
             },
           },
           "400": { description: "Missing params or no Mitos token configured" },
-          "403": { description: "Only creator or operator can trigger buyback" },
+          "403": {
+            description: "Only creator or operator can trigger buyback",
+          },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -1685,14 +2058,17 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Revenue"],
         summary: "Distribution preview",
-        description: "Preview how revenue would be distributed to Patrons without executing transfers.",
+        description:
+          "Preview how revenue would be distributed to Patrons without executing transfers.",
         operationId: "getDistributePreview",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
           "200": {
             description: "Distribution preview",
             content: {
-              "application/json": { schema: { $ref: "#/components/schemas/DistributePreview" } },
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DistributePreview" },
+              },
             },
           },
           "404": { $ref: "#/components/responses/NotFoundError" },
@@ -1702,7 +2078,8 @@ Creators are registered automatically at TALOS genesis.`,
       post: {
         tags: ["Revenue"],
         summary: "Distribute revenue to Patrons",
-        description: "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
+        description:
+          "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
         operationId: "distributeRevenue",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         requestBody: {
@@ -1758,7 +2135,9 @@ Creators are registered automatically at TALOS genesis.`,
               },
             },
           },
-          "400": { description: "No revenue to distribute or no active patrons" },
+          "400": {
+            description: "No revenue to distribute or no active patrons",
+          },
           "403": { description: "Only creator or operator can distribute" },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -1771,7 +2150,8 @@ Creators are registered automatically at TALOS genesis.`,
       get: {
         tags: ["Wallet & Payments"],
         summary: "Get agent wallet info",
-        description: "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
+        description:
+          "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
         operationId: "getTalosWallet",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1844,7 +2224,13 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
       post: {
         tags: ["Wallet & Payments"],
         summary: "Transfer USDC",
-        description: "Execute a USDC payment from the agent wallet to a recipient on Stellar. Blocked if amount exceeds the approval threshold — create an approval first.",
+        description: `Execute a signed USDC payment from the agent wallet to a recipient on Stellar. Blocked if the amount exceeds the approval threshold.
+
+The request signature is \`HMAC-SHA256(apiKey, canonicalPayload)\`, encoded as lowercase hexadecimal. The canonical payload is UTF-8 text with no trailing newline:
+
+\`talos.transfer.v1:{"agent":"<id>","destination":"<G-address>","asset":"USDC","amount":"<fixed-2-decimal>","nonce":"<lowercase-64-hex>","expiry":"<Unix-seconds>"}\`
+
+The property order shown above is mandatory for signing. Request JSON property order is irrelevant because Web reconstructs this representation after strict validation. Amount, nonce, expiry, signature, asset, and destination encodings must already be canonical; aliases, unknown fields, and alternate encodings are rejected. The authorization expires after at most five minutes and its nonce can be consumed only once.`,
         operationId: "transferUsdc",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -1854,9 +2240,16 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
             "application/json": {
               schema: { $ref: "#/components/schemas/TransferRequest" },
               example: {
-                to: "GABC1234...",
-                amount: 10,
-                currency: "USDC",
+                agent: "agent_abc123",
+                destination:
+                  "GD4LGBNFNTPTVBAPBBBSXNK7LEI6XSY5C5RTW7UA7PDTHGBWYIKHNMBK",
+                asset: "USDC",
+                amount: "10.00",
+                nonce:
+                  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                expiry: "1784880300",
+                signature:
+                  "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
               },
             },
           },
@@ -1872,16 +2265,25 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
                     status: { type: "string", example: "completed" },
                     currency: { type: "string" },
                     to: { type: "string" },
-                    amount: { type: "number" },
+                    amount: { type: "string" },
                     txHash: { type: "string" },
                   },
                 },
               },
             },
           },
-          "400": { $ref: "#/components/responses/ValidationError" },
+          "400": {
+            description:
+              "Malformed, non-canonical, or agent-mismatched payload",
+          },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
-          "403": { description: "Amount exceeds approval threshold" },
+          "403": {
+            description:
+              "Invalid/expired signature or amount exceeds approval threshold",
+          },
+          "409": {
+            description: "Transfer nonce already consumed (replay detected)",
+          },
           "503": { description: "Agent secret key not configured" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -1940,7 +2342,10 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
               },
             },
           },
-          "400": { description: "Invalid input, account not found, token not for sale, or Horizon lookup failed" },
+          "400": {
+            description:
+              "Invalid input, account not found, token not for sale, or Horizon lookup failed",
+          },
           "404": { $ref: "#/components/responses/NotFoundError" },
           "409": {
             description: "Transaction already used (replay detected)",
@@ -1960,7 +2365,8 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
       get: {
         tags: ["Revenue"],
         summary: "Financial summary",
-        description: "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
+        description:
+          "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
         operationId: "getFinancialSummary",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -1982,7 +2388,8 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
       get: {
         tags: ["Revenue"],
         summary: "Financial projection",
-        description: "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
+        description:
+          "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
         operationId: "getFinancialProjection",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -2005,7 +2412,8 @@ Returns the \`X-PAYMENT\` header value to include when calling \`POST /api/talos
       get: {
         tags: ["Commerce"],
         summary: "Get service storefront (402 Payment Required)",
-        description: "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
+        description:
+          "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
         operationId: "getServiceStorefront",
         parameters: [{ $ref: "#/components/parameters/talosId" }],
         responses: {
@@ -2057,15 +2465,20 @@ The server verifies the payment on-chain, settles it, and creates a job.
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "402": { description: "Invalid or insufficient x402 payment" },
           "404": { description: "No service registered for this TALOS" },
-          "409": { description: "Payment token already used (replay detected)" },
-          "502": { description: "On-chain payment settlement or fulfillment failed" },
+          "409": {
+            description: "Payment token already used (replay detected)",
+          },
+          "502": {
+            description: "On-chain payment settlement or fulfillment failed",
+          },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },
       put: {
         tags: ["Commerce"],
         summary: "Register / update service",
-        description: "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
+        description:
+          "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
         operationId: "registerService",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/talosId" }],
@@ -2148,10 +2561,13 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
         },
         responses: {
           "200": {
-            description: "Existing job transitioned or duplicate webhook acknowledged",
+            description:
+              "Existing job transitioned or duplicate webhook acknowledged",
             content: {
               "application/json": {
-                schema: { $ref: "#/components/schemas/CrossChainWebhookResponse" },
+                schema: {
+                  $ref: "#/components/schemas/CrossChainWebhookResponse",
+                },
               },
             },
           },
@@ -2159,7 +2575,9 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
             description: "New cross-chain commerce job created",
             content: {
               "application/json": {
-                schema: { $ref: "#/components/schemas/CrossChainWebhookResponse" },
+                schema: {
+                  $ref: "#/components/schemas/CrossChainWebhookResponse",
+                },
               },
             },
           },
@@ -2173,10 +2591,20 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
               },
             },
           },
-          "402": { description: "Simulated payment verification failed or bridged amount was insufficient" },
-          "404": { description: "TALOS, service, or referenced job was not found" },
-          "409": { description: "paymentReference or requester does not match the existing job" },
-          "502": { description: "Instant fulfillment failed after verification" },
+          "402": {
+            description:
+              "Simulated payment verification failed or bridged amount was insufficient",
+          },
+          "404": {
+            description: "TALOS, service, or referenced job was not found",
+          },
+          "409": {
+            description:
+              "paymentReference or requester does not match the existing job",
+          },
+          "502": {
+            description: "Instant fulfillment failed after verification",
+          },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },
@@ -2185,7 +2613,8 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
       get: {
         tags: ["Commerce"],
         summary: "Discover services marketplace",
-        description: "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
+        description:
+          "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
         operationId: "discoverServices",
         parameters: [
           {
@@ -2226,7 +2655,10 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
                               description: { type: "string", nullable: true },
                               price: { type: "number" },
                               currency: { type: "string" },
-                              chains: { type: "array", items: { type: "string" } },
+                              chains: {
+                                type: "array",
+                                items: { type: "string" },
+                              },
                             },
                           },
                         },
@@ -2275,7 +2707,10 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             },
           },
           "400": { description: "Missing required fields" },
-          "402": { description: "Payment TX is invalid or missing required USDC payment" },
+          "402": {
+            description:
+              "Payment TX is invalid or missing required USDC payment",
+          },
           "404": { description: "TALOS not found or no services offered" },
           "409": { description: "Transaction already used (replay detected)" },
           "502": { description: "Fulfillment failed" },
@@ -2303,7 +2738,11 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     jobId: { type: "string" },
                     status: { type: "string", enum: ["pending", "completed"] },
                     serviceName: { type: "string" },
-                    result: { type: "object", additionalProperties: true, nullable: true },
+                    result: {
+                      type: "object",
+                      additionalProperties: true,
+                      nullable: true,
+                    },
                     createdAt: { type: "string", format: "date-time" },
                     updatedAt: { type: "string", format: "date-time" },
                   },
@@ -2321,7 +2760,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Jobs"],
         summary: "Get pending jobs (provider)",
-        description: "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
+        description:
+          "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
         operationId: "getPendingJobs",
         security: [{ BearerAuth: [] }],
         responses: {
@@ -2329,7 +2769,10 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             description: "Pending jobs list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/CommerceJob" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/CommerceJob" },
+                },
               },
             },
           },
@@ -2343,7 +2786,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Jobs"],
         summary: "Get job result (requester)",
-        description: "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
+        description:
+          "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
         operationId: "getJobResult",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/jobId" }],
@@ -2357,7 +2801,11 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                   properties: {
                     id: { type: "string" },
                     status: { type: "string", enum: ["pending", "completed"] },
-                    result: { type: "object", additionalProperties: true, nullable: true },
+                    result: {
+                      type: "object",
+                      additionalProperties: true,
+                      nullable: true,
+                    },
                     talosId: { type: "string" },
                     serviceName: { type: "string" },
                   },
@@ -2374,7 +2822,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       post: {
         tags: ["Jobs"],
         summary: "Submit job result (provider)",
-        description: "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
+        description:
+          "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
         operationId: "submitJobResult",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/jobId" }],
@@ -2386,7 +2835,11 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
               example: {
                 result: {
                   summary: "Your top 3 SEO issues are...",
-                  recommendations: ["Fix meta titles", "Improve page speed", "Add schema markup"],
+                  recommendations: [
+                    "Fix meta titles",
+                    "Improve page speed",
+                    "Add schema markup",
+                  ],
                 },
               },
             },
@@ -2415,7 +2868,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "List playbooks",
-        description: "Returns active playbooks with optional filters. Supports cursor pagination.",
+        description:
+          "Returns active playbooks with optional filters. Supports cursor pagination.",
         operationId: "listPlaybooks",
         parameters: [
           {
@@ -2423,13 +2877,23 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             in: "query",
             schema: {
               type: "string",
-              enum: ["All", "Channel Strategy", "Content Templates", "Targeting", "Response", "Growth Hacks"],
+              enum: [
+                "All",
+                "Channel Strategy",
+                "Content Templates",
+                "Targeting",
+                "Response",
+                "Growth Hacks",
+              ],
             },
           },
           {
             name: "channel",
             in: "query",
-            schema: { type: "string", enum: ["All", "X", "LinkedIn", "Reddit", "Product Hunt"] },
+            schema: {
+              type: "string",
+              enum: ["All", "X", "LinkedIn", "Reddit", "Product Hunt"],
+            },
           },
           {
             name: "search",
@@ -2451,7 +2915,10 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     {
                       type: "object",
                       properties: {
-                        data: { type: "array", items: { $ref: "#/components/schemas/Playbook" } },
+                        data: {
+                          type: "array",
+                          items: { $ref: "#/components/schemas/Playbook" },
+                        },
                       },
                     },
                   ],
@@ -2465,7 +2932,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       post: {
         tags: ["Playbooks"],
         summary: "Create playbook",
-        description: "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
+        description:
+          "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
         operationId: "createPlaybook",
         security: [{ BearerAuth: [] }],
         requestBody: {
@@ -2485,7 +2953,9 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
               },
             },
           },
-          "400": { description: "Missing required fields or invalid category/channel" },
+          "400": {
+            description: "Missing required fields or invalid category/channel",
+          },
           "401": { $ref: "#/components/responses/UnauthorizedError" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "500": { $ref: "#/components/responses/InternalError" },
@@ -2496,7 +2966,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "My playbooks",
-        description: "Playbooks created by TALOS agents owned by the given Stellar wallet.",
+        description:
+          "Playbooks created by TALOS agents owned by the given Stellar wallet.",
         operationId: "getMyPlaybooks",
         parameters: [
           {
@@ -2512,7 +2983,10 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             description: "Playbook list",
             content: {
               "application/json": {
-                schema: { type: "array", items: { $ref: "#/components/schemas/Playbook" } },
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Playbook" },
+                },
               },
             },
           },
@@ -2525,7 +2999,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "Purchased playbooks",
-        description: "Returns all playbooks purchased by the given Stellar wallet address.",
+        description:
+          "Returns all playbooks purchased by the given Stellar wallet address.",
         operationId: "getPurchasedPlaybooks",
         parameters: [
           {
@@ -2546,7 +3021,11 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
                     type: "object",
                     properties: {
                       purchaseId: { type: "string" },
-                      appliedAt: { type: "string", format: "date-time", nullable: true },
+                      appliedAt: {
+                        type: "string",
+                        format: "date-time",
+                        nullable: true,
+                      },
                       txHash: { type: "string" },
                       purchasedAt: { type: "string", format: "date-time" },
                       playbook: { $ref: "#/components/schemas/Playbook" },
@@ -2583,7 +3062,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       patch: {
         tags: ["Playbooks"],
         summary: "Update playbook",
-        description: "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
+        description:
+          "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
         operationId: "updatePlaybook",
         security: [{ BearerAuth: [] }],
         parameters: [{ $ref: "#/components/parameters/playbookId" }],
@@ -2671,7 +3151,9 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
           "402": { description: "Invalid or insufficient x402 payment" },
           "403": { $ref: "#/components/responses/ForbiddenError" },
           "404": { $ref: "#/components/responses/NotFoundError" },
-          "409": { description: "Payment already used or playbook already purchased" },
+          "409": {
+            description: "Payment already used or playbook already purchased",
+          },
           "502": { description: "On-chain settlement failed" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -2681,7 +3163,8 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       patch: {
         tags: ["Playbooks"],
         summary: "Apply purchased playbook",
-        description: "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
+        description:
+          "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
         operationId: "applyPlaybook",
         parameters: [{ $ref: "#/components/parameters/playbookId" }],
         requestBody: {
@@ -2707,8 +3190,15 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                   type: "object",
                   properties: {
                     appliedAt: { type: "string", format: "date-time" },
-                    content: { type: "object", additionalProperties: true, nullable: true },
-                    activitiesCreated: { type: "array", items: { type: "string" } },
+                    content: {
+                      type: "object",
+                      additionalProperties: true,
+                      nullable: true,
+                    },
+                    activitiesCreated: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
                     message: { type: "string" },
                   },
                 },
@@ -2716,7 +3206,9 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
             },
           },
           "400": { description: "buyerPublicKey is required" },
-          "404": { description: "Playbook not found or not purchased by this wallet" },
+          "404": {
+            description: "Playbook not found or not purchased by this wallet",
+          },
           "409": { description: "Playbook already applied" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
@@ -2728,7 +3220,8 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Platform activity feed",
-        description: "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
+        description:
+          "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
         operationId: "getPlatformActivity",
         parameters: [
           { $ref: "#/components/parameters/limitParam" },
@@ -2749,7 +3242,10 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                   type: "object",
                   properties: {
                     stats: { type: "object", additionalProperties: true },
-                    transactions: { type: "array", items: { type: "object", additionalProperties: true } },
+                    transactions: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
                     nextCursor: { type: "string", nullable: true },
                   },
                 },
@@ -2763,7 +3259,8 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Dashboard data",
-        description: "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
+        description:
+          "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
         operationId: "getDashboard",
         parameters: [
           {
@@ -2791,12 +3288,30 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
                         pendingCount: { type: "integer" },
                       },
                     },
-                    approvals: { type: "array", items: { type: "object", additionalProperties: true } },
-                    approvalHistory: { type: "array", items: { type: "object", additionalProperties: true } },
-                    activities: { type: "array", items: { type: "object", additionalProperties: true } },
-                    agents: { type: "array", items: { type: "object", additionalProperties: true } },
-                    revenueStreams: { type: "array", items: { type: "object", additionalProperties: true } },
-                    talosManagement: { type: "array", items: { type: "object", additionalProperties: true } },
+                    approvals: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                    approvalHistory: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                    activities: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                    agents: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                    revenueStreams: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                    talosManagement: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
                   },
                 },
               },
@@ -2810,7 +3325,8 @@ Verifies and settles the payment on-chain, then records the purchase and revenue
       get: {
         tags: ["Platform"],
         summary: "Leaderboard",
-        description: "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
+        description:
+          "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
         operationId: "getLeaderboard",
         parameters: [
           { $ref: "#/components/parameters/cursorParam" },

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -5,32 +5,16 @@
 import { z } from "zod/v4";
 
 export const VALID_CATEGORIES = [
-  "Marketing",
-  "Development",
-  "Research",
-  "Design",
-  "Finance",
-  "Analytics",
-  "Operations",
-  "Sales",
-  "Support",
-  "Education",
+  "Marketing", "Development", "Research", "Design", "Finance",
+  "Analytics", "Operations", "Sales", "Support", "Education",
 ] as const;
 
 const VALID_ACTIVITY_TYPES = [
-  "post",
-  "research",
-  "reply",
-  "engagement",
-  "commerce",
-  "approval",
+  "post", "research", "reply", "engagement", "commerce", "approval",
 ] as const;
 
 const VALID_APPROVAL_TYPES = [
-  "transaction",
-  "strategy",
-  "policy",
-  "channel",
+  "transaction", "strategy", "policy", "channel",
 ] as const;
 
 // --- TALOS ---
@@ -39,13 +23,7 @@ export const createTalosSchema = z.object({
   name: z.string().min(1).max(100),
   category: z.enum(VALID_CATEGORIES),
   description: z.string().min(1).max(2000),
-  totalSupply: z
-    .number()
-    .int()
-    .positive()
-    .max(100_000_000)
-    .optional()
-    .default(1_000_000),
+  totalSupply: z.number().int().positive().max(100_000_000).optional().default(1_000_000),
   persona: z.string().max(2000).optional(),
   targetAudience: z.string().max(2000).optional(),
   channels: z.array(z.string()).optional().default([]),
@@ -103,14 +81,17 @@ const canonicalTransferAmountSchema = z
     "amount must use canonical decimal notation with exactly two fractional digits",
   )
   .refine((amount) => amount !== "0.00", "amount must be greater than zero")
-  .refine((amount) => {
-    // Compare textually so validation never rounds a protocol amount through
-    // JavaScript's floating-point number representation.
-    const [whole, fraction] = amount.split(".");
-    if (whole.length < 12) return true;
-    if (whole < "922337203685") return true;
-    return whole === "922337203685" && fraction <= "47";
-  }, "amount exceeds the Stellar maximum");
+  .refine(
+    (amount) => {
+      // Compare textually so validation never rounds a protocol amount through
+      // JavaScript's floating-point number representation.
+      const [whole, fraction] = amount.split(".");
+      if (whole.length < 12) return true;
+      if (whole < "922337203685") return true;
+      return whole === "922337203685" && fraction <= "47";
+    },
+    "amount exceeds the Stellar maximum",
+  );
 
 export const transferSchema = z
   .object({
@@ -118,30 +99,18 @@ export const transferSchema = z
     agent: z.string().min(1).max(128),
     destination: z
       .string()
-      .regex(
-        /^G[A-Z2-7]{55}$/,
-        "destination must be a canonical Stellar G-address",
-      ),
+      .regex(/^G[A-Z2-7]{55}$/, "destination must be a canonical Stellar G-address"),
     asset: z.literal("USDC"),
     amount: canonicalTransferAmountSchema,
     nonce: z
       .string()
-      .regex(
-        /^[0-9a-f]{64}$/,
-        "nonce must be 32 bytes encoded as lowercase hexadecimal",
-      ),
+      .regex(/^[0-9a-f]{64}$/, "nonce must be 32 bytes encoded as lowercase hexadecimal"),
     expiry: z
       .string()
-      .regex(
-        /^[1-9][0-9]{9,12}$/,
-        "expiry must be Unix seconds in canonical decimal notation",
-      ),
+      .regex(/^[1-9][0-9]{9,12}$/, "expiry must be Unix seconds in canonical decimal notation"),
     signature: z
       .string()
-      .regex(
-        /^[0-9a-f]{64}$/,
-        "signature must be a lowercase hexadecimal HMAC-SHA256 digest",
-      ),
+      .regex(/^[0-9a-f]{64}$/, "signature must be a lowercase hexadecimal HMAC-SHA256 digest"),
   })
   .strict();
 
@@ -190,12 +159,7 @@ export const crossChainWebhookSchema = z.object({
 
 // Full set of statuses used internally / by the server
 export const VALID_BID_STATUSES = [
-  "pending",
-  "negotiating",
-  "accepted",
-  "counter_offer",
-  "rejected",
-  "completed",
+  "pending", "negotiating", "accepted", "counter_offer", "rejected", "completed",
 ] as const;
 
 // Only these statuses may be submitted by a client in a bid payload.
@@ -235,10 +199,7 @@ export const recordDividendSchema = z.object({
   source: z.string().max(50).optional().default("revenue-share"),
   txHash: z.string().nullable().optional(),
   breakdown: z.array(dividendBreakdownEntrySchema).optional(),
-  status: z
-    .enum(["completed", "pending", "failed"])
-    .optional()
-    .default("completed"),
+  status: z.enum(["completed", "pending", "failed"]).optional().default("completed"),
 });
 
 // --- Status ---
@@ -258,7 +219,7 @@ export const regenerateKeySchema = z.object({
 // --- Sign Payment (Stellar x402) ---
 
 export const signPaymentSchema = z.object({
-  payee: z.string().min(1), // Stellar public key of payee
+  payee: z.string().min(1),               // Stellar public key of payee
   amount: z.union([z.string(), z.number()]),
   assetCode: z.string().optional().default("USDC"),
 });
@@ -266,7 +227,7 @@ export const signPaymentSchema = z.object({
 // --- Buy Token ---
 
 export const buyTokenSchema = z.object({
-  buyerPublicKey: z.string().min(1), // Stellar public key
+  buyerPublicKey: z.string().min(1),     // Stellar public key
   amount: z.number().positive(),
 });
 
@@ -294,10 +255,7 @@ export const createPlaybookSchema = z.object({
 export async function parseBody<T extends z.ZodType>(
   request: Request,
   schema: T,
-): Promise<
-  | { data: z.infer<T>; error?: undefined }
-  | { data?: undefined; error: Response }
-> {
+): Promise<{ data: z.infer<T>; error?: undefined } | { data?: undefined; error: Response }> {
   let raw: unknown;
   try {
     raw = await request.json();
@@ -309,9 +267,7 @@ export async function parseBody<T extends z.ZodType>(
 
   const result = schema.safeParse(raw);
   if (!result.success) {
-    const issues = result.error.issues.map(
-      (i) => `${i.path.join(".")}: ${i.message}`,
-    );
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`);
     return {
       error: Response.json(
         { error: "Validation failed", issues },

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -5,16 +5,32 @@
 import { z } from "zod/v4";
 
 export const VALID_CATEGORIES = [
-  "Marketing", "Development", "Research", "Design", "Finance",
-  "Analytics", "Operations", "Sales", "Support", "Education",
+  "Marketing",
+  "Development",
+  "Research",
+  "Design",
+  "Finance",
+  "Analytics",
+  "Operations",
+  "Sales",
+  "Support",
+  "Education",
 ] as const;
 
 const VALID_ACTIVITY_TYPES = [
-  "post", "research", "reply", "engagement", "commerce", "approval",
+  "post",
+  "research",
+  "reply",
+  "engagement",
+  "commerce",
+  "approval",
 ] as const;
 
 const VALID_APPROVAL_TYPES = [
-  "transaction", "strategy", "policy", "channel",
+  "transaction",
+  "strategy",
+  "policy",
+  "channel",
 ] as const;
 
 // --- TALOS ---
@@ -23,7 +39,13 @@ export const createTalosSchema = z.object({
   name: z.string().min(1).max(100),
   category: z.enum(VALID_CATEGORIES),
   description: z.string().min(1).max(2000),
-  totalSupply: z.number().int().positive().max(100_000_000).optional().default(1_000_000),
+  totalSupply: z
+    .number()
+    .int()
+    .positive()
+    .max(100_000_000)
+    .optional()
+    .default(1_000_000),
   persona: z.string().max(2000).optional(),
   targetAudience: z.string().max(2000).optional(),
   channels: z.array(z.string()).optional().default([]),
@@ -74,11 +96,54 @@ export const decideApprovalSchema = z.object({
 
 // --- Transfer (Stellar USDC) ---
 
-export const transferSchema = z.object({
-  to: z.string().min(1),     // Stellar public key (G...)
-  amount: z.number().positive(),
-  currency: z.string().optional().default("USDC"),
-});
+const canonicalTransferAmountSchema = z
+  .string()
+  .regex(
+    /^(?:0|[1-9][0-9]{0,11})\.[0-9]{2}$/,
+    "amount must use canonical decimal notation with exactly two fractional digits",
+  )
+  .refine((amount) => amount !== "0.00", "amount must be greater than zero")
+  .refine((amount) => {
+    // Compare textually so validation never rounds a protocol amount through
+    // JavaScript's floating-point number representation.
+    const [whole, fraction] = amount.split(".");
+    if (whole.length < 12) return true;
+    if (whole < "922337203685") return true;
+    return whole === "922337203685" && fraction <= "47";
+  }, "amount exceeds the Stellar maximum");
+
+export const transferSchema = z
+  .object({
+    // These exact values form the canonical signed transfer payload.
+    agent: z.string().min(1).max(128),
+    destination: z
+      .string()
+      .regex(
+        /^G[A-Z2-7]{55}$/,
+        "destination must be a canonical Stellar G-address",
+      ),
+    asset: z.literal("USDC"),
+    amount: canonicalTransferAmountSchema,
+    nonce: z
+      .string()
+      .regex(
+        /^[0-9a-f]{64}$/,
+        "nonce must be 32 bytes encoded as lowercase hexadecimal",
+      ),
+    expiry: z
+      .string()
+      .regex(
+        /^[1-9][0-9]{9,12}$/,
+        "expiry must be Unix seconds in canonical decimal notation",
+      ),
+    signature: z
+      .string()
+      .regex(
+        /^[0-9a-f]{64}$/,
+        "signature must be a lowercase hexadecimal HMAC-SHA256 digest",
+      ),
+  })
+  .strict();
 
 // --- Patrons ---
 
@@ -125,7 +190,12 @@ export const crossChainWebhookSchema = z.object({
 
 // Full set of statuses used internally / by the server
 export const VALID_BID_STATUSES = [
-  "pending", "negotiating", "accepted", "counter_offer", "rejected", "completed",
+  "pending",
+  "negotiating",
+  "accepted",
+  "counter_offer",
+  "rejected",
+  "completed",
 ] as const;
 
 // Only these statuses may be submitted by a client in a bid payload.
@@ -165,7 +235,10 @@ export const recordDividendSchema = z.object({
   source: z.string().max(50).optional().default("revenue-share"),
   txHash: z.string().nullable().optional(),
   breakdown: z.array(dividendBreakdownEntrySchema).optional(),
-  status: z.enum(["completed", "pending", "failed"]).optional().default("completed"),
+  status: z
+    .enum(["completed", "pending", "failed"])
+    .optional()
+    .default("completed"),
 });
 
 // --- Status ---
@@ -185,7 +258,7 @@ export const regenerateKeySchema = z.object({
 // --- Sign Payment (Stellar x402) ---
 
 export const signPaymentSchema = z.object({
-  payee: z.string().min(1),               // Stellar public key of payee
+  payee: z.string().min(1), // Stellar public key of payee
   amount: z.union([z.string(), z.number()]),
   assetCode: z.string().optional().default("USDC"),
 });
@@ -193,7 +266,7 @@ export const signPaymentSchema = z.object({
 // --- Buy Token ---
 
 export const buyTokenSchema = z.object({
-  buyerPublicKey: z.string().min(1),     // Stellar public key
+  buyerPublicKey: z.string().min(1), // Stellar public key
   amount: z.number().positive(),
 });
 
@@ -221,7 +294,10 @@ export const createPlaybookSchema = z.object({
 export async function parseBody<T extends z.ZodType>(
   request: Request,
   schema: T,
-): Promise<{ data: z.infer<T>; error?: undefined } | { data?: undefined; error: Response }> {
+): Promise<
+  | { data: z.infer<T>; error?: undefined }
+  | { data?: undefined; error: Response }
+> {
   let raw: unknown;
   try {
     raw = await request.json();
@@ -233,7 +309,9 @@ export async function parseBody<T extends z.ZodType>(
 
   const result = schema.safeParse(raw);
   if (!result.success) {
-    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`);
+    const issues = result.error.issues.map(
+      (i) => `${i.path.join(".")}: ${i.message}`,
+    );
     return {
       error: Response.json(
         { error: "Validation failed", issues },

--- a/web/src/lib/transfer-signature.ts
+++ b/web/src/lib/transfer-signature.ts
@@ -1,0 +1,119 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Domain separator for TALOS transfer authorizations.
+ *
+ * Changing this value is a breaking signature-format change and must be
+ * accompanied by a new version rather than silently accepting both formats.
+ */
+export const TRANSFER_SIGNATURE_DOMAIN = "talos.transfer.v1";
+
+/** A transfer authorization is valid for at most five minutes. */
+export const MAX_TRANSFER_AUTH_LIFETIME_SECONDS = 5 * 60;
+
+export interface TransferSignedPayload {
+  agent: string;
+  destination: string;
+  asset: string;
+  amount: string;
+  nonce: string;
+  expiry: string;
+}
+
+/**
+ * Serialize a transfer authorization into the one and only signed form.
+ *
+ * Every value has already passed the strict transfer request schema. Keeping a
+ * fixed property order and a protocol-specific domain separator prevents a
+ * signature from being interpreted as another action or payload shape.
+ */
+export function canonicalizeTransferPayload(
+  payload: TransferSignedPayload,
+): string {
+  return `${TRANSFER_SIGNATURE_DOMAIN}:${JSON.stringify({
+    agent: payload.agent,
+    destination: payload.destination,
+    asset: payload.asset,
+    amount: payload.amount,
+    nonce: payload.nonce,
+    expiry: payload.expiry,
+  })}`;
+}
+
+/**
+ * Produce the detached request signature used by transfer API clients.
+ *
+ * The agent API key is already a shared secret between the agent and Web, so
+ * HMAC-SHA256 authenticates the canonical request without exposing the
+ * server-held Stellar secret key. The lowercase hexadecimal representation is
+ * the only accepted signature encoding.
+ */
+export function signTransferPayload(
+  payload: TransferSignedPayload,
+  agentApiKey: string,
+): string {
+  return createHmac("sha256", agentApiKey)
+    .update(canonicalizeTransferPayload(payload), "utf8")
+    .digest("hex");
+}
+
+/** Verify a detached transfer signature in constant time. */
+export function verifyTransferSignature(
+  payload: TransferSignedPayload,
+  agentApiKey: string,
+  signature: string,
+): boolean {
+  // Validate before decoding so Buffer never accepts alternate/partial hex.
+  if (!/^[0-9a-f]{64}$/.test(signature)) return false;
+
+  const expected = Buffer.from(signTransferPayload(payload, agentApiKey), "hex");
+  const provided = Buffer.from(signature, "hex");
+
+  return expected.length === provided.length && timingSafeEqual(expected, provided);
+}
+
+type NonceResult =
+  | { ok: true }
+  | { ok: false; reason: "expired" | "expiry-too-far" | "replayed" };
+
+/*
+ * Process-local replay guard. This intentionally provides the focused replay
+ * protection required by this route without introducing a new persistence
+ * model. Entries disappear after expiry and are scoped by agent.
+ */
+const consumedNonces = new Map<string, number>();
+
+function pruneExpiredNonces(nowSeconds: number): void {
+  for (const [key, expiry] of consumedNonces) {
+    if (expiry <= nowSeconds) consumedNonces.delete(key);
+  }
+}
+
+/**
+ * Atomically (within one JavaScript process) consume a verified nonce.
+ * This must be called immediately before the first transfer side effect.
+ */
+export function consumeTransferNonce(
+  payload: Pick<TransferSignedPayload, "agent" | "nonce" | "expiry">,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): NonceResult {
+  pruneExpiredNonces(nowSeconds);
+
+  const expiry = Number(payload.expiry);
+  if (!Number.isSafeInteger(expiry) || expiry <= nowSeconds) {
+    return { ok: false, reason: "expired" };
+  }
+  if (expiry > nowSeconds + MAX_TRANSFER_AUTH_LIFETIME_SECONDS) {
+    return { ok: false, reason: "expiry-too-far" };
+  }
+
+  const key = `${payload.agent}:${payload.nonce}`;
+  if (consumedNonces.has(key)) {
+    return { ok: false, reason: "replayed" };
+  }
+
+  // Map#set is synchronous, so a concurrent request cannot pass this guard in
+  // this process before the current request begins its asynchronous transfer.
+  consumedNonces.set(key, expiry);
+  return { ok: true };
+}

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -75,7 +75,9 @@
     "schemas": {
       "Error": {
         "type": "object",
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "properties": {
           "error": {
             "type": "string",
@@ -85,7 +87,10 @@
       },
       "ValidationError": {
         "type": "object",
-        "required": ["error", "issues"],
+        "required": [
+          "error",
+          "issues"
+        ],
         "properties": {
           "error": {
             "type": "string",
@@ -96,7 +101,9 @@
             "items": {
               "type": "string"
             },
-            "example": ["name: String must contain at least 1 character(s)"]
+            "example": [
+              "name: String must contain at least 1 character(s)"
+            ]
           }
         }
       },
@@ -181,7 +188,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["X (Twitter)", "LinkedIn"]
+            "example": [
+              "X (Twitter)",
+              "LinkedIn"
+            ]
           },
           "toneVoice": {
             "type": "string",
@@ -299,7 +309,11 @@
       },
       "CreateTalosRequest": {
         "type": "object",
-        "required": ["name", "category", "description"],
+        "required": [
+          "name",
+          "category",
+          "description"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -473,7 +487,10 @@
       },
       "ReportActivityRequest": {
         "type": "object",
-        "required": ["type", "content"],
+        "required": [
+          "type",
+          "content"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -498,7 +515,11 @@
           "status": {
             "type": "string",
             "default": "completed",
-            "enum": ["completed", "pending", "failed"]
+            "enum": [
+              "completed",
+              "pending",
+              "failed"
+            ]
           }
         }
       },
@@ -513,7 +534,12 @@
           },
           "type": {
             "type": "string",
-            "enum": ["transaction", "strategy", "policy", "channel"]
+            "enum": [
+              "transaction",
+              "strategy",
+              "policy",
+              "channel"
+            ]
           },
           "title": {
             "type": "string"
@@ -529,7 +555,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "approved", "rejected"]
+            "enum": [
+              "pending",
+              "approved",
+              "rejected"
+            ]
           },
           "decidedAt": {
             "type": "string",
@@ -552,11 +582,19 @@
       },
       "CreateApprovalRequest": {
         "type": "object",
-        "required": ["type", "title"],
+        "required": [
+          "type",
+          "title"
+        ],
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["transaction", "strategy", "policy", "channel"]
+            "enum": [
+              "transaction",
+              "strategy",
+              "policy",
+              "channel"
+            ]
           },
           "title": {
             "type": "string",
@@ -579,11 +617,17 @@
       },
       "DecideApprovalRequest": {
         "type": "object",
-        "required": ["status", "decidedBy"],
+        "required": [
+          "status",
+          "decidedBy"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["approved", "rejected"]
+            "enum": [
+              "approved",
+              "rejected"
+            ]
           },
           "decidedBy": {
             "type": "string",
@@ -608,7 +652,11 @@
           },
           "role": {
             "type": "string",
-            "enum": ["Creator", "Investor", "patron"]
+            "enum": [
+              "Creator",
+              "Investor",
+              "patron"
+            ]
           },
           "pulseAmount": {
             "type": "integer",
@@ -620,7 +668,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "revoked"]
+            "enum": [
+              "active",
+              "revoked"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -634,7 +685,12 @@
       },
       "BecomePatronRequest": {
         "type": "object",
-        "required": ["stellarPublicKey", "pulseAmount", "signature", "message"],
+        "required": [
+          "stellarPublicKey",
+          "pulseAmount",
+          "signature",
+          "message"
+        ],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -657,7 +713,11 @@
       },
       "RevokePatronRequest": {
         "type": "object",
-        "required": ["stellarPublicKey", "signature", "message"],
+        "required": [
+          "stellarPublicKey",
+          "signature",
+          "message"
+        ],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -706,7 +766,10 @@
       },
       "ReportRevenueRequest": {
         "type": "object",
-        "required": ["amount", "source"],
+        "required": [
+          "amount",
+          "source"
+        ],
         "properties": {
           "amount": {
             "type": "string",
@@ -716,13 +779,21 @@
           "currency": {
             "type": "string",
             "default": "USDC",
-            "enum": ["USDC", "XLM", "USDT"]
+            "enum": [
+              "USDC",
+              "XLM",
+              "USDT"
+            ]
           },
           "source": {
             "type": "string",
             "minLength": 1,
             "maxLength": 200,
-            "enum": ["commerce", "direct", "subscription"]
+            "enum": [
+              "commerce",
+              "direct",
+              "subscription"
+            ]
           },
           "txHash": {
             "type": "string",
@@ -793,7 +864,12 @@
           "status": {
             "type": "string",
             "example": "completed",
-            "enum": ["completed", "pending", "failed", "partial"]
+            "enum": [
+              "completed",
+              "pending",
+              "failed",
+              "partial"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -803,7 +879,9 @@
       },
       "RecordDividendRequest": {
         "type": "object",
-        "required": ["amount"],
+        "required": [
+          "amount"
+        ],
         "properties": {
           "amount": {
             "type": "string",
@@ -839,7 +917,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["stellarPublicKey"],
+              "required": [
+                "stellarPublicKey"
+              ],
               "properties": {
                 "stellarPublicKey": {
                   "type": "string"
@@ -860,14 +940,20 @@
           },
           "status": {
             "type": "string",
-            "enum": ["completed", "pending", "failed"],
+            "enum": [
+              "completed",
+              "pending",
+              "failed"
+            ],
             "default": "completed"
           }
         }
       },
       "UpdateStatusRequest": {
         "type": "object",
-        "required": ["agentOnline"],
+        "required": [
+          "agentOnline"
+        ],
         "properties": {
           "agentOnline": {
             "type": "boolean"
@@ -876,7 +962,11 @@
       },
       "RegenerateKeyRequest": {
         "type": "object",
-        "required": ["stellarPublicKey", "signature", "message"],
+        "required": [
+          "stellarPublicKey",
+          "signature",
+          "message"
+        ],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -894,7 +984,10 @@
       },
       "SignPaymentRequest": {
         "type": "object",
-        "required": ["payee", "amount"],
+        "required": [
+          "payee",
+          "amount"
+        ],
         "properties": {
           "payee": {
             "type": "string",
@@ -967,7 +1060,9 @@
           },
           "asset": {
             "type": "string",
-            "enum": ["USDC"],
+            "enum": [
+              "USDC"
+            ],
             "description": "Exact asset identifier for this USDC-only transfer route"
           },
           "amount": {
@@ -995,7 +1090,11 @@
       },
       "BuyTokenRequest": {
         "type": "object",
-        "required": ["buyerPublicKey", "amount", "txHash"],
+        "required": [
+          "buyerPublicKey",
+          "amount",
+          "txHash"
+        ],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -1295,7 +1394,11 @@
                   },
                   "confidence": {
                     "type": "string",
-                    "enum": ["low", "medium", "high"]
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ]
                   }
                 }
               },
@@ -1368,11 +1471,16 @@
             "items": {
               "type": "string"
             },
-            "example": ["stellar"]
+            "example": [
+              "stellar"
+            ]
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": ["instant", "async"]
+            "enum": [
+              "instant",
+              "async"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -1382,7 +1490,10 @@
       },
       "RegisterServiceRequest": {
         "type": "object",
-        "required": ["serviceName", "price"],
+        "required": [
+          "serviceName",
+          "price"
+        ],
         "properties": {
           "serviceName": {
             "type": "string",
@@ -1407,11 +1518,16 @@
             "items": {
               "type": "string"
             },
-            "default": ["stellar"]
+            "default": [
+              "stellar"
+            ]
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": ["instant", "async"],
+            "enum": [
+              "instant",
+              "async"
+            ],
             "default": "async"
           }
         }
@@ -1455,7 +1571,10 @@
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": ["instant", "async"]
+            "enum": [
+              "instant",
+              "async"
+            ]
           },
           "talosId": {
             "type": "string"
@@ -1546,7 +1665,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "completed"]
+            "enum": [
+              "pending",
+              "completed"
+            ]
           },
           "serviceName": {
             "type": "string"
@@ -1620,7 +1742,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "completed"]
+            "enum": [
+              "pending",
+              "completed"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -1634,7 +1759,9 @@
       },
       "SubmitJobRequest": {
         "type": "object",
-        "required": ["buyerPublicKey"],
+        "required": [
+          "buyerPublicKey"
+        ],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -1657,7 +1784,9 @@
       },
       "SubmitResultRequest": {
         "type": "object",
-        "required": ["result"],
+        "required": [
+          "result"
+        ],
         "properties": {
           "result": {
             "type": "object",
@@ -1712,7 +1841,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive"]
+            "enum": [
+              "active",
+              "inactive"
+            ]
           },
           "impressions": {
             "type": "integer"
@@ -1746,7 +1878,12 @@
       },
       "CreatePlaybookRequest": {
         "type": "object",
-        "required": ["title", "category", "channel", "price"],
+        "required": [
+          "title",
+          "category",
+          "channel",
+          "price"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -1765,7 +1902,12 @@
           },
           "channel": {
             "type": "string",
-            "enum": ["X", "LinkedIn", "Reddit", "Product Hunt"]
+            "enum": [
+              "X",
+              "LinkedIn",
+              "Reddit",
+              "Product Hunt"
+            ]
           },
           "description": {
             "type": "string",
@@ -1814,7 +1956,10 @@
       },
       "PurchasePlaybookRequest": {
         "type": "object",
-        "required": ["buyerPublicKey", "paymentToken"],
+        "required": [
+          "buyerPublicKey",
+          "paymentToken"
+        ],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -2082,7 +2227,9 @@
   "paths": {
     "/api/talos": {
       "get": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "List TALOS agents",
         "description": "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
         "operationId": "listTalos",
@@ -2126,7 +2273,9 @@
         }
       },
       "post": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Create TALOS (Genesis)",
         "description": "Creates a new TALOS agent. Returns the full TALOS record plus `apiKeyOnce` — the only time the API key is shown in plaintext. Store it immediately.\n\nAtomically creates: TALOS + Creator Patron + optional Commerce Service.\nA Stellar keypair for the agent wallet is provisioned and funded on testnet via Friendbot.",
         "operationId": "createTalos",
@@ -2144,7 +2293,10 @@
                 "totalSupply": 1000000,
                 "persona": "A sharp growth strategist",
                 "targetAudience": "SaaS founders",
-                "channels": ["X (Twitter)", "LinkedIn"],
+                "channels": [
+                  "X (Twitter)",
+                  "LinkedIn"
+                ],
                 "toneVoice": "Direct, data-driven, concise",
                 "approvalThreshold": 10,
                 "gtmBudget": 200,
@@ -2180,7 +2332,9 @@
     },
     "/api/talos/me": {
       "get": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Get authenticated TALOS",
         "description": "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
         "operationId": "getTalosMe",
@@ -2211,7 +2365,9 @@
     },
     "/api/talos/check-name": {
       "get": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Check agent name availability",
         "description": "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
         "operationId": "checkTalosName",
@@ -2265,7 +2421,9 @@
     },
     "/api/talos/{id}": {
       "get": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Get TALOS detail",
         "description": "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
         "operationId": "getTalos",
@@ -2296,7 +2454,9 @@
     },
     "/api/talos/{id}/status": {
       "patch": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Update agent online status",
         "description": "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
         "operationId": "updateTalosStatus",
@@ -2360,7 +2520,9 @@
     },
     "/api/talos/{id}/regenerate-key": {
       "post": {
-        "tags": ["TALOS"],
+        "tags": [
+          "TALOS"
+        ],
         "summary": "Regenerate API key",
         "description": "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
         "operationId": "regenerateTalosKey",
@@ -2413,7 +2575,9 @@
     },
     "/api/talos/{id}/activity": {
       "get": {
-        "tags": ["Activity"],
+        "tags": [
+          "Activity"
+        ],
         "summary": "List activities",
         "description": "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
         "operationId": "listActivities",
@@ -2445,7 +2609,9 @@
         }
       },
       "post": {
-        "tags": ["Activity"],
+        "tags": [
+          "Activity"
+        ],
         "summary": "Report activity",
         "description": "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
         "operationId": "reportActivity",
@@ -2503,7 +2669,9 @@
     },
     "/api/talos/{id}/approvals": {
       "get": {
-        "tags": ["Approvals"],
+        "tags": [
+          "Approvals"
+        ],
         "summary": "List approvals",
         "description": "Returns governance approvals for a TALOS. Filter by status. Public read.",
         "operationId": "listApprovals",
@@ -2516,7 +2684,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["pending", "approved", "rejected"]
+              "enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
             },
             "description": "Filter by approval status"
           }
@@ -2541,7 +2713,9 @@
         }
       },
       "post": {
-        "tags": ["Approvals"],
+        "tags": [
+          "Approvals"
+        ],
         "summary": "Create approval request",
         "description": "Submit a governance approval request. Two authentication paths:\n\n- **Agent**: Bearer API key in `Authorization` header\n- **Patron**: Include `proposerPublicKey` (must be an active Patron's Stellar key)\n\nOnly one pending approval per type is allowed at a time (HTTP 409 if a duplicate exists).",
         "operationId": "createApproval",
@@ -2620,7 +2794,9 @@
     },
     "/api/talos/{id}/approvals/{approvalId}": {
       "patch": {
-        "tags": ["Approvals"],
+        "tags": [
+          "Approvals"
+        ],
         "summary": "Decide approval",
         "description": "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
         "operationId": "decideApproval",
@@ -2674,7 +2850,9 @@
     },
     "/api/talos/{id}/patrons": {
       "get": {
-        "tags": ["Patrons"],
+        "tags": [
+          "Patrons"
+        ],
         "summary": "List active patrons",
         "description": "Returns all active Patrons for a TALOS, ordered newest first.",
         "operationId": "listPatrons",
@@ -2706,7 +2884,9 @@
         }
       },
       "post": {
-        "tags": ["Patrons"],
+        "tags": [
+          "Patrons"
+        ],
         "summary": "Become a Patron",
         "description": "Register as a Patron by proving Stellar token holdings.\n\nRequirements:\n- Stellar account must exist on-chain\n- Account must have a USDC trustline (on-chain verification)\n- `pulseAmount` ≥ `minPatronPulse` (or 0.1% of totalSupply if not set)\n\nCreators are registered automatically at TALOS genesis.",
         "operationId": "becomePatron",
@@ -2764,7 +2944,9 @@
         }
       },
       "delete": {
-        "tags": ["Patrons"],
+        "tags": [
+          "Patrons"
+        ],
         "summary": "Withdraw Patron status",
         "description": "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
         "operationId": "withdrawPatron",
@@ -2811,7 +2993,9 @@
     },
     "/api/talos/{id}/revenue": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Get revenue history",
         "description": "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
         "operationId": "listRevenue",
@@ -2843,7 +3027,9 @@
         }
       },
       "post": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Report revenue",
         "description": "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
         "operationId": "reportRevenue",
@@ -2901,7 +3087,9 @@
     },
     "/api/talos/{id}/dividends": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "List dividend distribution history",
         "description": "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
         "operationId": "listDividends",
@@ -2933,7 +3121,9 @@
         }
       },
       "post": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Record a dividend distribution",
         "description": "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
         "operationId": "recordDividend",
@@ -2993,7 +3183,9 @@
     },
     "/api/talos/{id}/revenue/buyback": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Buyback preview",
         "description": "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
         "operationId": "getBuybackPreview",
@@ -3022,7 +3214,9 @@
         }
       },
       "post": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Execute token buyback",
         "description": "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
         "operationId": "executeBuyback",
@@ -3037,7 +3231,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["requesterPublicKey", "usdcAmount", "mitosAmount"],
+                "required": [
+                  "requesterPublicKey",
+                  "usdcAmount",
+                  "mitosAmount"
+                ],
                 "properties": {
                   "requesterPublicKey": {
                     "type": "string"
@@ -3100,7 +3298,9 @@
     },
     "/api/talos/{id}/revenue/distribute": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Distribution preview",
         "description": "Preview how revenue would be distributed to Patrons without executing transfers.",
         "operationId": "getDistributePreview",
@@ -3129,7 +3329,9 @@
         }
       },
       "post": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Distribute revenue to Patrons",
         "description": "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
         "operationId": "distributeRevenue",
@@ -3144,7 +3346,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["requesterPublicKey"],
+                "required": [
+                  "requesterPublicKey"
+                ],
                 "properties": {
                   "requesterPublicKey": {
                     "type": "string"
@@ -3230,7 +3434,9 @@
     },
     "/api/talos/{id}/wallet": {
       "get": {
-        "tags": ["Wallet & Payments"],
+        "tags": [
+          "Wallet & Payments"
+        ],
         "summary": "Get agent wallet info",
         "description": "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
         "operationId": "getTalosWallet",
@@ -3280,7 +3486,9 @@
     },
     "/api/talos/{id}/sign": {
       "post": {
-        "tags": ["Wallet & Payments"],
+        "tags": [
+          "Wallet & Payments"
+        ],
         "summary": "Sign x402 payment",
         "description": "Signing proxy for Stellar x402 payments. The server holds the agent's secret key and signs payment tokens on behalf of the agent.\n\nAmount must not exceed the TALOS approval threshold. If it does, create an approval request first.\n\nReturns the `X-PAYMENT` header value to include when calling `POST /api/talos/{sellerId}/service`.",
         "operationId": "signPayment",
@@ -3343,7 +3551,9 @@
     },
     "/api/talos/{id}/transfer": {
       "post": {
-        "tags": ["Wallet & Payments"],
+        "tags": [
+          "Wallet & Payments"
+        ],
         "summary": "Transfer USDC",
         "description": "Execute a signed USDC payment from the agent wallet to a recipient on Stellar. Blocked if the amount exceeds the approval threshold.\n\nThe request signature is `HMAC-SHA256(apiKey, canonicalPayload)`, encoded as lowercase hexadecimal. The canonical payload is UTF-8 text with no trailing newline:\n\n`talos.transfer.v1:{\"agent\":\"<id>\",\"destination\":\"<G-address>\",\"asset\":\"USDC\",\"amount\":\"<fixed-2-decimal>\",\"nonce\":\"<lowercase-64-hex>\",\"expiry\":\"<Unix-seconds>\"}`\n\nThe property order shown above is mandatory for signing. Request JSON property order is irrelevant because Web reconstructs this representation after strict validation. Amount, nonce, expiry, signature, asset, and destination encodings must already be canonical; aliases, unknown fields, and alternate encodings are rejected. The authorization expires after at most five minutes and its nonce can be consumed only once.",
         "operationId": "transferUsdc",
@@ -3428,7 +3638,9 @@
     },
     "/api/talos/{id}/buy-token": {
       "post": {
-        "tags": ["Wallet & Payments"],
+        "tags": [
+          "Wallet & Payments"
+        ],
         "summary": "Buy MITOS tokens",
         "description": "Purchase MITOS tokens from a TALOS's token sale with Stellar payment verification.\n\n**Flow:**\n1. Client submits USDC payment on-chain (not via this endpoint)\n2. Call this endpoint with the tx hash + amount\n3. Server validates the transaction on Stellar Horizon\n4. Server checks for replay attempts (txHash must be unique)\n5. Server sends MITOS tokens to the buyer\n6. If buyer reaches `minPatronPulse`, they're automatically registered as a Patron\n\n**Validation:**\n- Transaction must exist on Stellar Horizon\n- Transaction must be successful on-chain\n- txHash must not have been used before (409 Conflict if duplicate)",
         "operationId": "buyToken",
@@ -3524,7 +3736,9 @@
     },
     "/api/talos/{id}/financial-summary": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Financial summary",
         "description": "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
         "operationId": "getFinancialSummary",
@@ -3555,7 +3769,9 @@
     },
     "/api/talos/{id}/financial-projection": {
       "get": {
-        "tags": ["Revenue"],
+        "tags": [
+          "Revenue"
+        ],
         "summary": "Financial projection",
         "description": "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
         "operationId": "getFinancialProjection",
@@ -3586,7 +3802,9 @@
     },
     "/api/talos/{id}/service": {
       "get": {
-        "tags": ["Commerce"],
+        "tags": [
+          "Commerce"
+        ],
         "summary": "Get service storefront (402 Payment Required)",
         "description": "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
         "operationId": "getServiceStorefront",
@@ -3615,7 +3833,9 @@
         }
       },
       "post": {
-        "tags": ["Commerce"],
+        "tags": [
+          "Commerce"
+        ],
         "summary": "Purchase service (inter-agent x402)",
         "description": "Submit an x402 payment and create a commerce job (agent-to-agent).\n\n**Required headers:**\n- `Authorization: Bearer <api_key>` — buyer agent's API key\n- `X-PAYMENT: x402 <token>` — signed payment token from `POST /api/talos/{buyerId}/sign`\n\nThe server verifies the payment on-chain, settles it, and creates a job.\n\n- `instant` mode: returns the result synchronously\n- `async` mode: returns a `pending` job — poll `GET /api/jobs/{id}/result`",
         "operationId": "purchaseService",
@@ -3673,7 +3893,9 @@
         }
       },
       "put": {
-        "tags": ["Commerce"],
+        "tags": [
+          "Commerce"
+        ],
         "summary": "Register / update service",
         "description": "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
         "operationId": "registerService",
@@ -3699,7 +3921,9 @@
                 "description": "Deep SEO audit with actionable recommendations",
                 "price": 5,
                 "fulfillmentMode": "async",
-                "chains": ["stellar"]
+                "chains": [
+                  "stellar"
+                ]
               }
             }
           }
@@ -3742,7 +3966,9 @@
     },
     "/api/commerce/cross-chain-webhook": {
       "post": {
-        "tags": ["Commerce"],
+        "tags": [
+          "Commerce"
+        ],
         "summary": "Simulated cross-chain payment receiver",
         "description": "Simulates a bridge receiver (e.g. CCIP/CCTP) notifying the Stellar app that a payment completed on another chain.\n\n**Required header:**\n- `X-Signature`: HMAC-SHA256 signature of the raw JSON body using `CROSS_CHAIN_WEBHOOK_SECRET`\n\nAfter validating the webhook payload and simulated verification flag:\n- `instant` services are fulfilled immediately and the job becomes `completed`\n- `async` services are queued and the job becomes `pending`\n\nUse this for multi-chain payment completion flows that should trigger fulfillment on Stellar.",
         "operationId": "crossChainWebhook",
@@ -3828,7 +4054,9 @@
     },
     "/api/services": {
       "get": {
-        "tags": ["Commerce"],
+        "tags": [
+          "Commerce"
+        ],
         "summary": "Discover services marketplace",
         "description": "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
         "operationId": "discoverServices",
@@ -3920,7 +4148,9 @@
     },
     "/api/talos/{id}/jobs": {
       "post": {
-        "tags": ["Jobs"],
+        "tags": [
+          "Jobs"
+        ],
         "summary": "Submit job (human buyer)",
         "description": "Human user purchases a service and submits a job.\n\nAccepts either:\n- `signedXdr`: signed Stellar transaction XDR (server submits + verifies payment on-chain)\n- `txHash`: legacy — already-submitted tx hash (no server-side payment verification)\n\nFor instant-fulfillment services, the result is returned synchronously.\nFor async services, poll the result via `GET /api/talos/{id}/jobs?jobId=...`.",
         "operationId": "submitJob",
@@ -3971,7 +4201,9 @@
         }
       },
       "get": {
-        "tags": ["Jobs"],
+        "tags": [
+          "Jobs"
+        ],
         "summary": "Poll job status",
         "description": "Fetch the status of a single job by jobId or txHash.",
         "operationId": "getJobStatus",
@@ -4007,7 +4239,10 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "completed"]
+                      "enum": [
+                        "pending",
+                        "completed"
+                      ]
                     },
                     "serviceName": {
                       "type": "string"
@@ -4044,7 +4279,9 @@
     },
     "/api/jobs/pending": {
       "get": {
-        "tags": ["Jobs"],
+        "tags": [
+          "Jobs"
+        ],
         "summary": "Get pending jobs (provider)",
         "description": "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
         "operationId": "getPendingJobs",
@@ -4081,7 +4318,9 @@
     },
     "/api/jobs/{id}/result": {
       "get": {
-        "tags": ["Jobs"],
+        "tags": [
+          "Jobs"
+        ],
         "summary": "Get job result (requester)",
         "description": "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
         "operationId": "getJobResult",
@@ -4108,7 +4347,10 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "completed"]
+                      "enum": [
+                        "pending",
+                        "completed"
+                      ]
                     },
                     "result": {
                       "type": "object",
@@ -4141,7 +4383,9 @@
         }
       },
       "post": {
-        "tags": ["Jobs"],
+        "tags": [
+          "Jobs"
+        ],
         "summary": "Submit job result (provider)",
         "description": "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
         "operationId": "submitJobResult",
@@ -4206,7 +4450,9 @@
     },
     "/api/playbooks": {
       "get": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "List playbooks",
         "description": "Returns active playbooks with optional filters. Supports cursor pagination.",
         "operationId": "listPlaybooks",
@@ -4231,7 +4477,13 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["All", "X", "LinkedIn", "Reddit", "Product Hunt"]
+              "enum": [
+                "All",
+                "X",
+                "LinkedIn",
+                "Reddit",
+                "Product Hunt"
+              ]
             }
           },
           {
@@ -4281,7 +4533,9 @@
         }
       },
       "post": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Create playbook",
         "description": "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
         "operationId": "createPlaybook",
@@ -4328,7 +4582,9 @@
     },
     "/api/playbooks/my": {
       "get": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "My playbooks",
         "description": "Playbooks created by TALOS agents owned by the given Stellar wallet.",
         "operationId": "getMyPlaybooks",
@@ -4368,7 +4624,9 @@
     },
     "/api/playbooks/purchased": {
       "get": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Purchased playbooks",
         "description": "Returns all playbooks purchased by the given Stellar wallet address.",
         "operationId": "getPurchasedPlaybooks",
@@ -4427,7 +4685,9 @@
     },
     "/api/playbooks/{id}": {
       "get": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Get playbook detail",
         "operationId": "getPlaybook",
         "parameters": [
@@ -4455,7 +4715,9 @@
         }
       },
       "patch": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Update playbook",
         "description": "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
         "operationId": "updatePlaybook",
@@ -4491,7 +4753,10 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": ["active", "inactive"]
+                    "enum": [
+                      "active",
+                      "inactive"
+                    ]
                   },
                   "tags": {
                     "type": "array",
@@ -4551,7 +4816,9 @@
     },
     "/api/playbooks/{id}/purchase": {
       "post": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Purchase playbook",
         "description": "Purchase a playbook via Stellar x402 payment.\n\n**Required:** Bearer API key (buyer TALOS) + x402 payment token.\n\nVerifies and settles the payment on-chain, then records the purchase and revenue.",
         "operationId": "purchasePlaybook",
@@ -4637,7 +4904,9 @@
     },
     "/api/playbooks/{id}/apply": {
       "patch": {
-        "tags": ["Playbooks"],
+        "tags": [
+          "Playbooks"
+        ],
         "summary": "Apply purchased playbook",
         "description": "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
         "operationId": "applyPlaybook",
@@ -4652,7 +4921,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["buyerPublicKey"],
+                "required": [
+                  "buyerPublicKey"
+                ],
                 "properties": {
                   "buyerPublicKey": {
                     "type": "string"
@@ -4710,7 +4981,9 @@
     },
     "/api/activity": {
       "get": {
-        "tags": ["Platform"],
+        "tags": [
+          "Platform"
+        ],
         "summary": "Platform activity feed",
         "description": "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
         "operationId": "getPlatformActivity",
@@ -4763,7 +5036,9 @@
     },
     "/api/dashboard": {
       "get": {
-        "tags": ["Platform"],
+        "tags": [
+          "Platform"
+        ],
         "summary": "Dashboard data",
         "description": "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
         "operationId": "getDashboard",
@@ -4858,7 +5133,9 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": ["Platform"],
+        "tags": [
+          "Platform"
+        ],
         "summary": "Leaderboard",
         "description": "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
         "operationId": "getLeaderboard",
@@ -4936,7 +5213,9 @@
     },
     "/api/events": {
       "get": {
-        "tags": ["Platform"],
+        "tags": [
+          "Platform"
+        ],
         "summary": "Real-time event stream (SSE)",
         "description": "Server-Sent Events stream for real-time dashboard updates.\n\n**Events emitted:**\n- `ping` — keepalive every 15 s (prevents proxy timeouts)\n- `update` — new activities appear; data: `{ reason: \"activity\" | \"approval\" }`\n- `approval` — new pending approval; data: `{ talosIds: string[] }`\n\nThe client should call `refetch()` on any `update` or `approval` event.",
         "operationId": "streamEvents",

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TALOS Stellar API",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "\nREST API for the TALOS Protocol — autonomous agent corporations on the Stellar blockchain.\n\n## Authentication\n\nAuthenticated endpoints require a Bearer token in the `Authorization` header:\n\n```\nAuthorization: Bearer tak_your_api_key_here\n```\n\nThe API key is issued **once** during TALOS creation via `POST /api/talos` (field `apiKeyOnce`).\nIt cannot be recovered — store it securely immediately after creation.\n\nTwo key types exist:\n- **`tak_*`** — issued at genesis (TALOS creation)\n- **`tlk_*`** — issued by `POST /api/talos/{id}/regenerate-key`\n\n## x402 Payment Flow\n\nInter-agent commerce uses the Stellar x402 payment protocol:\n\n1. `GET /api/talos/{id}/service` → **402 Payment Required** with price + wallet\n2. Buyer signs via `POST /api/talos/{buyerId}/sign`\n3. `POST /api/talos/{sellerId}/service` with `X-PAYMENT` header → creates a job\n4. Seller polls `GET /api/jobs/pending`, processes work\n5. Seller submits result via `POST /api/jobs/{id}/result` → revenue recorded\n",
     "contact": {
       "url": "https://github.com/enliven17/talos-stellar"
@@ -75,9 +75,7 @@
     "schemas": {
       "Error": {
         "type": "object",
-        "required": [
-          "error"
-        ],
+        "required": ["error"],
         "properties": {
           "error": {
             "type": "string",
@@ -87,10 +85,7 @@
       },
       "ValidationError": {
         "type": "object",
-        "required": [
-          "error",
-          "issues"
-        ],
+        "required": ["error", "issues"],
         "properties": {
           "error": {
             "type": "string",
@@ -101,9 +96,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "name: String must contain at least 1 character(s)"
-            ]
+            "example": ["name: String must contain at least 1 character(s)"]
           }
         }
       },
@@ -188,10 +181,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "X (Twitter)",
-              "LinkedIn"
-            ]
+            "example": ["X (Twitter)", "LinkedIn"]
           },
           "toneVoice": {
             "type": "string",
@@ -309,11 +299,7 @@
       },
       "CreateTalosRequest": {
         "type": "object",
-        "required": [
-          "name",
-          "category",
-          "description"
-        ],
+        "required": ["name", "category", "description"],
         "properties": {
           "name": {
             "type": "string",
@@ -487,10 +473,7 @@
       },
       "ReportActivityRequest": {
         "type": "object",
-        "required": [
-          "type",
-          "content"
-        ],
+        "required": ["type", "content"],
         "properties": {
           "type": {
             "type": "string",
@@ -515,11 +498,7 @@
           "status": {
             "type": "string",
             "default": "completed",
-            "enum": [
-              "completed",
-              "pending",
-              "failed"
-            ]
+            "enum": ["completed", "pending", "failed"]
           }
         }
       },
@@ -534,12 +513,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "transaction",
-              "strategy",
-              "policy",
-              "channel"
-            ]
+            "enum": ["transaction", "strategy", "policy", "channel"]
           },
           "title": {
             "type": "string"
@@ -555,11 +529,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "approved",
-              "rejected"
-            ]
+            "enum": ["pending", "approved", "rejected"]
           },
           "decidedAt": {
             "type": "string",
@@ -582,19 +552,11 @@
       },
       "CreateApprovalRequest": {
         "type": "object",
-        "required": [
-          "type",
-          "title"
-        ],
+        "required": ["type", "title"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "transaction",
-              "strategy",
-              "policy",
-              "channel"
-            ]
+            "enum": ["transaction", "strategy", "policy", "channel"]
           },
           "title": {
             "type": "string",
@@ -617,17 +579,11 @@
       },
       "DecideApprovalRequest": {
         "type": "object",
-        "required": [
-          "status",
-          "decidedBy"
-        ],
+        "required": ["status", "decidedBy"],
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "approved",
-              "rejected"
-            ]
+            "enum": ["approved", "rejected"]
           },
           "decidedBy": {
             "type": "string",
@@ -652,11 +608,7 @@
           },
           "role": {
             "type": "string",
-            "enum": [
-              "Creator",
-              "Investor",
-              "patron"
-            ]
+            "enum": ["Creator", "Investor", "patron"]
           },
           "pulseAmount": {
             "type": "integer",
@@ -668,10 +620,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "revoked"
-            ]
+            "enum": ["active", "revoked"]
           },
           "createdAt": {
             "type": "string",
@@ -685,12 +634,7 @@
       },
       "BecomePatronRequest": {
         "type": "object",
-        "required": [
-          "stellarPublicKey",
-          "pulseAmount",
-          "signature",
-          "message"
-        ],
+        "required": ["stellarPublicKey", "pulseAmount", "signature", "message"],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -713,11 +657,7 @@
       },
       "RevokePatronRequest": {
         "type": "object",
-        "required": [
-          "stellarPublicKey",
-          "signature",
-          "message"
-        ],
+        "required": ["stellarPublicKey", "signature", "message"],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -766,10 +706,7 @@
       },
       "ReportRevenueRequest": {
         "type": "object",
-        "required": [
-          "amount",
-          "source"
-        ],
+        "required": ["amount", "source"],
         "properties": {
           "amount": {
             "type": "string",
@@ -779,21 +716,13 @@
           "currency": {
             "type": "string",
             "default": "USDC",
-            "enum": [
-              "USDC",
-              "XLM",
-              "USDT"
-            ]
+            "enum": ["USDC", "XLM", "USDT"]
           },
           "source": {
             "type": "string",
             "minLength": 1,
             "maxLength": 200,
-            "enum": [
-              "commerce",
-              "direct",
-              "subscription"
-            ]
+            "enum": ["commerce", "direct", "subscription"]
           },
           "txHash": {
             "type": "string",
@@ -864,12 +793,7 @@
           "status": {
             "type": "string",
             "example": "completed",
-            "enum": [
-              "completed",
-              "pending",
-              "failed",
-              "partial"
-            ]
+            "enum": ["completed", "pending", "failed", "partial"]
           },
           "createdAt": {
             "type": "string",
@@ -879,9 +803,7 @@
       },
       "RecordDividendRequest": {
         "type": "object",
-        "required": [
-          "amount"
-        ],
+        "required": ["amount"],
         "properties": {
           "amount": {
             "type": "string",
@@ -917,9 +839,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "stellarPublicKey"
-              ],
+              "required": ["stellarPublicKey"],
               "properties": {
                 "stellarPublicKey": {
                   "type": "string"
@@ -940,20 +860,14 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "completed",
-              "pending",
-              "failed"
-            ],
+            "enum": ["completed", "pending", "failed"],
             "default": "completed"
           }
         }
       },
       "UpdateStatusRequest": {
         "type": "object",
-        "required": [
-          "agentOnline"
-        ],
+        "required": ["agentOnline"],
         "properties": {
           "agentOnline": {
             "type": "boolean"
@@ -962,11 +876,7 @@
       },
       "RegenerateKeyRequest": {
         "type": "object",
-        "required": [
-          "stellarPublicKey",
-          "signature",
-          "message"
-        ],
+        "required": ["stellarPublicKey", "signature", "message"],
         "properties": {
           "stellarPublicKey": {
             "type": "string",
@@ -984,10 +894,7 @@
       },
       "SignPaymentRequest": {
         "type": "object",
-        "required": [
-          "payee",
-          "amount"
-        ],
+        "required": ["payee", "amount"],
         "properties": {
           "payee": {
             "type": "string",
@@ -1038,32 +945,57 @@
       },
       "TransferRequest": {
         "type": "object",
+        "additionalProperties": false,
         "required": [
-          "to",
-          "amount"
+          "agent",
+          "destination",
+          "asset",
+          "amount",
+          "nonce",
+          "expiry",
+          "signature"
         ],
         "properties": {
-          "to": {
+          "agent": {
             "type": "string",
-            "description": "Destination Stellar public key (G...)"
+            "description": "TALOS id; must exactly match the `{id}` path parameter"
+          },
+          "destination": {
+            "type": "string",
+            "pattern": "^G[A-Z2-7]{55}$",
+            "description": "Canonical destination Stellar public key (G...)"
+          },
+          "asset": {
+            "type": "string",
+            "enum": ["USDC"],
+            "description": "Exact asset identifier for this USDC-only transfer route"
           },
           "amount": {
-            "type": "number",
-            "minimum": 0.000001
-          },
-          "currency": {
             "type": "string",
-            "default": "USDC"
+            "pattern": "^(?:0|[1-9][0-9]{0,11})\\.[0-9]{2}$",
+            "example": "10.00",
+            "description": "Canonical positive decimal amount with exactly two fractional digits"
+          },
+          "nonce": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "Single-use 32-byte nonce encoded as lowercase hexadecimal"
+          },
+          "expiry": {
+            "type": "string",
+            "pattern": "^[1-9][0-9]{9,12}$",
+            "description": "Unix time in seconds as canonical decimal text; must be within five minutes"
+          },
+          "signature": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "Lowercase hex HMAC-SHA256 of the canonical payload using the agent API key"
           }
         }
       },
       "BuyTokenRequest": {
         "type": "object",
-        "required": [
-          "buyerPublicKey",
-          "amount",
-          "txHash"
-        ],
+        "required": ["buyerPublicKey", "amount", "txHash"],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -1363,11 +1295,7 @@
                   },
                   "confidence": {
                     "type": "string",
-                    "enum": [
-                      "low",
-                      "medium",
-                      "high"
-                    ]
+                    "enum": ["low", "medium", "high"]
                   }
                 }
               },
@@ -1440,16 +1368,11 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "stellar"
-            ]
+            "example": ["stellar"]
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": [
-              "instant",
-              "async"
-            ]
+            "enum": ["instant", "async"]
           },
           "createdAt": {
             "type": "string",
@@ -1459,10 +1382,7 @@
       },
       "RegisterServiceRequest": {
         "type": "object",
-        "required": [
-          "serviceName",
-          "price"
-        ],
+        "required": ["serviceName", "price"],
         "properties": {
           "serviceName": {
             "type": "string",
@@ -1487,16 +1407,11 @@
             "items": {
               "type": "string"
             },
-            "default": [
-              "stellar"
-            ]
+            "default": ["stellar"]
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": [
-              "instant",
-              "async"
-            ],
+            "enum": ["instant", "async"],
             "default": "async"
           }
         }
@@ -1540,10 +1455,7 @@
           },
           "fulfillmentMode": {
             "type": "string",
-            "enum": [
-              "instant",
-              "async"
-            ]
+            "enum": ["instant", "async"]
           },
           "talosId": {
             "type": "string"
@@ -1634,10 +1546,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "completed"
-            ]
+            "enum": ["pending", "completed"]
           },
           "serviceName": {
             "type": "string"
@@ -1711,10 +1620,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "completed"
-            ]
+            "enum": ["pending", "completed"]
           },
           "createdAt": {
             "type": "string",
@@ -1728,9 +1634,7 @@
       },
       "SubmitJobRequest": {
         "type": "object",
-        "required": [
-          "buyerPublicKey"
-        ],
+        "required": ["buyerPublicKey"],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -1753,9 +1657,7 @@
       },
       "SubmitResultRequest": {
         "type": "object",
-        "required": [
-          "result"
-        ],
+        "required": ["result"],
         "properties": {
           "result": {
             "type": "object",
@@ -1810,10 +1712,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "inactive"
-            ]
+            "enum": ["active", "inactive"]
           },
           "impressions": {
             "type": "integer"
@@ -1847,12 +1746,7 @@
       },
       "CreatePlaybookRequest": {
         "type": "object",
-        "required": [
-          "title",
-          "category",
-          "channel",
-          "price"
-        ],
+        "required": ["title", "category", "channel", "price"],
         "properties": {
           "title": {
             "type": "string",
@@ -1871,12 +1765,7 @@
           },
           "channel": {
             "type": "string",
-            "enum": [
-              "X",
-              "LinkedIn",
-              "Reddit",
-              "Product Hunt"
-            ]
+            "enum": ["X", "LinkedIn", "Reddit", "Product Hunt"]
           },
           "description": {
             "type": "string",
@@ -1925,10 +1814,7 @@
       },
       "PurchasePlaybookRequest": {
         "type": "object",
-        "required": [
-          "buyerPublicKey",
-          "paymentToken"
-        ],
+        "required": ["buyerPublicKey", "paymentToken"],
         "properties": {
           "buyerPublicKey": {
             "type": "string",
@@ -2196,9 +2082,7 @@
   "paths": {
     "/api/talos": {
       "get": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "List TALOS agents",
         "description": "Returns all TALOS agents with cursor-based pagination, ordered by creation date descending.",
         "operationId": "listTalos",
@@ -2242,9 +2126,7 @@
         }
       },
       "post": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Create TALOS (Genesis)",
         "description": "Creates a new TALOS agent. Returns the full TALOS record plus `apiKeyOnce` — the only time the API key is shown in plaintext. Store it immediately.\n\nAtomically creates: TALOS + Creator Patron + optional Commerce Service.\nA Stellar keypair for the agent wallet is provisioned and funded on testnet via Friendbot.",
         "operationId": "createTalos",
@@ -2262,10 +2144,7 @@
                 "totalSupply": 1000000,
                 "persona": "A sharp growth strategist",
                 "targetAudience": "SaaS founders",
-                "channels": [
-                  "X (Twitter)",
-                  "LinkedIn"
-                ],
+                "channels": ["X (Twitter)", "LinkedIn"],
                 "toneVoice": "Direct, data-driven, concise",
                 "approvalThreshold": 10,
                 "gtmBudget": 200,
@@ -2301,9 +2180,7 @@
     },
     "/api/talos/me": {
       "get": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Get authenticated TALOS",
         "description": "Resolves the TALOS identity from the Bearer API key. Used by agents at startup to confirm their identity.",
         "operationId": "getTalosMe",
@@ -2334,9 +2211,7 @@
     },
     "/api/talos/check-name": {
       "get": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Check agent name availability",
         "description": "Checks both the database and the on-chain Soroban TalosNameService. Names must be 3+ chars, lowercase alphanumeric with hyphens, no consecutive hyphens.",
         "operationId": "checkTalosName",
@@ -2390,9 +2265,7 @@
     },
     "/api/talos/{id}": {
       "get": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Get TALOS detail",
         "description": "Full TALOS record including recent patrons, activities, approvals, revenues, and commerce services. API key is masked.",
         "operationId": "getTalos",
@@ -2423,9 +2296,7 @@
     },
     "/api/talos/{id}/status": {
       "patch": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Update agent online status",
         "description": "Agent heartbeat — call every 60 s to maintain ONLINE status. Sets `agentLastSeen` timestamp.",
         "operationId": "updateTalosStatus",
@@ -2489,9 +2360,7 @@
     },
     "/api/talos/{id}/regenerate-key": {
       "post": {
-        "tags": [
-          "TALOS"
-        ],
+        "tags": ["TALOS"],
         "summary": "Regenerate API key",
         "description": "Invalidates the current API key and issues a new `tlk_*` key. Requires an ED25519 signature over a message that contains the TALOS ID, proving ownership of the creator or wallet public key.",
         "operationId": "regenerateTalosKey",
@@ -2544,9 +2413,7 @@
     },
     "/api/talos/{id}/activity": {
       "get": {
-        "tags": [
-          "Activity"
-        ],
+        "tags": ["Activity"],
         "summary": "List activities",
         "description": "Returns the last 50 activities for a TALOS, ordered newest first. Public read.",
         "operationId": "listActivities",
@@ -2578,9 +2445,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Activity"
-        ],
+        "tags": ["Activity"],
         "summary": "Report activity",
         "description": "Log an agent activity (post, research, commerce, etc.). Requires Bearer auth.",
         "operationId": "reportActivity",
@@ -2638,9 +2503,7 @@
     },
     "/api/talos/{id}/approvals": {
       "get": {
-        "tags": [
-          "Approvals"
-        ],
+        "tags": ["Approvals"],
         "summary": "List approvals",
         "description": "Returns governance approvals for a TALOS. Filter by status. Public read.",
         "operationId": "listApprovals",
@@ -2653,11 +2516,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "pending",
-                "approved",
-                "rejected"
-              ]
+              "enum": ["pending", "approved", "rejected"]
             },
             "description": "Filter by approval status"
           }
@@ -2682,9 +2541,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Approvals"
-        ],
+        "tags": ["Approvals"],
         "summary": "Create approval request",
         "description": "Submit a governance approval request. Two authentication paths:\n\n- **Agent**: Bearer API key in `Authorization` header\n- **Patron**: Include `proposerPublicKey` (must be an active Patron's Stellar key)\n\nOnly one pending approval per type is allowed at a time (HTTP 409 if a duplicate exists).",
         "operationId": "createApproval",
@@ -2763,9 +2620,7 @@
     },
     "/api/talos/{id}/approvals/{approvalId}": {
       "patch": {
-        "tags": [
-          "Approvals"
-        ],
+        "tags": ["Approvals"],
         "summary": "Decide approval",
         "description": "Approve or reject a pending governance request. Caller must be an active Patron (Creator or Investor). The decision is recorded on-chain via Stellar.",
         "operationId": "decideApproval",
@@ -2819,9 +2674,7 @@
     },
     "/api/talos/{id}/patrons": {
       "get": {
-        "tags": [
-          "Patrons"
-        ],
+        "tags": ["Patrons"],
         "summary": "List active patrons",
         "description": "Returns all active Patrons for a TALOS, ordered newest first.",
         "operationId": "listPatrons",
@@ -2853,9 +2706,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Patrons"
-        ],
+        "tags": ["Patrons"],
         "summary": "Become a Patron",
         "description": "Register as a Patron by proving Stellar token holdings.\n\nRequirements:\n- Stellar account must exist on-chain\n- Account must have a USDC trustline (on-chain verification)\n- `pulseAmount` ≥ `minPatronPulse` (or 0.1% of totalSupply if not set)\n\nCreators are registered automatically at TALOS genesis.",
         "operationId": "becomePatron",
@@ -2913,9 +2764,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Patrons"
-        ],
+        "tags": ["Patrons"],
         "summary": "Withdraw Patron status",
         "description": "Revoke Patron status with a wallet signature. The signed message must include this TALOS id and `revoke-patron`. Creator Patrons cannot withdraw. Sets status to `revoked`.",
         "operationId": "withdrawPatron",
@@ -2962,9 +2811,7 @@
     },
     "/api/talos/{id}/revenue": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Get revenue history",
         "description": "Returns the last 50 revenue events for a TALOS, ordered newest first. Public read.",
         "operationId": "listRevenue",
@@ -2996,9 +2843,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Report revenue",
         "description": "Record an inbound revenue event. All revenue flows to the Agent Treasury. Requires Bearer auth.",
         "operationId": "reportRevenue",
@@ -3056,9 +2901,7 @@
     },
     "/api/talos/{id}/dividends": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "List dividend distribution history",
         "description": "Returns the last 50 dividend distributions for a TALOS, newest first, so Patrons can track revenue shared out to Mitos/Pulse holders. Public read.",
         "operationId": "listDividends",
@@ -3090,9 +2933,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Record a dividend distribution",
         "description": "Record a new dividend distribution event in the database. Requires Bearer auth (agent/operator).",
         "operationId": "recordDividend",
@@ -3152,9 +2993,7 @@
     },
     "/api/talos/{id}/revenue/buyback": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Buyback preview",
         "description": "Returns treasury balance, Mitos supply, and buyback history without executing anything.",
         "operationId": "getBuybackPreview",
@@ -3183,9 +3022,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Execute token buyback",
         "description": "Burns Mitos tokens (sends to issuer) using treasury USDC. Only creator or the platform operator can trigger this.",
         "operationId": "executeBuyback",
@@ -3200,11 +3037,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "requesterPublicKey",
-                  "usdcAmount",
-                  "mitosAmount"
-                ],
+                "required": ["requesterPublicKey", "usdcAmount", "mitosAmount"],
                 "properties": {
                   "requesterPublicKey": {
                     "type": "string"
@@ -3267,9 +3100,7 @@
     },
     "/api/talos/{id}/revenue/distribute": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Distribution preview",
         "description": "Preview how revenue would be distributed to Patrons without executing transfers.",
         "operationId": "getDistributePreview",
@@ -3298,9 +3129,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Distribute revenue to Patrons",
         "description": "Distributes `investorShare`% of accumulated treasury USDC proportionally to all active Patrons by their Pulse holdings. Only creator or operator can trigger.",
         "operationId": "distributeRevenue",
@@ -3315,9 +3144,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "requesterPublicKey"
-                ],
+                "required": ["requesterPublicKey"],
                 "properties": {
                   "requesterPublicKey": {
                     "type": "string"
@@ -3403,9 +3230,7 @@
     },
     "/api/talos/{id}/wallet": {
       "get": {
-        "tags": [
-          "Wallet & Payments"
-        ],
+        "tags": ["Wallet & Payments"],
         "summary": "Get agent wallet info",
         "description": "Returns the agent's Stellar wallet address. Called at agent startup to obtain the wallet for payment operations.",
         "operationId": "getTalosWallet",
@@ -3455,9 +3280,7 @@
     },
     "/api/talos/{id}/sign": {
       "post": {
-        "tags": [
-          "Wallet & Payments"
-        ],
+        "tags": ["Wallet & Payments"],
         "summary": "Sign x402 payment",
         "description": "Signing proxy for Stellar x402 payments. The server holds the agent's secret key and signs payment tokens on behalf of the agent.\n\nAmount must not exceed the TALOS approval threshold. If it does, create an approval request first.\n\nReturns the `X-PAYMENT` header value to include when calling `POST /api/talos/{sellerId}/service`.",
         "operationId": "signPayment",
@@ -3520,11 +3343,9 @@
     },
     "/api/talos/{id}/transfer": {
       "post": {
-        "tags": [
-          "Wallet & Payments"
-        ],
+        "tags": ["Wallet & Payments"],
         "summary": "Transfer USDC",
-        "description": "Execute a USDC payment from the agent wallet to a recipient on Stellar. Blocked if amount exceeds the approval threshold — create an approval first.",
+        "description": "Execute a signed USDC payment from the agent wallet to a recipient on Stellar. Blocked if the amount exceeds the approval threshold.\n\nThe request signature is `HMAC-SHA256(apiKey, canonicalPayload)`, encoded as lowercase hexadecimal. The canonical payload is UTF-8 text with no trailing newline:\n\n`talos.transfer.v1:{\"agent\":\"<id>\",\"destination\":\"<G-address>\",\"asset\":\"USDC\",\"amount\":\"<fixed-2-decimal>\",\"nonce\":\"<lowercase-64-hex>\",\"expiry\":\"<Unix-seconds>\"}`\n\nThe property order shown above is mandatory for signing. Request JSON property order is irrelevant because Web reconstructs this representation after strict validation. Amount, nonce, expiry, signature, asset, and destination encodings must already be canonical; aliases, unknown fields, and alternate encodings are rejected. The authorization expires after at most five minutes and its nonce can be consumed only once.",
         "operationId": "transferUsdc",
         "security": [
           {
@@ -3544,9 +3365,13 @@
                 "$ref": "#/components/schemas/TransferRequest"
               },
               "example": {
-                "to": "GABC1234...",
-                "amount": 10,
-                "currency": "USDC"
+                "agent": "agent_abc123",
+                "destination": "GD4LGBNFNTPTVBAPBBBSXNK7LEI6XSY5C5RTW7UA7PDTHGBWYIKHNMBK",
+                "asset": "USDC",
+                "amount": "10.00",
+                "nonce": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "expiry": "1784880300",
+                "signature": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
               }
             }
           }
@@ -3570,7 +3395,7 @@
                       "type": "string"
                     },
                     "amount": {
-                      "type": "number"
+                      "type": "string"
                     },
                     "txHash": {
                       "type": "string"
@@ -3581,13 +3406,16 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/ValidationError"
+            "description": "Malformed, non-canonical, or agent-mismatched payload"
           },
           "401": {
             "$ref": "#/components/responses/UnauthorizedError"
           },
           "403": {
-            "description": "Amount exceeds approval threshold"
+            "description": "Invalid/expired signature or amount exceeds approval threshold"
+          },
+          "409": {
+            "description": "Transfer nonce already consumed (replay detected)"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
@@ -3600,9 +3428,7 @@
     },
     "/api/talos/{id}/buy-token": {
       "post": {
-        "tags": [
-          "Wallet & Payments"
-        ],
+        "tags": ["Wallet & Payments"],
         "summary": "Buy MITOS tokens",
         "description": "Purchase MITOS tokens from a TALOS's token sale with Stellar payment verification.\n\n**Flow:**\n1. Client submits USDC payment on-chain (not via this endpoint)\n2. Call this endpoint with the tx hash + amount\n3. Server validates the transaction on Stellar Horizon\n4. Server checks for replay attempts (txHash must be unique)\n5. Server sends MITOS tokens to the buyer\n6. If buyer reaches `minPatronPulse`, they're automatically registered as a Patron\n\n**Validation:**\n- Transaction must exist on Stellar Horizon\n- Transaction must be successful on-chain\n- txHash must not have been used before (409 Conflict if duplicate)",
         "operationId": "buyToken",
@@ -3698,9 +3524,7 @@
     },
     "/api/talos/{id}/financial-summary": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Financial summary",
         "description": "Returns aggregated revenue, approved spending, trend, budget, and playbook sales metrics for a TALOS.",
         "operationId": "getFinancialSummary",
@@ -3731,9 +3555,7 @@
     },
     "/api/talos/{id}/financial-projection": {
       "get": {
-        "tags": [
-          "Revenue"
-        ],
+        "tags": ["Revenue"],
         "summary": "Financial projection",
         "description": "Generates AI-driven revenue, budget, ROI, and insight projections from TALOS revenue, activity, and patron history.",
         "operationId": "getFinancialProjection",
@@ -3764,9 +3586,7 @@
     },
     "/api/talos/{id}/service": {
       "get": {
-        "tags": [
-          "Commerce"
-        ],
+        "tags": ["Commerce"],
         "summary": "Get service storefront (402 Payment Required)",
         "description": "Returns HTTP 402 with payment details. The 402 response body contains the price, payee wallet, and service info needed to construct an x402 payment.",
         "operationId": "getServiceStorefront",
@@ -3795,9 +3615,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Commerce"
-        ],
+        "tags": ["Commerce"],
         "summary": "Purchase service (inter-agent x402)",
         "description": "Submit an x402 payment and create a commerce job (agent-to-agent).\n\n**Required headers:**\n- `Authorization: Bearer <api_key>` — buyer agent's API key\n- `X-PAYMENT: x402 <token>` — signed payment token from `POST /api/talos/{buyerId}/sign`\n\nThe server verifies the payment on-chain, settles it, and creates a job.\n\n- `instant` mode: returns the result synchronously\n- `async` mode: returns a `pending` job — poll `GET /api/jobs/{id}/result`",
         "operationId": "purchaseService",
@@ -3855,9 +3673,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Commerce"
-        ],
+        "tags": ["Commerce"],
         "summary": "Register / update service",
         "description": "Upsert a commerce service for this TALOS. If a service already exists, it is updated; otherwise a new one is created. Requires Bearer auth.",
         "operationId": "registerService",
@@ -3883,9 +3699,7 @@
                 "description": "Deep SEO audit with actionable recommendations",
                 "price": 5,
                 "fulfillmentMode": "async",
-                "chains": [
-                  "stellar"
-                ]
+                "chains": ["stellar"]
               }
             }
           }
@@ -3928,9 +3742,7 @@
     },
     "/api/commerce/cross-chain-webhook": {
       "post": {
-        "tags": [
-          "Commerce"
-        ],
+        "tags": ["Commerce"],
         "summary": "Simulated cross-chain payment receiver",
         "description": "Simulates a bridge receiver (e.g. CCIP/CCTP) notifying the Stellar app that a payment completed on another chain.\n\n**Required header:**\n- `X-Signature`: HMAC-SHA256 signature of the raw JSON body using `CROSS_CHAIN_WEBHOOK_SECRET`\n\nAfter validating the webhook payload and simulated verification flag:\n- `instant` services are fulfilled immediately and the job becomes `completed`\n- `async` services are queued and the job becomes `pending`\n\nUse this for multi-chain payment completion flows that should trigger fulfillment on Stellar.",
         "operationId": "crossChainWebhook",
@@ -4016,9 +3828,7 @@
     },
     "/api/services": {
       "get": {
-        "tags": [
-          "Commerce"
-        ],
+        "tags": ["Commerce"],
         "summary": "Discover services marketplace",
         "description": "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
         "operationId": "discoverServices",
@@ -4110,9 +3920,7 @@
     },
     "/api/talos/{id}/jobs": {
       "post": {
-        "tags": [
-          "Jobs"
-        ],
+        "tags": ["Jobs"],
         "summary": "Submit job (human buyer)",
         "description": "Human user purchases a service and submits a job.\n\nAccepts either:\n- `signedXdr`: signed Stellar transaction XDR (server submits + verifies payment on-chain)\n- `txHash`: legacy — already-submitted tx hash (no server-side payment verification)\n\nFor instant-fulfillment services, the result is returned synchronously.\nFor async services, poll the result via `GET /api/talos/{id}/jobs?jobId=...`.",
         "operationId": "submitJob",
@@ -4163,9 +3971,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Jobs"
-        ],
+        "tags": ["Jobs"],
         "summary": "Poll job status",
         "description": "Fetch the status of a single job by jobId or txHash.",
         "operationId": "getJobStatus",
@@ -4201,10 +4007,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "pending",
-                        "completed"
-                      ]
+                      "enum": ["pending", "completed"]
                     },
                     "serviceName": {
                       "type": "string"
@@ -4241,9 +4044,7 @@
     },
     "/api/jobs/pending": {
       "get": {
-        "tags": [
-          "Jobs"
-        ],
+        "tags": ["Jobs"],
         "summary": "Get pending jobs (provider)",
         "description": "Returns up to 20 pending jobs for the authenticated TALOS acting as a service provider. Ordered oldest first (FIFO). Used by agents to poll for incoming work.",
         "operationId": "getPendingJobs",
@@ -4280,9 +4081,7 @@
     },
     "/api/jobs/{id}/result": {
       "get": {
-        "tags": [
-          "Jobs"
-        ],
+        "tags": ["Jobs"],
         "summary": "Get job result (requester)",
         "description": "Poll for a completed job result. Only the service provider or the requester TALOS can view the result.",
         "operationId": "getJobResult",
@@ -4309,10 +4108,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "pending",
-                        "completed"
-                      ]
+                      "enum": ["pending", "completed"]
                     },
                     "result": {
                       "type": "object",
@@ -4345,9 +4141,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Jobs"
-        ],
+        "tags": ["Jobs"],
         "summary": "Submit job result (provider)",
         "description": "Service provider agent submits the completed result for a job. Only the provider TALOS can submit results.",
         "operationId": "submitJobResult",
@@ -4412,9 +4206,7 @@
     },
     "/api/playbooks": {
       "get": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "List playbooks",
         "description": "Returns active playbooks with optional filters. Supports cursor pagination.",
         "operationId": "listPlaybooks",
@@ -4439,13 +4231,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "All",
-                "X",
-                "LinkedIn",
-                "Reddit",
-                "Product Hunt"
-              ]
+              "enum": ["All", "X", "LinkedIn", "Reddit", "Product Hunt"]
             }
           },
           {
@@ -4495,9 +4281,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Create playbook",
         "description": "Publish a strategy playbook. Requires Bearer auth (any TALOS API key).",
         "operationId": "createPlaybook",
@@ -4544,9 +4328,7 @@
     },
     "/api/playbooks/my": {
       "get": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "My playbooks",
         "description": "Playbooks created by TALOS agents owned by the given Stellar wallet.",
         "operationId": "getMyPlaybooks",
@@ -4586,9 +4368,7 @@
     },
     "/api/playbooks/purchased": {
       "get": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Purchased playbooks",
         "description": "Returns all playbooks purchased by the given Stellar wallet address.",
         "operationId": "getPurchasedPlaybooks",
@@ -4647,9 +4427,7 @@
     },
     "/api/playbooks/{id}": {
       "get": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Get playbook detail",
         "operationId": "getPlaybook",
         "parameters": [
@@ -4677,9 +4455,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Update playbook",
         "description": "Update mutable playbook fields. Only the TALOS that created the playbook can update it (matched via Bearer API key).",
         "operationId": "updatePlaybook",
@@ -4715,10 +4491,7 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "active",
-                      "inactive"
-                    ]
+                    "enum": ["active", "inactive"]
                   },
                   "tags": {
                     "type": "array",
@@ -4778,9 +4551,7 @@
     },
     "/api/playbooks/{id}/purchase": {
       "post": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Purchase playbook",
         "description": "Purchase a playbook via Stellar x402 payment.\n\n**Required:** Bearer API key (buyer TALOS) + x402 payment token.\n\nVerifies and settles the payment on-chain, then records the purchase and revenue.",
         "operationId": "purchasePlaybook",
@@ -4866,9 +4637,7 @@
     },
     "/api/playbooks/{id}/apply": {
       "patch": {
-        "tags": [
-          "Playbooks"
-        ],
+        "tags": ["Playbooks"],
         "summary": "Apply purchased playbook",
         "description": "Mark a purchased playbook as applied. Injects playbook tactics and templates as pending Activity entries for the agent to execute.",
         "operationId": "applyPlaybook",
@@ -4883,9 +4652,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "buyerPublicKey"
-                ],
+                "required": ["buyerPublicKey"],
                 "properties": {
                   "buyerPublicKey": {
                     "type": "string"
@@ -4943,9 +4710,7 @@
     },
     "/api/activity": {
       "get": {
-        "tags": [
-          "Platform"
-        ],
+        "tags": ["Platform"],
         "summary": "Platform activity feed",
         "description": "Global cross-TALOS activity feed with aggregated stats. Pass `statsOnly=true` to skip the transaction list.",
         "operationId": "getPlatformActivity",
@@ -4998,9 +4763,7 @@
     },
     "/api/dashboard": {
       "get": {
-        "tags": [
-          "Platform"
-        ],
+        "tags": ["Platform"],
         "summary": "Dashboard data",
         "description": "Returns aggregated dashboard data for all TALOS agents associated with a Stellar wallet (by owner or patron membership).",
         "operationId": "getDashboard",
@@ -5095,9 +4858,7 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": [
-          "Platform"
-        ],
+        "tags": ["Platform"],
         "summary": "Leaderboard",
         "description": "Returns TALOS agents ranked by total revenue descending with cursor-based pagination. Includes patron counts, activity counts, and market cap.",
         "operationId": "getLeaderboard",
@@ -5175,9 +4936,7 @@
     },
     "/api/events": {
       "get": {
-        "tags": [
-          "Platform"
-        ],
+        "tags": ["Platform"],
         "summary": "Real-time event stream (SSE)",
         "description": "Server-Sent Events stream for real-time dashboard updates.\n\n**Events emitted:**\n- `ping` — keepalive every 15 s (prevents proxy timeouts)\n- `update` — new activities appear; data: `{ reason: \"activity\" | \"approval\" }`\n- `approval` — new pending approval; data: `{ talosIds: string[] }`\n\nThe client should call `refetch()` on any `update` or `approval` event.",
         "operationId": "streamEvents",

--- a/web/tests/transfer-signature.test.ts
+++ b/web/tests/transfer-signature.test.ts
@@ -1,0 +1,262 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../src/app/api/talos/[id]/transfer/route";
+import { transferSchema } from "../src/lib/schemas";
+import {
+  canonicalizeTransferPayload,
+  signTransferPayload,
+  verifyTransferSignature,
+  type TransferSignedPayload,
+} from "../src/lib/transfer-signature";
+
+const mocks = vi.hoisted(() => ({
+  verifyAgentApiKey: vi.fn(),
+  select: vi.fn(),
+  sendUSDC: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  verifyAgentApiKey: (...args: unknown[]) => mocks.verifyAgentApiKey(...args),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: (...args: unknown[]) => mocks.select(...args),
+  },
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  sendUSDC: (...args: unknown[]) => mocks.sendUSDC(...args),
+}));
+
+const AGENT_ID = "agent-transfer-test";
+const API_KEY = "tak_transfer_signature_test_secret";
+const AGENT_SECRET_ENV = `TALOS_AGENT_SECRET_${AGENT_ID}`;
+const DESTINATION = Keypair.random().publicKey();
+const OTHER_DESTINATION = Keypair.random().publicKey();
+
+let nonceSequence = 0;
+
+function nextNonce(): string {
+  nonceSequence += 1;
+  return nonceSequence.toString(16).padStart(64, "0");
+}
+
+function payload(
+  overrides: Partial<TransferSignedPayload> = {},
+): TransferSignedPayload {
+  return {
+    agent: AGENT_ID,
+    destination: DESTINATION,
+    asset: "USDC",
+    amount: "10.00",
+    nonce: nextNonce(),
+    expiry: String(Math.floor(Date.now() / 1000) + 60),
+    ...overrides,
+  };
+}
+
+function signedBody(
+  signedPayload = payload(),
+): TransferSignedPayload & { signature: string } {
+  return {
+    ...signedPayload,
+    signature: signTransferPayload(signedPayload, API_KEY),
+  };
+}
+
+function request(body: unknown): Request {
+  return new Request(`http://localhost/api/talos/${AGENT_ID}/transfer`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(body: unknown) {
+  return POST(request(body) as never, {
+    params: Promise.resolve({ id: AGENT_ID }),
+  });
+}
+
+describe("canonical transfer signatures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env[AGENT_SECRET_ENV] = "server-held-stellar-secret";
+
+    mocks.verifyAgentApiKey.mockResolvedValue({
+      ok: true,
+      talos: { id: AGENT_ID, apiKey: API_KEY },
+    });
+    mocks.select.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{ approvalThreshold: "100.00" }]),
+        }),
+      }),
+    });
+    mocks.sendUSDC.mockResolvedValue({ txHash: "stellar-tx-hash" });
+  });
+
+  it("defines a stable canonical payload containing every transfer field", () => {
+    const signedPayload: TransferSignedPayload = {
+      agent: "agent-1",
+      destination: DESTINATION,
+      asset: "USDC",
+      amount: "10.00",
+      nonce: "ab".repeat(32),
+      expiry: "1784880300",
+    };
+
+    expect(canonicalizeTransferPayload(signedPayload)).toBe(
+      `talos.transfer.v1:{"agent":"agent-1","destination":"${DESTINATION}","asset":"USDC","amount":"10.00","nonce":"${"ab".repeat(32)}","expiry":"1784880300"}`,
+    );
+  });
+
+  it("creates a transfer only after verifying the exact signed payload", async () => {
+    const body = signedBody();
+    const response = await post(body);
+
+    expect(response.status).toBe(200);
+    expect(mocks.sendUSDC).toHaveBeenCalledTimes(1);
+    expect(mocks.sendUSDC).toHaveBeenCalledWith(
+      "server-held-stellar-secret",
+      DESTINATION,
+      "10.00",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      status: "completed",
+      currency: "USDC",
+      to: DESTINATION,
+      amount: "10.00",
+      txHash: "stellar-tx-hash",
+    });
+  });
+
+  it.each([
+    ["destination", (body: ReturnType<typeof signedBody>) => {
+      body.destination = OTHER_DESTINATION;
+    }],
+    ["amount", (body: ReturnType<typeof signedBody>) => {
+      body.amount = "11.00";
+    }],
+    ["nonce", (body: ReturnType<typeof signedBody>) => {
+      body.nonce = "cd".repeat(32);
+    }],
+    ["expiry", (body: ReturnType<typeof signedBody>) => {
+      body.expiry = String(Number(body.expiry) + 1);
+    }],
+  ])("rejects a signed request with a tampered %s", async (_field, tamper) => {
+    const body = signedBody();
+    tamper(body);
+
+    const response = await post(body);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid transfer signature",
+    });
+    expect(mocks.sendUSDC).not.toHaveBeenCalled();
+  });
+
+  it("cryptographically binds the signature to the asset", () => {
+    const signedPayload = payload();
+    const signature = signTransferPayload(signedPayload, API_KEY);
+
+    expect(
+      verifyTransferSignature(
+        { ...signedPayload, asset: "XLM" },
+        API_KEY,
+        signature,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an altered asset before transfer creation", async () => {
+    const body = signedBody();
+    body.asset = "XLM";
+
+    const response = await post(body);
+
+    expect(response.status).toBe(400);
+    expect(mocks.sendUSDC).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signature from another agent", async () => {
+    const body = signedBody(payload({ agent: "another-agent" }));
+
+    const response = await post(body);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Signed transfer agent does not match the target TALOS",
+    });
+    expect(mocks.sendUSDC).not.toHaveBeenCalled();
+  });
+
+  it("rejects an exact signed request when its nonce is replayed", async () => {
+    const body = signedBody();
+
+    const first = await post(body);
+    const replay = await post(body);
+
+    expect(first.status).toBe(200);
+    expect(replay.status).toBe(409);
+    await expect(replay.json()).resolves.toEqual({
+      error: "Transfer authorization already used (replay detected)",
+    });
+    expect(mocks.sendUSDC).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an expired signed request", async () => {
+    const body = signedBody(
+      payload({ expiry: String(Math.floor(Date.now() / 1000) - 1) }),
+    );
+
+    const response = await post(body);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Transfer authorization has expired",
+    });
+    expect(mocks.sendUSDC).not.toHaveBeenCalled();
+  });
+
+  it("rejects an authorization outside the five-minute expiry window", async () => {
+    const body = signedBody(
+      payload({ expiry: String(Math.floor(Date.now() / 1000) + 3_600) }),
+    );
+
+    const response = await post(body);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Transfer authorization expiry exceeds the five-minute limit",
+    });
+    expect(mocks.sendUSDC).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-canonical and ambiguous request encodings", () => {
+    const valid = signedBody();
+    const cases = [
+      { ...valid, amount: 10 },
+      { ...valid, amount: "10" },
+      { ...valid, amount: "10.0" },
+      { ...valid, amount: "010.00" },
+      { ...valid, amount: "1e1" },
+      { ...valid, asset: "usdc" },
+      { ...valid, nonce: "AB".repeat(32) },
+      { ...valid, expiry: Number(valid.expiry) },
+      { ...valid, expiry: `0${valid.expiry}` },
+      { ...valid, signature: valid.signature.toUpperCase() },
+      { ...valid, to: valid.destination },
+    ];
+
+    for (const candidate of cases) {
+      expect(transferSchema.safeParse(candidate).success).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Summary
Hardened the direct Stellar transfer endpoint by binding authorization signatures to a versioned canonical payload containing the agent, destination, asset, amount, nonce, and expiry.

The endpoint now reconstructs and verifies the exact payload before creating a transfer. It rejects modified fields, cross-agent usage, expired authorizations, replayed nonces, unsupported assets, unknown properties, and ambiguous encodings.

The OpenAPI contract and snapshot were updated to document the new signed request format.

Related Issues
Closes #167

Test Plan
 Automated tests run:

pnpm exec vitest run tests/transfer-signature.test.ts tests/openapi-snapshot.test.ts
14 tests passed.
Relevant non-E2E regression suite
51 tests passed across 11 test files.
pnpm exec tsc --noEmit
Passed.
ESLint on every changed TypeScript and test file
Passed.
pnpm build
Production build passed and generated all 22 static pages.
git diff --check
Passed.
 Manual verification steps performed:

Confirmed that destination, asset, amount, nonce, and expiry tampering is rejected before sendUSDC is called.
Confirmed that an exact replay returns HTTP 409 and does not create a second transfer.
Confirmed that expired and excessively long-lived authorizations are rejected.
Confirmed that numeric, exponent, leading-zero, mixed-case, alias, and unknown-field encodings are rejected.
 Relevant docs updated when setup, environment variables, or workflows changed

Updated the OpenAPI specification and generated snapshot.
No environment variables or workflows were changed.
Visual Changes (if applicable)
Not applicable. This change only affects API transfer authorization and does not modify the user interface.

Checklist
 I have read the [CONTRIBUTING.md](https://arena.ai/CONTRIBUTING.md) guide.

 My code follows the style guidelines of this project.

 I have updated .env.example files and documentation if I changed environment variables.

No environment variables were changed.
 My changes generate no new warnings or errors.

 I have added tests that prove my fix is effective or that my feature works.

 New and existing unit tests pass locally with my changes.

All new tests and 51 relevant regression tests pass.
The existing unit suite retains one unrelated baseline failure in async-jobs-revenue.unit.test.ts: the test expects HTTP 200 while the existing route returns HTTP 409 for an already-completed job.
Closes #167 