### PR TITLE
ci: automate versioned releases and changelog generation

### DIFF
--- a/.github/workflows/release-plan.yml
+++ b/.github/workflows/release-plan.yml
@@ -1,0 +1,71 @@
+name: Release Plan
+
+# Opens/updates a "chore(release)" pull request with component-aware version
+# bumps and changelog entries for web, sdk, agent, and contracts, computed
+# from Conventional Commits since each component's last release tag. Nothing
+# is tagged or published here — see release-publish.yml for that. Merging
+# this PR is the human approval gate for cutting a release.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Prerelease channel (leave blank for a stable release)'
+        required: false
+        type: choice
+        default: ''
+        options: ['', 'beta', 'rc']
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-plan
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    # The release commit created by this workflow (or merged from its PR)
+    # must not re-trigger itself. github.event.head_commit only exists on
+    # push events, so workflow_dispatch runs always pass this check.
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release)') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Compute release plan
+        id: plan
+        run: |
+          PRERELEASE_FLAG=""
+          if [ -n "${{ inputs.prerelease }}" ]; then
+            PRERELEASE_FLAG="--prerelease=${{ inputs.prerelease }}"
+          fi
+          node scripts/release/cli.mjs plan $PRERELEASE_FLAG --summary-out=/tmp/release-summary.md
+
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update release PR
+        if: steps.plan.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(release): version bump"
+          branch: release/please
+          title: "chore(release): version bump"
+          body-path: /tmp/release-summary.md
+          labels: release
+          delete-branch: true

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,156 @@
+name: Release Publish
+
+# Runs after a "chore(release)" version-bump commit (opened by release-plan.yml
+# and approved/merged by a maintainer) lands on main. Tags each component
+# whose manifest version isn't tagged yet, builds its release artifact, and
+# publishes a GitHub Release with the changelog section as notes. Tag
+# creation is idempotent (existing tags are skipped), so a failed or
+# re-triggered run only ever creates what's still missing.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: ${{ contains(github.event.head_commit.message, 'chore(release)') }}
+    runs-on: ubuntu-latest
+    outputs:
+      has_releases: ${{ steps.tag.outputs.has_releases }}
+      releases: ${{ steps.tag.outputs.releases }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Create tags for released components
+        id: tag
+        run: |
+          node scripts/release/cli.mjs tag --create --notes-dir=/tmp/release-notes > /tmp/releasable.json
+          cat /tmp/releasable.json
+
+          if [ "$(jq 'length' /tmp/releasable.json)" = "0" ]; then
+            echo "has_releases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_releases=true" >> "$GITHUB_OUTPUT"
+            echo "releases=$(jq -c . /tmp/releasable.json)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push new tags
+        if: steps.tag.outputs.has_releases == 'true'
+        run: git push origin --tags
+
+      - name: Upload release notes
+        if: steps.tag.outputs.has_releases == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: /tmp/release-notes
+
+  build-and-release:
+    needs: prepare
+    if: needs.prepare.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJson(needs.prepare.outputs.releases) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.release.tag }}
+
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes
+
+      # --- sdk ---
+      - name: Setup pnpm
+        if: matrix.release.name == 'sdk'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        if: matrix.release.name == 'sdk'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Build sdk artifact
+        if: matrix.release.name == 'sdk'
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --dir packages/sdk build
+          cd packages/sdk && npm pack
+
+      # --- agent ---
+      - name: Setup Python
+        if: matrix.release.name == 'agent'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup uv
+        if: matrix.release.name == 'agent'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build agent artifact
+        if: matrix.release.name == 'agent'
+        working-directory: packages/prime-agent
+        run: |
+          uv sync --frozen --all-extras --all-groups
+          uv build
+
+      # --- contracts ---
+      - name: Install Rust toolchain
+        if: matrix.release.name == 'contracts'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build contracts artifact
+        if: matrix.release.name == 'contracts'
+        working-directory: contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Collect artifact paths
+        id: artifacts
+        run: |
+          case "${{ matrix.release.name }}" in
+            sdk) echo "paths=packages/sdk/*.tgz" >> "$GITHUB_OUTPUT" ;;
+            agent) echo "paths=packages/prime-agent/dist/*" >> "$GITHUB_OUTPUT" ;;
+            contracts) echo "paths=contracts/target/wasm32-unknown-unknown/release/*.wasm" >> "$GITHUB_OUTPUT" ;;
+            web) echo "paths=" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FLAGS=()
+          if [ "${{ matrix.release.prerelease }}" = "true" ]; then
+            FLAGS+=(--prerelease)
+          fi
+          gh release create "${{ matrix.release.tag }}" \
+            --title "${{ matrix.release.name }} v${{ matrix.release.version }}" \
+            --notes-file "release-notes/${{ matrix.release.name }}.md" \
+            "${FLAGS[@]}" \
+            ${{ steps.artifacts.outputs.paths }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,13 @@ cargo test --target wasm32-unknown-unknown
 5. Open a pull request using the template in [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md)
 6. Link the issue in your PR description, for example `Closes #39`
 
+## Releases
+
+Versioning, changelogs, and tagging for `web`, `sdk`, `agent`, and `contracts` are automated —
+see [`RELEASES.md`](./RELEASES.md). You don't need to do anything for this beyond writing
+[Conventional Commits](https://www.conventionalcommits.org/) subjects (`feat: ...`, `fix: ...`,
+etc.) in your PRs; version bumps are computed from those.
+
 ## Issue and PR Templates
 
 Use the templates already included in the repo when filing new work:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,88 @@
+# Release Process
+
+Talos Protocol ships four independently versioned components:
+
+| Component   | Path                     | Manifest(s)                                                                                            | Tag format         |
+|-------------|--------------------------|-----------------------------------------------------------------------------------------------------------|---------------------|
+| `web`       | `web/`                   | `web/package.json`                                                                                       | `web-vX.Y.Z`        |
+| `sdk`       | `packages/sdk/`          | `packages/sdk/package.json`                                                                               | `sdk-vX.Y.Z`        |
+| `agent`     | `packages/prime-agent/`  | `packages/prime-agent/pyproject.toml`                                                                     | `agent-vX.Y.Z`      |
+| `contracts` | `contracts/`             | `contracts/talos_registry/Cargo.toml`, `contracts/talos_name_service/Cargo.toml`, `contracts/talos_governance/Cargo.toml` | `contracts-vX.Y.Z`  |
+
+Contracts are versioned as one unit — the three Soroban crates are built, tested, and deployed
+together (see `contracts-ci.yml`), so lockstep versions keep them from drifting apart.
+
+The process is driven by [`scripts/release/`](scripts/release) and two workflows. Nothing in
+either workflow publishes anything without a human merging a PR first.
+
+## How it works
+
+1. **`Release Plan`** ([`.github/workflows/release-plan.yml`](.github/workflows/release-plan.yml))
+   runs on every push to `main`. It classifies commits since each component's last release tag
+   using [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat:` → minor bump
+   - `fix:` / `perf:` → patch bump
+   - a `!` after the type (`feat!:`) or a `BREAKING CHANGE:` footer → major bump
+   - anything else (`docs:`, `chore:`, `refactor:`, etc.) doesn't trigger a release on its own
+
+   A component with no commits since its last tag, or only non-releasing commits, is left alone —
+   there is never an empty release. If any component has releasable changes, the workflow opens or
+   updates a `chore(release): version bump` pull request with the bumped manifest(s) and an updated
+   `CHANGELOG.md` per component (created on first use).
+
+   **This PR is the approval gate.** A maintainer reviews the computed versions and changelog
+   entries and merges (or edits and merges) it like any other PR. Nothing is tagged yet.
+
+2. **`Release Publish`** ([`.github/workflows/release-publish.yml`](.github/workflows/release-publish.yml))
+   runs when a `chore(release)` commit lands on `main`. For every component whose manifest version
+   doesn't already have a matching git tag, it:
+   - creates and pushes an annotated tag (`<component>-vX.Y.Z`)
+   - builds that component's release artifact (sdk: npm tarball, agent: wheel + sdist, contracts:
+     wasm binaries; web has no build artifact here since it's already deployed via
+     [`deploy.yml`](.github/workflows/deploy.yml) on every push to `main`)
+   - publishes a GitHub Release with the corresponding changelog section as its notes
+
+   Tag creation is idempotent — components that already have a tag matching their current manifest
+   version are skipped — so re-running this workflow after a partial failure only finishes what's
+   left; it never double-tags or double-releases.
+
+## Prereleases
+
+Trigger `Release Plan` manually (`workflow_dispatch`) with a `prerelease` input of `beta` or `rc`
+to compute `X.Y.Z-beta.N` / `X.Y.Z-rc.N` versions instead of stable ones. Everything downstream
+(the PR, the tag, the GitHub Release) works identically; the release is marked "prerelease" on
+GitHub automatically.
+
+## Rollback
+
+- **Before the release PR is merged**: close the PR without merging. `Release Plan` will
+  recompute it on the next push.
+- **After a tag/release was published but should not have been**: delete the GitHub Release and
+  the tag (`git push origin :refs/tags/<tag>`). Do not edit or delete the merged manifest/changelog
+  commit — open a new PR that reverts it, and let `Release Plan` pick up the next real release
+  from there. Tags are treated as immutable once pushed; never force-push or re-tag an existing
+  version.
+- **A bad version shipped**: cut a new patch/major release with the fix rather than mutating the
+  old tag. Consumers that pinned the bad version are unaffected until they upgrade.
+
+## Local reproduction
+
+```bash
+# See what would be released, without a real PR:
+node scripts/release/cli.mjs plan --summary-out=/tmp/summary.md
+git diff   # inspect the computed bumps and changelog entries
+git checkout -- .   # discard the dry run
+
+# Run the test suite for the release scripts:
+node --test scripts/release/*.test.mjs
+```
+
+## Limitations
+
+- Version classification is per-commit-subject only; it does not inspect diffs, so a commit
+  mislabeled with the wrong Conventional Commit type will bump the wrong severity.
+- The four manifests are the source of truth. Manually editing a version number without going
+  through the release PR will desync it from its git tag history — `plan`/`tag` will still work
+  off whatever the manifest says, so keep manual edits out of the affected commits.
+- `contracts`'s three crates must always share one version; a mismatch fails `plan`/`tag` loudly
+  rather than guessing which one is right.

--- a/scripts/release/classify.mjs
+++ b/scripts/release/classify.mjs
@@ -1,0 +1,119 @@
+// Pure, git/fs-free logic for turning Conventional Commit subjects into a
+// semver bump and a changelog section. Kept dependency-free and side-effect
+// free so it can be unit tested without a real repo.
+
+const CONVENTIONAL_RE = /^(\w+)(\(([^)]+)\))?(!)?:\s*(.+)$/;
+
+const BUMP_RANK = { none: 0, patch: 1, minor: 2, major: 3 };
+
+/**
+ * @param {string} subject first line of a commit message
+ * @param {string} body remainder of the commit message
+ * @returns {{type: string, scope: string|null, breaking: boolean, description: string} | null}
+ *   null when the subject does not follow Conventional Commits — such
+ *   commits are recorded but never drive a version bump.
+ */
+export function parseCommit(subject, body = "") {
+  const trimmed = (subject || "").trim();
+  const match = CONVENTIONAL_RE.exec(trimmed);
+  if (!match) return null;
+
+  const [, type, , scope, bang, description] = match;
+  const breaking = Boolean(bang) || /BREAKING[ -]CHANGE:/.test(body || "");
+
+  return {
+    type: type.toLowerCase(),
+    scope: scope || null,
+    breaking,
+    description: description.trim(),
+  };
+}
+
+/**
+ * @param {ReturnType<typeof parseCommit>} commit
+ * @returns {'major'|'minor'|'patch'|'none'}
+ */
+export function bumpForCommit(commit) {
+  if (!commit) return "none";
+  if (commit.breaking) return "major";
+  if (commit.type === "feat") return "minor";
+  if (commit.type === "fix" || commit.type === "perf") return "patch";
+  return "none";
+}
+
+/**
+ * @param {Array<ReturnType<typeof parseCommit>>} commits
+ * @returns {'major'|'minor'|'patch'|'none'}
+ */
+export function bumpForCommits(commits) {
+  let best = "none";
+  for (const commit of commits) {
+    const bump = bumpForCommit(commit);
+    if (BUMP_RANK[bump] > BUMP_RANK[best]) best = bump;
+  }
+  return best;
+}
+
+/**
+ * @param {string} version current "MAJOR.MINOR.PATCH" (prerelease suffix, if any, is ignored)
+ * @param {'major'|'minor'|'patch'} bump
+ */
+export function applyBump(version, bump) {
+  const base = String(version).split("-")[0];
+  const parts = base.split(".").map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`invalid semver version: ${version}`);
+  }
+  let [major, minor, patch] = parts;
+  if (bump === "major") {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (bump === "minor") {
+    minor += 1;
+    patch = 0;
+  } else if (bump === "patch") {
+    patch += 1;
+  } else {
+    throw new Error(`cannot apply bump "${bump}"`);
+  }
+  return `${major}.${minor}.${patch}`;
+}
+
+/**
+ * Appends an incrementing prerelease identifier, e.g. "1.2.0" + "beta" -> "1.2.0-beta.0".
+ * @param {string} baseVersion
+ * @param {string} channel
+ * @param {number} nextIndex
+ */
+export function toPrerelease(baseVersion, channel, nextIndex) {
+  return `${baseVersion}-${channel}.${nextIndex}`;
+}
+
+const SECTION_ORDER = [
+  ["major", "Breaking Changes"],
+  ["minor", "Features"],
+  ["patch", "Fixes"],
+  ["none", "Other Changes"],
+];
+
+/**
+ * @param {{component: string, version: string, date: string, entries: Array<{sha: string, commit: ReturnType<typeof parseCommit>, subject: string}>}} params
+ */
+export function renderChangelogSection({ component, version, date, entries }) {
+  const byBump = { major: [], minor: [], patch: [], none: [] };
+  for (const entry of entries) {
+    const bump = bumpForCommit(entry.commit);
+    const line = entry.commit
+      ? `- ${entry.commit.description} (${entry.sha})`
+      : `- ${entry.subject} (${entry.sha})`;
+    byBump[bump].push(line);
+  }
+
+  const lines = [`## ${component} v${version} - ${date}`, ""];
+  for (const [bump, heading] of SECTION_ORDER) {
+    if (byBump[bump].length === 0) continue;
+    lines.push(`### ${heading}`, "", ...byBump[bump], "");
+  }
+  return lines.join("\n").trimEnd() + "\n";
+}

--- a/scripts/release/classify.test.mjs
+++ b/scripts/release/classify.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseCommit,
+  bumpForCommit,
+  bumpForCommits,
+  applyBump,
+  toPrerelease,
+  renderChangelogSection,
+} from "./classify.mjs";
+
+test("parseCommit reads type, scope, and description", () => {
+  const commit = parseCommit("feat(sdk): add payment resource client");
+  assert.deepEqual(commit, {
+    type: "feat",
+    scope: "sdk",
+    breaking: false,
+    description: "add payment resource client",
+  });
+});
+
+test("parseCommit detects breaking change via ! marker", () => {
+  const commit = parseCommit("feat(api)!: drop legacy auth header");
+  assert.equal(commit.breaking, true);
+});
+
+test("parseCommit detects breaking change via BREAKING CHANGE footer", () => {
+  const commit = parseCommit("refactor: rework token storage", "BREAKING CHANGE: old tokens are invalid");
+  assert.equal(commit.breaking, true);
+});
+
+test("parseCommit returns null for non-conventional subjects", () => {
+  assert.equal(parseCommit("wip"), null);
+  assert.equal(parseCommit("Merge branch 'main'"), null);
+  assert.equal(parseCommit(""), null);
+});
+
+test("bumpForCommit maps type to severity", () => {
+  assert.equal(bumpForCommit(parseCommit("feat: x")), "minor");
+  assert.equal(bumpForCommit(parseCommit("fix: x")), "patch");
+  assert.equal(bumpForCommit(parseCommit("perf: x")), "patch");
+  assert.equal(bumpForCommit(parseCommit("docs: x")), "none");
+  assert.equal(bumpForCommit(parseCommit("feat!: x")), "major");
+  assert.equal(bumpForCommit(null), "none");
+});
+
+test("bumpForCommits takes the highest severity across all commits", () => {
+  const commits = [parseCommit("docs: readme"), parseCommit("fix: null check"), parseCommit("feat: new endpoint")];
+  assert.equal(bumpForCommits(commits), "minor");
+});
+
+test("bumpForCommits is major when any commit is breaking, regardless of order", () => {
+  const commits = [parseCommit("feat: new endpoint"), parseCommit("fix!: remove default")];
+  assert.equal(bumpForCommits(commits), "major");
+});
+
+test("bumpForCommits is none when nothing is releasable", () => {
+  const commits = [parseCommit("docs: readme"), parseCommit("chore: bump deps"), null];
+  assert.equal(bumpForCommits(commits), "none");
+});
+
+test("applyBump increments the right segment and resets lower ones", () => {
+  assert.equal(applyBump("1.2.3", "patch"), "1.2.4");
+  assert.equal(applyBump("1.2.3", "minor"), "1.3.0");
+  assert.equal(applyBump("1.2.3", "major"), "2.0.0");
+});
+
+test("applyBump ignores an existing prerelease suffix on the input", () => {
+  assert.equal(applyBump("1.2.3-beta.4", "patch"), "1.2.4");
+});
+
+test("applyBump rejects a malformed version", () => {
+  assert.throws(() => applyBump("not-a-version", "patch"), /invalid semver/);
+});
+
+test("applyBump rejects an unknown bump kind", () => {
+  assert.throws(() => applyBump("1.0.0", "sideways"), /cannot apply bump/);
+});
+
+test("toPrerelease appends a channel and index", () => {
+  assert.equal(toPrerelease("1.2.0", "beta", 0), "1.2.0-beta.0");
+  assert.equal(toPrerelease("1.2.0", "beta", 3), "1.2.0-beta.3");
+});
+
+test("renderChangelogSection groups entries under their bump heading", () => {
+  const md = renderChangelogSection({
+    component: "sdk",
+    version: "1.3.0",
+    date: "2026-07-24",
+    entries: [
+      { sha: "abc1234", subject: "feat: add x", commit: parseCommit("feat: add x") },
+      { sha: "def5678", subject: "fix: y", commit: parseCommit("fix: y") },
+      { sha: "aaa1111", subject: "chore: bump", commit: parseCommit("chore: bump") },
+    ],
+  });
+
+  assert.match(md, /^## sdk v1\.3\.0 - 2026-07-24/);
+  assert.match(md, /### Features\n\n- add x \(abc1234\)/);
+  assert.match(md, /### Fixes\n\n- y \(def5678\)/);
+  assert.match(md, /### Other Changes\n\n- bump \(aaa1111\)/);
+});
+
+test("renderChangelogSection omits headings with no entries", () => {
+  const md = renderChangelogSection({
+    component: "agent",
+    version: "0.2.0",
+    date: "2026-07-24",
+    entries: [{ sha: "abc1234", subject: "feat: add y", commit: parseCommit("feat: add y") }],
+  });
+  assert.doesNotMatch(md, /Breaking Changes/);
+  assert.doesNotMatch(md, /Fixes/);
+  assert.doesNotMatch(md, /Other Changes/);
+});

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// Component-aware release planner/tagger for web, sdk, agent, and contracts.
+//
+// Usage:
+//   node scripts/release/cli.mjs plan [--prerelease=<channel>] [--summary-out=<file>]
+//   node scripts/release/cli.mjs tag [--create]
+//
+// See RELEASES.md for the full workflow this drives.
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import {
+  parseCommit,
+  bumpForCommits,
+  applyBump,
+  toPrerelease,
+  renderChangelogSection,
+} from "./classify.mjs";
+import { readVersion, writeVersion } from "./version-files.mjs";
+import { COMPONENTS } from "./components.mjs";
+import { latestTag, tagExists, commitsTouchingPaths, createAnnotatedTag } from "./git.mjs";
+
+// Overridable so integration tests can point the CLI at a throwaway repo
+// instead of the real one.
+const REPO_ROOT = process.env.RELEASE_CLI_REPO_ROOT || path.resolve(new URL("../..", import.meta.url).pathname);
+
+function readComponentVersion(component) {
+  const versions = component.manifests.map((m) => readVersion(path.join(REPO_ROOT, m.file), m.kind));
+  const distinct = new Set(versions);
+  if (distinct.size > 1) {
+    throw new Error(
+      `component "${component.name}" has manifests with divergent versions: ` +
+        component.manifests.map((m, i) => `${m.file}=${versions[i]}`).join(", "),
+    );
+  }
+  return versions[0];
+}
+
+function writeComponentVersion(component, version) {
+  for (const m of component.manifests) {
+    writeVersion(path.join(REPO_ROOT, m.file), m.kind, version);
+  }
+}
+
+function prependChangelog(component, section) {
+  const file = path.join(REPO_ROOT, component.changelog);
+  const existing = existsSync(file) ? readFileSync(file, "utf8") : `# ${component.name} Changelog\n\n`;
+  const [header, ...rest] = existing.split("\n\n");
+  const body = rest.join("\n\n");
+  const updated = body
+    ? `${header}\n\n${section}\n${body}`
+    : `${header}\n\n${section}`;
+  writeFileSync(file, updated.trimEnd() + "\n");
+}
+
+function extractChangelogSection(component, version) {
+  const file = path.join(REPO_ROOT, component.changelog);
+  if (!existsSync(file)) return null;
+  const text = readFileSync(file, "utf8");
+  const heading = `## ${component.name} v${version} -`;
+  const start = text.indexOf(heading);
+  if (start === -1) return null;
+  const rest = text.slice(start);
+  const nextHeading = rest.indexOf("\n## ", 1);
+  return (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim();
+}
+
+function nextPrereleaseIndex(cwd, name, baseVersion, channel) {
+  const pattern = `${name}-v${baseVersion}-${channel}.*`;
+  // latestTag sorts by version, so scanning all matches is unnecessary — the
+  // count of existing matches is enough to pick the next index.
+  const out = latestTag(cwd, pattern);
+  if (!out) return 0;
+  const match = /\.(\d+)$/.exec(out);
+  return match ? Number(match[1]) + 1 : 0;
+}
+
+function planCommand(args) {
+  const prerelease = args.find((a) => a.startsWith("--prerelease="))?.split("=")[1] || null;
+  const summaryOut = args.find((a) => a.startsWith("--summary-out="))?.split("=")[1] || null;
+
+  const results = [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  for (const component of COMPONENTS) {
+    const currentVersion = readComponentVersion(component);
+    const tagPattern = `${component.name}-v*`;
+    const lastTag = latestTag(REPO_ROOT, tagPattern);
+
+    const commits = commitsTouchingPaths(REPO_ROOT, lastTag, component.paths);
+    if (commits.length === 0) continue;
+
+    const parsed = commits.map((c) => ({ ...c, commit: parseCommit(c.subject, c.body) }));
+    const bump = bumpForCommits(parsed.map((p) => p.commit));
+
+    let baseVersion;
+    let bumpApplied;
+    if (!lastTag) {
+      // First-ever release for this component: cut whatever is already in
+      // the manifest as the baseline instead of guessing a bump.
+      baseVersion = currentVersion;
+      bumpApplied = "baseline";
+    } else {
+      if (bump === "none") continue; // only docs/chore/etc touched this component
+      baseVersion = applyBump(currentVersion, bump);
+      bumpApplied = bump;
+    }
+
+    const targetVersion = prerelease
+      ? toPrerelease(baseVersion, prerelease, nextPrereleaseIndex(REPO_ROOT, component.name, baseVersion, prerelease))
+      : baseVersion;
+
+    writeComponentVersion(component, targetVersion);
+    prependChangelog(component, renderChangelogSection({
+      component: component.name,
+      version: targetVersion,
+      date: today,
+      entries: parsed.map((p) => ({ sha: p.sha, commit: p.commit, subject: p.subject })),
+    }));
+
+    results.push({ name: component.name, from: currentVersion, to: targetVersion, bump: bumpApplied, commits: commits.length });
+  }
+
+  if (results.length === 0) {
+    console.log("No releasable changes detected for any component.");
+    return;
+  }
+
+  const lines = ["# Release Plan", ""];
+  for (const r of results) {
+    lines.push(`- **${r.name}**: ${r.from} -> ${r.to} (${r.bump}, ${r.commits} commit${r.commits === 1 ? "" : "s"})`);
+  }
+  const summary = lines.join("\n") + "\n";
+  console.log(summary);
+  if (summaryOut) writeFileSync(summaryOut, summary);
+}
+
+function tagCommand(args) {
+  const create = args.includes("--create");
+  const notesDir = args.find((a) => a.startsWith("--notes-dir="))?.split("=")[1] || null;
+  if (notesDir) mkdirSync(notesDir, { recursive: true });
+
+  const releasable = [];
+
+  for (const component of COMPONENTS) {
+    const version = readComponentVersion(component);
+    const tag = `${component.name}-v${version}`;
+    if (tagExists(REPO_ROOT, tag)) continue;
+
+    const notes = extractChangelogSection(component, version) || `Release ${tag}`;
+    releasable.push({ name: component.name, version, tag, prerelease: version.includes("-") });
+    if (notesDir) writeFileSync(path.join(notesDir, `${component.name}.md`), notes + "\n");
+
+    if (create) {
+      createAnnotatedTag(REPO_ROOT, tag, `${component.name} v${version}`);
+    }
+  }
+
+  console.log(JSON.stringify(releasable, null, 2));
+}
+
+const [, , command, ...rest] = process.argv;
+
+if (command === "plan") {
+  planCommand(rest);
+} else if (command === "tag") {
+  tagCommand(rest);
+} else {
+  console.error("usage: cli.mjs <plan|tag> [options]");
+  process.exit(1);
+}

--- a/scripts/release/cli.test.mjs
+++ b/scripts/release/cli.test.mjs
@@ -1,0 +1,153 @@
+// Integration test: drives the real cli.mjs against a throwaway git repo
+// scaffolded to mirror the actual monorepo layout (web/, packages/sdk/,
+// packages/prime-agent/, contracts/*), exercising git + filesystem together
+// instead of mocking them.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.mjs");
+
+function sh(cwd, cmd, args) {
+  return execFileSync(cmd, args, { cwd, encoding: "utf8" });
+}
+
+function runCli(repo, args) {
+  return sh(repo, "node", [CLI, ...args]);
+}
+
+function runCliExpectFailure(repo, args) {
+  try {
+    runCli(repo, args);
+    assert.fail("expected cli to exit with a non-zero status");
+  } catch (err) {
+    return err; // execFileSync throws with .status/.stdout/.stderr on non-zero exit
+  }
+}
+
+function scaffoldRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), "release-cli-"));
+  process.env.RELEASE_CLI_REPO_ROOT = dir;
+
+  sh(dir, "git", ["init", "-q"]);
+  sh(dir, "git", ["config", "user.email", "test@example.com"]);
+  sh(dir, "git", ["config", "user.name", "Test"]);
+
+  mkdirSync(path.join(dir, "web"), { recursive: true });
+  writeFileSync(path.join(dir, "web/package.json"), JSON.stringify({ name: "web", version: "0.1.0" }, null, 2));
+
+  mkdirSync(path.join(dir, "packages/sdk"), { recursive: true });
+  writeFileSync(path.join(dir, "packages/sdk/package.json"), JSON.stringify({ name: "sdk", version: "0.1.0" }, null, 2));
+
+  mkdirSync(path.join(dir, "packages/prime-agent"), { recursive: true });
+  writeFileSync(path.join(dir, "packages/prime-agent/pyproject.toml"), '[project]\nname = "talos-agent"\nversion = "0.1.0"\n');
+
+  for (const crate of ["talos_registry", "talos_name_service", "talos_governance"]) {
+    mkdirSync(path.join(dir, "contracts", crate), { recursive: true });
+    writeFileSync(path.join(dir, "contracts", crate, "Cargo.toml"), `[package]\nname = "${crate}"\nversion = "0.1.0"\n`);
+  }
+
+  sh(dir, "git", ["add", "-A"]);
+  sh(dir, "git", ["commit", "-q", "-m", "chore: scaffold monorepo"]);
+
+  return dir;
+}
+
+test("plan cuts a baseline release for every component on first run", () => {
+  const repo = scaffoldRepo();
+  try {
+    const out = runCli(repo, ["plan"]);
+    for (const name of ["web", "sdk", "agent", "contracts"]) {
+      assert.match(out, new RegExp(`\\*\\*${name}\\*\\*: 0\\.1\\.0 -> 0\\.1\\.0 \\(baseline`));
+    }
+    assert.match(readFileSync(path.join(repo, "web/CHANGELOG.md"), "utf8"), /## web v0\.1\.0/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("tag --create tags every baselined component exactly once", () => {
+  const repo = scaffoldRepo();
+  try {
+    runCli(repo, ["plan"]);
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "chore(release): cut baseline"]);
+
+    const first = JSON.parse(runCli(repo, ["tag", "--create"]));
+    assert.deepEqual(
+      first.map((r) => r.tag).sort(),
+      ["agent-v0.1.0", "contracts-v0.1.0", "sdk-v0.1.0", "web-v0.1.0"],
+    );
+
+    const tags = sh(repo, "git", ["tag", "--list"]).trim().split("\n").sort();
+    assert.deepEqual(tags, ["agent-v0.1.0", "contracts-v0.1.0", "sdk-v0.1.0", "web-v0.1.0"]);
+
+    // Idempotent: re-running with nothing new to release tags nothing again.
+    const second = JSON.parse(runCli(repo, ["tag", "--create"]));
+    assert.deepEqual(second, []);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("plan only bumps the component whose path actually changed", () => {
+  const repo = scaffoldRepo();
+  try {
+    runCli(repo, ["plan"]);
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "chore(release): cut baseline"]);
+    runCli(repo, ["tag", "--create"]);
+
+    writeFileSync(path.join(repo, "packages/sdk/README.md"), "docs\n");
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "feat(sdk): add payments resource"]);
+
+    const out = runCli(repo, ["plan"]);
+    assert.match(out, /\*\*sdk\*\*: 0\.1\.0 -> 0\.2\.0 \(minor, 1 commit\)/);
+    assert.doesNotMatch(out, /\*\*web\*\*/);
+    assert.doesNotMatch(out, /\*\*agent\*\*/);
+    assert.doesNotMatch(out, /\*\*contracts\*\*/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("plan skips a component whose only new commits are non-releasing", () => {
+  const repo = scaffoldRepo();
+  try {
+    runCli(repo, ["plan"]);
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "chore(release): cut baseline"]);
+    runCli(repo, ["tag", "--create"]);
+
+    writeFileSync(path.join(repo, "web/README.md"), "docs\n");
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "docs(web): fix typo"]);
+
+    const out = runCli(repo, ["plan"]);
+    assert.equal(out.trim(), "No releasable changes detected for any component.");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("plan fails loudly when contracts crates have divergent versions", () => {
+  const repo = scaffoldRepo();
+  try {
+    writeFileSync(
+      path.join(repo, "contracts/talos_governance/Cargo.toml"),
+      '[package]\nname = "talos_governance"\nversion = "0.2.0"\n',
+    );
+    sh(repo, "git", ["add", "-A"]);
+    sh(repo, "git", ["commit", "-q", "-m", "fix(contracts): oops"]);
+
+    const err = runCliExpectFailure(repo, ["plan"]);
+    assert.match(err.stderr, /divergent versions/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/release/components.mjs
+++ b/scripts/release/components.mjs
@@ -1,0 +1,34 @@
+// The four release surfaces named in issue #264: web, agent, SDK, contracts.
+// `contracts` bundles the three Soroban crates — they are built, deployed
+// and versioned together (see contracts-ci.yml), so a single component with
+// multiple lockstep manifests keeps their versions from drifting apart.
+export const COMPONENTS = [
+  {
+    name: "web",
+    paths: ["web/"],
+    manifests: [{ file: "web/package.json", kind: "json" }],
+    changelog: "web/CHANGELOG.md",
+  },
+  {
+    name: "sdk",
+    paths: ["packages/sdk/"],
+    manifests: [{ file: "packages/sdk/package.json", kind: "json" }],
+    changelog: "packages/sdk/CHANGELOG.md",
+  },
+  {
+    name: "agent",
+    paths: ["packages/prime-agent/"],
+    manifests: [{ file: "packages/prime-agent/pyproject.toml", kind: "toml" }],
+    changelog: "packages/prime-agent/CHANGELOG.md",
+  },
+  {
+    name: "contracts",
+    paths: ["contracts/"],
+    manifests: [
+      { file: "contracts/talos_registry/Cargo.toml", kind: "toml" },
+      { file: "contracts/talos_name_service/Cargo.toml", kind: "toml" },
+      { file: "contracts/talos_governance/Cargo.toml", kind: "toml" },
+    ],
+    changelog: "contracts/CHANGELOG.md",
+  },
+];

--- a/scripts/release/git.mjs
+++ b/scripts/release/git.mjs
@@ -1,0 +1,46 @@
+import { execFileSync } from "node:child_process";
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/**
+ * Most recent tag matching a glob (e.g. "web-v*"), or null if there is none yet.
+ */
+export function latestTag(cwd, pattern) {
+  const out = git(cwd, ["tag", "--list", pattern, "--sort=-v:refname"]);
+  const first = out.split("\n").find((line) => line.trim().length > 0);
+  return first || null;
+}
+
+export function tagExists(cwd, tag) {
+  const out = git(cwd, ["tag", "--list", tag]);
+  return out.trim().length > 0;
+}
+
+/**
+ * Commits touching `paths`, oldest first. `sinceTag` is exclusive; when null
+ * the full history reachable from HEAD is used.
+ */
+export function commitsTouchingPaths(cwd, sinceTag, paths) {
+  const range = sinceTag ? `${sinceTag}..HEAD` : "HEAD";
+  const out = git(cwd, [
+    "log",
+    range,
+    "--reverse",
+    "--pretty=format:%H",
+    "--",
+    ...paths,
+  ]);
+  if (!out) return [];
+
+  return out.split("\n").map((sha) => {
+    const subject = git(cwd, ["show", "-s", "--format=%s", sha]);
+    const body = git(cwd, ["show", "-s", "--format=%b", sha]);
+    return { sha: sha.slice(0, 7), subject, body };
+  });
+}
+
+export function createAnnotatedTag(cwd, tag, message) {
+  git(cwd, ["tag", "-a", tag, "-m", message]);
+}

--- a/scripts/release/version-files.mjs
+++ b/scripts/release/version-files.mjs
@@ -1,0 +1,60 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const VERSION_LINE_RE = /^(\s*version\s*=\s*")([^"]+)(")/m;
+
+/**
+ * @param {string} file
+ * @param {'json'|'toml'} kind
+ * @returns {string}
+ */
+export function readVersion(file, kind) {
+  if (!existsSync(file)) {
+    throw new Error(`manifest not found: ${file}`);
+  }
+  const text = readFileSync(file, "utf8");
+
+  if (kind === "json") {
+    const parsed = JSON.parse(text);
+    if (typeof parsed.version !== "string") {
+      throw new Error(`${file} has no "version" string field`);
+    }
+    return parsed.version;
+  }
+
+  if (kind === "toml") {
+    const match = VERSION_LINE_RE.exec(text);
+    if (!match) {
+      throw new Error(`${file} has no version = "..." line`);
+    }
+    return match[2];
+  }
+
+  throw new Error(`unknown manifest kind: ${kind}`);
+}
+
+/**
+ * @param {string} file
+ * @param {'json'|'toml'} kind
+ * @param {string} version
+ */
+export function writeVersion(file, kind, version) {
+  const text = readFileSync(file, "utf8");
+
+  if (kind === "json") {
+    const parsed = JSON.parse(text);
+    parsed.version = version;
+    writeFileSync(file, JSON.stringify(parsed, null, 2) + "\n");
+    return;
+  }
+
+  if (kind === "toml") {
+    if (!VERSION_LINE_RE.test(text)) {
+      throw new Error(`${file} has no version = "..." line`);
+    }
+    const updated = text.replace(VERSION_LINE_RE, `$1${version}$3`);
+    writeFileSync(file, updated);
+    return;
+  }
+
+  throw new Error(`unknown manifest kind: ${kind}`);
+}

--- a/scripts/release/version-files.test.mjs
+++ b/scripts/release/version-files.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readVersion, writeVersion } from "./version-files.mjs";
+
+function withTmpDir(fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), "release-version-files-"));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("readVersion/writeVersion round-trip a package.json", () => {
+  withTmpDir((dir) => {
+    const file = path.join(dir, "package.json");
+    writeFileSync(file, JSON.stringify({ name: "sdk", version: "0.1.0", dependencies: { a: "1" } }, null, 2));
+
+    assert.equal(readVersion(file, "json"), "0.1.0");
+    writeVersion(file, "json", "0.2.0");
+    assert.equal(readVersion(file, "json"), "0.2.0");
+
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    assert.equal(parsed.dependencies.a, "1", "unrelated fields must survive the rewrite");
+  });
+});
+
+test("readVersion/writeVersion round-trip a Cargo.toml-style file", () => {
+  withTmpDir((dir) => {
+    const file = path.join(dir, "Cargo.toml");
+    writeFileSync(
+      file,
+      ['[package]', 'name = "talos-registry"', 'version = "0.1.0"', 'edition = "2021"', ""].join("\n"),
+    );
+
+    assert.equal(readVersion(file, "toml"), "0.1.0");
+    writeVersion(file, "toml", "0.2.0");
+    assert.equal(readVersion(file, "toml"), "0.2.0");
+
+    const text = readFileSync(file, "utf8");
+    assert.match(text, /name = "talos-registry"/, "unrelated lines must survive the rewrite");
+  });
+});
+
+test("readVersion throws for a missing file", () => {
+  withTmpDir((dir) => {
+    assert.throws(() => readVersion(path.join(dir, "missing.json"), "json"), /not found/);
+  });
+});
+
+test("readVersion throws when a toml file has no version line", () => {
+  withTmpDir((dir) => {
+    const file = path.join(dir, "Cargo.toml");
+    writeFileSync(file, "[package]\nname = \"x\"\n");
+    assert.throws(() => readVersion(file, "toml"), /no version/);
+  });
+});
+
+test("readVersion throws when a json file has no version field", () => {
+  withTmpDir((dir) => {
+    const file = path.join(dir, "package.json");
+    writeFileSync(file, JSON.stringify({ name: "x" }));
+    assert.throws(() => readVersion(file, "json"), /no "version"/);
+  });
+});


### PR DESCRIPTION
Add component-aware release automation for web, sdk, agent, and contracts. scripts/release/ classifies Conventional Commits since each component's last <name>-vX.Y.Z tag, computes the next semver bump (feat=minor, fix/perf=patch, breaking=major), and generates a changelog section — with unit tests for the classification/version logic and an integration test that drives the CLI against a real throwaway git repo.

Two workflows wire it up:
- release-plan.yml runs on every push to main and opens/updates a chore(release) PR with the computed version bumps and changelogs. Merging that PR is the approval gate; nothing is tagged yet.
- release-publish.yml runs when a chore(release) commit lands on main, tags each newly-versioned component, builds its artifact (sdk tarball, agent wheel/sdist, contracts wasm), and publishes a GitHub Release with the changelog as notes. Tagging is idempotent, so a re-run only finishes whatever a prior partial run missed.

workflow_dispatch on release-plan supports beta/rc prereleases. RELEASES.md documents the flow, prereleases, rollback, and limitations.

Closes #264

