### PR TITLE
ci: validate migrations against ephemeral Postgres

### DIFF
--- a/.github/workflows/web-migrations-ci.yml
+++ b/.github/workflows/web-migrations-ci.yml
@@ -1,0 +1,128 @@
+name: Web Migrations CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/drizzle/**'
+      - 'web/src/db/**'
+      - 'web/drizzle.config.ts'
+      - 'web/package.json'
+      - 'web/pnpm-lock.yaml'
+      - '.github/workflows/web-migrations-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/drizzle/**'
+      - 'web/src/db/**'
+      - 'web/drizzle.config.ts'
+      - 'web/package.json'
+      - 'web/pnpm-lock.yaml'
+      - '.github/workflows/web-migrations-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  migrations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: web
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: talos_migrations_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/talos_migrations_ci
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/talos_migrations_ci
+      PGPASSWORD: postgres
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bootstrap roles required by RLS migrations
+        run: psql -h localhost -U postgres -d talos_migrations_ci -f drizzle/bootstrap-roles.sql
+
+      - name: Apply migrations to empty schema (fresh install)
+        id: fresh_migrate
+        run: timeout 120 pnpm db:migrate 2>&1 | tee /tmp/migrate-fresh.log
+
+      - name: Check for schema drift between schema.ts and committed migrations
+        run: |
+          pnpm db:generate
+          if ! git diff --quiet --exit-code -- drizzle; then
+            echo "::error::schema.ts is out of sync with committed migration files. Run 'pnpm db:generate' and commit the result."
+            git diff -- drizzle
+            exit 1
+          fi
+
+      - name: Seed data fixture
+        run: pnpm db:seed
+
+      - name: Snapshot row counts before replay
+        run: |
+          psql -h localhost -U postgres -d talos_migrations_ci -t -c \
+            "SELECT count(*) FROM tls_talos;" | tr -d ' ' > /tmp/count-before.txt
+          cat /tmp/count-before.txt
+
+      - name: Re-apply migrations against previous/seeded schema (idempotency + data preservation)
+        id: replay_migrate
+        run: timeout 120 pnpm db:migrate 2>&1 | tee /tmp/migrate-replay.log
+
+      - name: Verify data survived replay
+        run: |
+          psql -h localhost -U postgres -d talos_migrations_ci -t -c \
+            "SELECT count(*) FROM tls_talos;" | tr -d ' ' > /tmp/count-after.txt
+          diff /tmp/count-before.txt /tmp/count-after.txt || \
+            (echo "::error::row count changed after re-applying migrations, data was not preserved" && exit 1)
+
+      - name: Check for orphaned migration lock
+        if: always()
+        run: |
+          psql -h localhost -U postgres -d talos_migrations_ci -t -c \
+            "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';" | tr -d ' ' > /tmp/lock-count.txt
+          if [ "$(cat /tmp/lock-count.txt)" != "0" ]; then
+            echo "::error::advisory lock left held after migration run, migrator did not release its lock"
+            exit 1
+          fi
+
+      - name: Upload migration logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-logs
+          path: |
+            /tmp/migrate-fresh.log
+            /tmp/migrate-replay.log
+          retention-days: 14
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,11 @@ pnpm test:unit
 pnpm test:e2e
 ```
 
+Any PR that changes `web/drizzle/**` or `web/src/db/**` is validated by the `Web Migrations CI`
+workflow, which applies your migrations to an ephemeral Postgres instance. See
+[`MIGRATIONS.md`](./MIGRATIONS.md) for what it checks, how to reproduce it locally, and rollback
+guidance.
+
 ### Prime Agent
 
 ```bash

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,75 @@
+# Database Migrations Guide
+
+`web/` uses Drizzle ORM with SQL migration files in [`web/drizzle`](web/drizzle). The
+`Web Migrations CI` workflow ([`.github/workflows/web-migrations-ci.yml`](.github/workflows/web-migrations-ci.yml))
+validates every migration against an ephemeral Postgres 16 service before merge.
+
+## What CI checks
+
+On any PR touching `web/drizzle/**`, `web/src/db/**`, or `web/drizzle.config.ts`:
+
+1. **Fresh install** — applies all migrations in order to an empty database (`pnpm db:migrate`), catching ordering and syntax failures.
+2. **Schema drift** — runs `pnpm db:generate` and fails the build if it produces changes that were not committed, meaning `schema.ts` and the migration files have diverged.
+3. **Data preservation / idempotency** — seeds data (`pnpm db:seed`), records row counts, then re-runs `pnpm db:migrate` against that already-migrated database to confirm re-applying migrations is a no-op and existing data survives.
+4. **Lock hygiene** — checks `pg_locks` after the run to catch an advisory lock left held by a crashed migrator.
+5. **Timeout budget** — each `pnpm db:migrate` invocation is bounded with `timeout 120` and the job itself has a 15-minute cap, so a hung migration fails the build instead of hanging CI.
+6. **Artifacts** — migration output is uploaded as a `migration-logs` workflow artifact (fresh run and replay) for post-mortem review, always, even on failure.
+
+## Role bootstrap
+
+The RLS migrations (`0001_enable_rls.sql`, `0002_rls_postgres_role.sql`) grant policies to
+Supabase's `anon` and `authenticated` roles. Supabase provisions those automatically; a plain
+Postgres instance (CI, local Docker) does not. [`web/drizzle/bootstrap-roles.sql`](web/drizzle/bootstrap-roles.sql)
+creates them idempotently and must be run once against a fresh database before the first migration:
+
+```bash
+psql "$DIRECT_URL" -f web/drizzle/bootstrap-roles.sql
+```
+
+## Reproducing locally
+
+```bash
+docker run --rm -d --name talos-migrations-ci \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=talos_migrations_ci \
+  -p 5432:5432 postgres:16
+
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/talos_migrations_ci
+export DIRECT_URL=$DATABASE_URL
+
+cd web
+psql "$DIRECT_URL" -f drizzle/bootstrap-roles.sql
+pnpm install
+pnpm db:migrate
+
+docker stop talos-migrations-ci
+```
+
+## Rollback
+
+These migrations are forward-only; there are no generated `down` scripts. To roll back a bad
+migration:
+
+1. Restore the database from the pre-migration snapshot/backup (Supabase point-in-time recovery,
+   or your own `pg_dump` taken before deploying).
+2. Write a new forward migration that reverses the change, rather than editing or deleting an
+   already-merged migration file — migration files are treated as immutable history once merged.
+
+Because of this, prefer additive, backward-compatible migrations (new nullable columns, new
+tables) over destructive ones, and split destructive changes (drop column/table) into a separate,
+later migration once the application no longer reads the old shape.
+
+## Troubleshooting
+
+- **`role "anon" does not exist` / `role "authenticated" does not exist`** — run
+  `bootstrap-roles.sql` against the target database before migrating (see above). Supabase-hosted
+  databases already have these roles.
+- **Schema drift failure in CI** — you changed `web/src/db/schema.ts` without committing a
+  matching migration. Run `pnpm db:generate` inside `web/` and commit the generated file(s) in
+  `web/drizzle/`.
+- **Migration times out** — check the `migration-logs` artifact from the failed run; a hang
+  usually means a lock is held by a concurrent migration or long-running transaction against the
+  same database.
+- **Advisory lock check fails** — a previous migrator run crashed mid-migration and left its lock
+  held. On a real database, restart the connection pool holding the lock, or open a new session
+  and run `SELECT pg_advisory_unlock_all();` after confirming no migration is genuinely in
+  progress.

--- a/web/drizzle/bootstrap-roles.sql
+++ b/web/drizzle/bootstrap-roles.sql
@@ -1,0 +1,16 @@
+-- Supabase provisions `anon` and `authenticated` roles automatically; a plain
+-- Postgres instance (local Docker, CI) does not. The RLS migrations
+-- (0001_enable_rls, 0002_rls_postgres_role) grant policies to those roles, so
+-- they must exist before `pnpm db:migrate` runs against an ephemeral or
+-- self-hosted database. Safe to run multiple times.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+END
+$$;


### PR DESCRIPTION
Add a CI workflow that spins up a Postgres 16 service and runs the web/ Drizzle migrations against it on every PR touching web/drizzle or web/src/db. It applies migrations to an empty database (fresh install), checks schema.ts against committed migrations for drift, replays migrations against seeded data to catch non-idempotent migrations and data loss, checks for orphaned advisory locks, bounds each run with a timeout, and uploads migration logs as an artifact.

Also adds bootstrap-roles.sql to create the anon/authenticated roles the RLS migrations depend on (present on Supabase, absent on a plain Postgres instance), and MIGRATIONS.md documenting the CI checks, local reproduction steps, rollback strategy, and troubleshooting.

Closes #258

