### PR TITLE
security(contracts): implement scoped emergency pause controls

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -14,8 +14,9 @@ Stellar-based smart contracts for the Talos Protocol, built with Rust and the So
   - 3% protocol fee to protocol wallet on creation
   - **Two-step admin transfer** (`propose_admin` / `accept_admin` / `cancel_admin_transfer`)
   - **Admin timelocks** (`schedule_action` / `execute_action` / `cancel_action` / `set_timelock_config`)
-  - **Interface version query** (`version()` — immutable, compile-time constant `(1, 1, 0)`)
-  - Events: `tls_crt`, `pat_upd`, `fee_chg`, `adm_prp`, `adm_acc`, `adm_cnl`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`
+  - **Scoped emergency pause controls** (`pause` / `unpause` / `add_guardian` / `remove_guardian`) — see [Emergency Pause Controls](#emergency-pause-controls)
+  - **Interface version query** (`version()` — immutable, compile-time constant `(1, 2, 0)`)
+  - Events: `tls_crt`, `pat_upd`, `fee_chg`, `adm_prp`, `adm_acc`, `adm_cnl`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `pause_on`, `pause_off`, `guard_add`, `guard_rem`
 
 ### 2. TalosNameService
 - **Purpose**: Human-readable name registration for Talos IDs
@@ -24,8 +25,9 @@ Stellar-based smart contracts for the Talos Protocol, built with Rust and the So
   - Validation: 3-32 chars, lowercase alphanumeric + hyphens, no consecutive hyphens
   - Admin-controlled registry contract pointer (`set_registry_contract`)
   - **Admin timelocks** (`schedule_action` / `execute_action` / `cancel_action` / `set_timelock_config`)
-  - **Interface version query** (`version()` — immutable, compile-time constant `(1, 1, 0)`)
-  - Events: `name_reg`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`
+  - **Scoped emergency pause controls** (`pause` / `unpause` / `add_guardian` / `remove_guardian`) — see [Emergency Pause Controls](#emergency-pause-controls)
+  - **Interface version query** (`version()` — immutable, compile-time constant `(1, 2, 0)`)
+  - Events: `name_reg`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `pause_on`, `pause_off`, `guard_add`, `guard_rem`
 
 ### 3. TalosGovernance
 - **Purpose**: Token-weighted governance for Talos Protocol
@@ -266,6 +268,9 @@ stellar contract invoke \
 | "Timelock enabled: action must be scheduled" | min_delay > 0 | Use `schedule_action` then `execute_action` |
 | "Timelock delay not met" | Executed before ETA | Wait for `eta` ledger timestamp |
 | "Proposal expired" | Executed after grace window | Re-schedule; old proposal is permanently expired |
+| "Domain is paused" / `ContractError::DomainPaused` | A guardian or the admin paused that write path | Wait for the pause to expire, or have the admin call `unpause` |
+| "Caller is not admin or guardian" | Non-authorized address called `pause` | Have the admin add the caller via `add_guardian`, or use the admin key |
+| "Domain locked by admin; guardians cannot modify" | A guardian tried to override an admin-set pause | Only the admin can change or lift it — call `unpause` with the admin key |
 
 ## Invoke Examples
 
@@ -340,6 +345,10 @@ Both contracts emit typed Soroban events on every meaningful state change. Off-c
 | `tl_exec` | `(symbol_short!("tl_exec"), proposal_id: u64)` | `(action: AdminAction, executor: Address)` | `execute_action` success |
 | `tl_cnl`  | `(symbol_short!("tl_cnl"), proposal_id: u64)` | `(action: AdminAction, canceller: Address)` | `cancel_action` success |
 | `tl_cfg`  | `(symbol_short!("tl_cfg"),)` | `(old_min_delay: u64, new_min_delay: u64, grace_period: u64)` | `set_timelock_config` success |
+| `pause_on`  | `(symbol_short!("pause_on"), domain: PauseDomain)` | `(actor: Address, expires_at: u64)` | `pause` success (`expires_at = 0` means indefinite) |
+| `pause_off` | `(symbol_short!("pause_off"), domain: PauseDomain)` | `(actor: Address,)` | `unpause` success (never emitted for a no-op unpause) |
+| `guard_add` | `(symbol_short!("guard_add"),)` | `(guardian: Address,)` | `add_guardian` success |
+| `guard_rem` | `(symbol_short!("guard_rem"),)` | `(guardian: Address,)` | `remove_guardian` success |
 
 **Filtering examples**
 
@@ -641,12 +650,170 @@ stellar contract invoke \
 4. **Timelocks are per-contract, not cross-contract**: A Registry timelock and a Name Service timelock are fully independent. There is no coordinated multi-contract proposal mechanism.
 5. **Proposal IDs are sequential per contract**: IDs are 1-indexed u64 counters. They are never reused or removed from storage.
 
+## Emergency Pause Controls
+
+`TalosRegistry` and `TalosNameService` both implement a narrowly-scoped emergency pause mechanism for containing a compromised or buggy write path without disabling reads, and without permanently centralizing control in a single always-on kill switch.
+
+### Design goals
+
+| Goal | How it is met |
+|------|--------------|
+| Narrow blast radius | Each **pause domain** gates exactly one write path (e.g. `TalosCreation`). Pausing one domain never affects any other domain or any read entry-point. |
+| Fast containment | `pause` requires no timelock — it is deliberately the *fastest* lever in the contract, usable the moment a problem is discovered. |
+| Bounded guardian risk | A **guardian** role can trigger a pause but can never lift one, and can never set an indefinite pause — the maximum a compromised guardian key can do is force a temporary (≤ 7 day), auto-expiring, single-domain outage. |
+| No permanent centralization | Guardian pauses always expire on their own even if nobody calls `unpause`. Only the admin may set an indefinite pause (`duration = 0`), and only the admin may lift any pause. |
+| Admin lock is not overridable by guardians | If the admin pauses a domain, a guardian cannot refresh, shorten, or otherwise modify that pause — only the admin can change or lift it. |
+| Reads always work | `get_talos`, `is_active`, `resolve_name`, `is_name_available`, etc. never consult pause state. Dashboards, indexers, and off-chain agents keep functioning during a pause. |
+| Backward-compatible default | No domain is paused until `pause` is explicitly called. Existing deployed instances that never call `pause` behave exactly as before this feature shipped. |
+| Idempotent, retry-safe | Re-pausing an already-paused domain refreshes it deterministically instead of failing. Calling `unpause` on a domain with no active pause is a silent no-op, not a panic — safe for duplicate or retried transactions. |
+| Observability | Every state transition emits an event (`pause_on` / `pause_off` / `guard_add` / `guard_rem`) carrying the actor and new expiry, and `pause_info` exposes the same data for on-demand polling. |
+
+### Roles
+
+| Role | Can pause | Can unpause | Duration rules | Managed by |
+|------|-----------|-------------|-----------------|------------|
+| **Admin** (`ProtocolWallet` / `Admin`) | Any domain | Any domain, regardless of who paused it | `duration = 0` → indefinite; non-zero must be ≤ 30 days | N/A (the protocol admin) |
+| **Guardian** | Any domain *not already admin-paused* | Never | Must be non-zero and ≤ 7 days — indefinite pauses are impossible for a guardian | `add_guardian` / `remove_guardian` (admin-only, bounded to 10 guardians) |
+| Anyone else | No | No | — | — |
+
+Guardians exist so an on-call responder (a bot, a multisig signer, an ops key with narrower trust than the protocol admin) can contain a live incident in one transaction without waiting on the admin key, while structurally bounding what that narrower-trust key can do: it cannot lock the protocol forever, and it cannot lift a pause the admin has already escalated.
+
+### Pause domains
+
+#### TalosRegistry
+
+| Domain | Gates |
+|--------|-------|
+| `TalosCreation` | `create_talos` |
+| `PatronUpdates` | `update_patron` |
+| `KernelUpdates` | `update_kernel` |
+| `PulseUpdates` | `update_pulse` |
+| `Deactivation` | `deactivate_talos` |
+
+#### TalosNameService
+
+| Domain | Gates |
+|--------|-------|
+| `NameRegistration` | `register_name` |
+
+Administrative entry-points (`set_protocol_fee`, admin transfer, `set_registry_contract`, all timelock management, and pause/guardian management itself) are **intentionally never pausable**. They already carry their own admin-auth (and optionally timelock) protection, and making the escape hatch itself pausable would risk a state where the protocol can no longer be unpaused at all.
+
+### State model
+
+```
+                     pause(caller, domain, duration)
+                                  │
+                                  ▼
+   (no record) ──────────────► PauseState { paused_by, paused_at, expires_at }
+        ▲                                │
+        │                                │ expires_at == 0 → indefinite (admin only)
+        │        unpause(domain)         │ expires_at  > 0 → lifts automatically once
+        └────────── (admin-only) ────────┘                    now >= expires_at (no write needed)
+```
+
+`is_paused(domain)` (and every gated entry-point internally) evaluates expiry lazily against `ledger().timestamp()` — an expired guardian pause needs no explicit `unpause` call to stop blocking writes.
+
+### Entry-points
+
+*(identical shape on both contracts; `TalosNameService` sources the admin from `Admin` instead of `ProtocolWallet`)*
+
+| Entry-point | Auth | Description |
+|-------------|------|-------------|
+| `pause(caller, domain, duration)` | Admin or guardian (`caller` must sign) | Pauses `domain`. See [Roles](#roles) for duration bounds. Idempotent refresh; guardians cannot overwrite an admin-set pause. |
+| `unpause(domain)` | Admin | Lifts an active pause. No-op (does not panic) if the domain has no active pause record. |
+| `is_paused(domain)` | None (read-only) | `true` if `domain` is currently paused and not yet expired. |
+| `pause_info(domain)` | None (read-only) | Full status: `active`, `paused_by`, `paused_at`, `expires_at` (`None` = not paused, or paused indefinitely). |
+| `add_guardian(guardian)` | Admin | Registers a guardian. Idempotent; bounded to 10 guardians. |
+| `remove_guardian(guardian)` | Admin | Revokes a guardian. Idempotent. Does not affect any pause that guardian already set. |
+| `is_guardian(addr)` | None (read-only) | `true` if `addr` currently holds guardian authority. |
+| `list_guardians()` | None (read-only) | Returns all registered guardians. |
+
+### Storage
+
+| Key | Type | Lifecycle |
+|-----|------|-----------|
+| `PauseState(domain)` | `PauseState { paused_by, paused_at, expires_at }` | Written by `pause`. Removed by `unpause`. Lazily treated as inactive once `expires_at` passes, without a storage write. |
+| `Guardians` | `Vec<Address>` | Written by `add_guardian` / `remove_guardian`. Bounded to 10 entries — absent means no guardians registered. |
+
+Both keys are new additions to each contract's `DataKey` enum. Existing deployed instances that have never called `pause` or `add_guardian` simply have no entries for these keys — `is_paused` returns `false` and `list_guardians` returns an empty vector, so no migration is required and no existing behavior changes until an operator opts in.
+
+### Operational runbook
+
+#### Containing an incident (guardian, fast path)
+
+```bash
+# A guardian bounds the outage to at most 1 hour on a single write path.
+stellar contract invoke \
+  --id "$REGISTRY_CONTRACT" \
+  --source guardian-key \
+  --network testnet \
+  -- \
+  pause \
+  --caller GGUARDIAN... \
+  --domain '{"TalosCreation": {}}' \
+  --duration 3600
+
+# Confirm:
+stellar contract invoke --id "$REGISTRY_CONTRACT" --network testnet -- \
+  pause_info --domain '{"TalosCreation": {}}'
+```
+
+#### Escalating to an indefinite admin lock
+
+```bash
+stellar contract invoke \
+  --id "$REGISTRY_CONTRACT" \
+  --source admin-key \
+  --network testnet \
+  -- \
+  pause \
+  --caller GADMIN... \
+  --domain '{"TalosCreation": {}}' \
+  --duration 0
+```
+
+#### Rollback — lifting a pause once the fix is deployed or the incident is resolved
+
+```bash
+stellar contract invoke \
+  --id "$REGISTRY_CONTRACT" \
+  --source admin-key \
+  --network testnet \
+  -- \
+  unpause \
+  --domain '{"TalosCreation": {}}'
+
+# Idempotent — safe to call again even if it was already lifted or had expired.
+```
+
+If the admin key itself is unavailable, no action is required for a guardian-initiated pause: it lifts on its own within at most 7 days by construction. There is deliberately no way to make a pause permanently unrecoverable short of losing the admin key entirely — the same trust assumption the rest of the contract's admin surface already relies on.
+
+#### Managing guardians
+
+```bash
+stellar contract invoke --id "$REGISTRY_CONTRACT" --source admin-key --network testnet -- \
+  add_guardian --guardian GGUARDIAN...
+
+stellar contract invoke --id "$REGISTRY_CONTRACT" --source admin-key --network testnet -- \
+  remove_guardian --guardian GGUARDIAN...
+
+stellar contract invoke --id "$REGISTRY_CONTRACT" --network testnet -- \
+  list_guardians
+```
+
+### Known limitations
+
+1. **Pause state is per-contract, not cross-contract**: pausing `TalosRegistry::TalosCreation` has no effect on `TalosNameService::NameRegistration`, and vice versa — mirrors the existing per-contract scope of admin timelocks.
+2. **Guardian removal does not retroactively lift an active pause**: revoking a guardian stops them from pausing again, but a pause they already set continues to run until it expires or the admin calls `unpause`.
+3. **`add_guardian` / `remove_guardian` are not timelocked**: like `set_timelock_config`, guardian roster changes take effect immediately by design, since they are part of the emergency-response surface itself.
+4. **Guardian list is bounded to 10 entries**: a well-intentioned operator adding more must first remove an existing guardian; this is a deliberate bound on unbounded storage growth, not a governance mechanism.
+
 ## Interface Versioning
 
 Both `TalosRegistry` and `TalosNameService` expose a `version()` entry-point that returns the contract's interface version as `(major: u32, minor: u32, patch: u32)`.
 
-Current version: **`(1, 1, 0)`**  
-_(minor bumped from `1.0.0` when timelock entry-points were added in this release)_
+Current version: **`(1, 2, 0)`**  
+_(minor bumped from `1.1.0` when the scoped emergency pause entry-points were added in this release)_
 
 ```bash
 # Query TalosRegistry version
@@ -743,6 +910,7 @@ The test suites live in each contract's `#[cfg(test)] mod tests` block and cover
 - Two-step admin transfer (propose → accept → cancel paths)
 - Event emission for every state transition
 - Interface version consistency
+- Emergency pause: per-domain scoping (pausing one domain never blocks another, reads always succeed), admin vs. guardian authorization and duration bounds, guardian-cannot-override-admin-lock and admin-can-override-guardian invariants, auto-expiry without an explicit `unpause`, idempotent `pause`/`unpause`/`add_guardian`/`remove_guardian` under duplicate calls, and guardian roster bounds
 
 ## License
 

--- a/contracts/talos_name_service/src/lib.rs
+++ b/contracts/talos_name_service/src/lib.rs
@@ -16,7 +16,7 @@ use std::string::ToString;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Env, IntoVal, String, Symbol,
+    Env, IntoVal, String, Symbol, Vec,
 };
 
 // ── Data Types ──────────────────────────────────────────────────────
@@ -54,6 +54,40 @@ pub struct TimelockConfig {
     pub grace_period: u64,
 }
 
+/// A narrowly-scoped write path that can be independently paused.
+///
+/// Reads (`resolve_name`, `name_of`, `is_name_available`, `has_name`) are
+/// never gated by any pause domain. Admin entry-points (`set_registry_contract`,
+/// timelock management) are intentionally not pausable — they already carry
+/// their own admin-auth (and optional timelock) protection.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PauseDomain {
+    NameRegistration,
+}
+
+/// Persisted record of an active pause on a single [`PauseDomain`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseState {
+    pub paused_by: Address,
+    pub paused_at: u64,
+    /// Unix timestamp after which the pause automatically lifts.
+    /// `0` means indefinite — only settable by the admin, never by a guardian.
+    pub expires_at: u64,
+}
+
+/// Computed, read-friendly view of a domain's pause status.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseInfo {
+    pub active: bool,
+    pub paused_by: Option<Address>,
+    pub paused_at: Option<u64>,
+    /// `None` when not paused, or when paused indefinitely by the admin.
+    pub expires_at: Option<u64>,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -64,6 +98,10 @@ pub enum DataKey {
     TimelockConfig,
     TimelockProposal(u64),
     NextTimelockId,
+    /// Active pause record for a domain, if any. Absence means unpaused.
+    PauseState(PauseDomain),
+    /// Bounded list of guardian addresses authorized to trigger (but not lift) pauses.
+    Guardians,
 }
 
 #[contracterror]
@@ -72,6 +110,11 @@ pub enum ContractError {
     AlreadyInitialized = 1,
     UnauthorizedCaller = 2,
     TimelockEnabled = 3,
+    DomainPaused = 4,
+    NotAdminOrGuardian = 5,
+    DomainLockedByAdmin = 6,
+    InvalidPauseDuration = 7,
+    GuardianLimitReached = 8,
 }
 
 // ── Events ──────────────────────────────────────────────────────────
@@ -83,6 +126,10 @@ pub enum ContractError {
 //   tl_exec  : (symbol, proposal_id: u64) → (action: AdminAction, executor: Address)
 //   tl_cnl   : (symbol, proposal_id: u64) → (action: AdminAction, canceller: Address)
 //   tl_cfg   : (symbol,)               → (old_min_delay: u64, new_min_delay: u64, grace_period: u64)
+//   pause_on  : (symbol, domain: PauseDomain) → (actor: Address, expires_at: u64)
+//   pause_off : (symbol, domain: PauseDomain) → (actor: Address,)
+//   guard_add : (symbol,)                     → (guardian: Address,)
+//   guard_rem : (symbol,)                     → (guardian: Address,)
 
 fn emit_name_registered(env: &Env, talos_id: u32, name: String, owner: Address) {
     let topics = (symbol_short!("name_reg"), talos_id);
@@ -136,8 +183,63 @@ fn emit_timelock_config_changed(
         .publish(topics, (old_min_delay, new_min_delay, grace_period));
 }
 
+fn emit_pause_set(env: &Env, domain: &PauseDomain, actor: &Address, expires_at: u64) {
+    let topics = (symbol_short!("pause_on"), domain.clone());
+    env.events().publish(topics, (actor.clone(), expires_at));
+}
+
+fn emit_pause_cleared(env: &Env, domain: &PauseDomain, actor: &Address) {
+    let topics = (symbol_short!("pause_off"), domain.clone());
+    env.events().publish(topics, (actor.clone(),));
+}
+
+fn emit_guardian_added(env: &Env, guardian: Address) {
+    let topics = (symbol_short!("guard_add"),);
+    env.events().publish(topics, (guardian,));
+}
+
+fn emit_guardian_removed(env: &Env, guardian: Address) {
+    let topics = (symbol_short!("guard_rem"),);
+    env.events().publish(topics, (guardian,));
+}
+
+// ── Emergency Pause Helpers ────────────────────────────────────────
+
+fn get_guardians(e: &Env) -> Vec<Address> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::Guardians)
+        .unwrap_or(Vec::new(e))
+}
+
+fn is_guardian_internal(e: &Env, addr: &Address) -> bool {
+    get_guardians(e).iter().any(|g| g == *addr)
+}
+
+/// Evaluate whether `domain` is currently paused, lazily treating an expired
+/// (non-indefinite) pause record as inactive without mutating storage.
+fn is_domain_paused(e: &Env, domain: &PauseDomain) -> bool {
+    match e
+        .storage()
+        .persistent()
+        .get::<_, PauseState>(&DataKey::PauseState(domain.clone()))
+    {
+        None => false,
+        Some(state) => state.expires_at == 0 || e.ledger().timestamp() < state.expires_at,
+    }
+}
+
+fn require_not_paused(e: &Env, domain: PauseDomain) {
+    if is_domain_paused(e, &domain) {
+        panic_with_error!(e, ContractError::DomainPaused);
+    }
+}
+
 const DEFAULT_GRACE_PERIOD: u64 = 604_800; // 7 days in seconds
 const MAX_MIN_DELAY: u64 = 2_592_000; // 30 days in seconds
+const MAX_GUARDIAN_PAUSE_SECS: u64 = 604_800; // 7 days — bounds guardian blast radius
+const MAX_ADMIN_PAUSE_SECS: u64 = 2_592_000; // 30 days; 0 (indefinite) is also allowed for admin
+const MAX_GUARDIANS: u32 = 10; // bounds unbounded storage growth
 
 // ── Validation ──────────────────────────────────────────────────────
 fn validate_name(name: &String) -> bool {
@@ -185,7 +287,7 @@ fn validate_name(name: &String) -> bool {
 /// This constant is embedded in the WASM binary at compile time and is
 /// therefore immutable once deployed; it cannot be altered by any admin
 /// call, storage write, or cross-contract invocation.
-pub const CONTRACT_VERSION: (u32, u32, u32) = (1, 1, 0);
+pub const CONTRACT_VERSION: (u32, u32, u32) = (1, 2, 0);
 
 #[contract]
 pub struct TalosNameService;
@@ -217,6 +319,8 @@ impl TalosNameService {
     /// * `talos_id` - The Talos ID to associate with the name
     /// * `name` - Human-readable name (3-32 chars, lowercase alphanumeric + hyphens)
     pub fn register_name(e: Env, owner: Address, talos_id: u32, name: String) {
+        require_not_paused(&e, PauseDomain::NameRegistration);
+
         owner.require_auth();
 
         if !validate_name(&name) {
@@ -488,6 +592,193 @@ impl TalosNameService {
             .get(&DataKey::TimelockProposal(proposal_id))
     }
 
+    // ── Emergency Pause Controls ──────────────────────────────────────
+
+    /// Pause a single write-path domain, blocking it while leaving all
+    /// reads fully functional. See `TalosRegistry::pause` for full semantics
+    /// (duration rules, idempotency, admin-lock protection) — identical here.
+    ///
+    /// # Panics
+    /// - `Admin not configured` — if `set_admin` has not been called.
+    /// - `ContractError::NotAdminOrGuardian` — unauthorized caller.
+    /// - `ContractError::DomainLockedByAdmin` — a guardian attempted to
+    ///   overwrite an admin-established pause.
+    /// - `ContractError::InvalidPauseDuration` — duration out of bounds.
+    pub fn pause(e: Env, caller: Address, domain: PauseDomain, duration: u64) {
+        caller.require_auth();
+
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin not configured");
+
+        let is_admin_caller = caller == admin;
+        if !is_admin_caller && !is_guardian_internal(&e, &caller) {
+            panic_with_error!(&e, ContractError::NotAdminOrGuardian);
+        }
+
+        let key = DataKey::PauseState(domain.clone());
+
+        if !is_admin_caller {
+            if let Some(existing) = e.storage().persistent().get::<_, PauseState>(&key) {
+                if existing.paused_by == admin {
+                    panic_with_error!(&e, ContractError::DomainLockedByAdmin);
+                }
+            }
+        }
+
+        let now = e.ledger().timestamp();
+        let expires_at = if is_admin_caller {
+            if duration == 0 {
+                0
+            } else {
+                if duration > MAX_ADMIN_PAUSE_SECS {
+                    panic_with_error!(&e, ContractError::InvalidPauseDuration);
+                }
+                now.saturating_add(duration)
+            }
+        } else {
+            if duration == 0 || duration > MAX_GUARDIAN_PAUSE_SECS {
+                panic_with_error!(&e, ContractError::InvalidPauseDuration);
+            }
+            now.saturating_add(duration)
+        };
+
+        e.storage().persistent().set(
+            &key,
+            &PauseState {
+                paused_by: caller.clone(),
+                paused_at: now,
+                expires_at,
+            },
+        );
+
+        emit_pause_set(&e, &domain, &caller, expires_at);
+    }
+
+    /// Lift an active pause on `domain`. Idempotent no-op if not paused.
+    ///
+    /// # Authorization
+    /// Only the current admin may unpause, regardless of who set the pause.
+    pub fn unpause(e: Env, domain: PauseDomain) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin not configured");
+        admin.require_auth();
+
+        let key = DataKey::PauseState(domain.clone());
+        if e.storage().persistent().get::<_, PauseState>(&key).is_none() {
+            return;
+        }
+
+        e.storage().persistent().remove(&key);
+        emit_pause_cleared(&e, &domain, &admin);
+    }
+
+    /// Returns `true` if `domain` is currently paused (and not yet expired).
+    pub fn is_paused(e: Env, domain: PauseDomain) -> bool {
+        is_domain_paused(&e, &domain)
+    }
+
+    /// Full observability view of a domain's pause status.
+    pub fn pause_info(e: Env, domain: PauseDomain) -> PauseInfo {
+        match e
+            .storage()
+            .persistent()
+            .get::<_, PauseState>(&DataKey::PauseState(domain.clone()))
+        {
+            None => PauseInfo {
+                active: false,
+                paused_by: None,
+                paused_at: None,
+                expires_at: None,
+            },
+            Some(state) => {
+                let active = state.expires_at == 0 || e.ledger().timestamp() < state.expires_at;
+                PauseInfo {
+                    active,
+                    paused_by: Some(state.paused_by),
+                    paused_at: Some(state.paused_at),
+                    expires_at: if state.expires_at == 0 {
+                        None
+                    } else {
+                        Some(state.expires_at)
+                    },
+                }
+            }
+        }
+    }
+
+    /// Register a guardian address authorized to trigger (but never lift)
+    /// bounded-duration pauses. Idempotent; bounded to `MAX_GUARDIANS`.
+    ///
+    /// # Authorization
+    /// Requires current admin authorization.
+    pub fn add_guardian(e: Env, guardian: Address) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin not configured");
+        admin.require_auth();
+
+        let mut guardians = get_guardians(&e);
+        if guardians.iter().any(|g| g == guardian) {
+            return;
+        }
+        if guardians.len() >= MAX_GUARDIANS {
+            panic_with_error!(&e, ContractError::GuardianLimitReached);
+        }
+
+        guardians.push_back(guardian.clone());
+        e.storage().persistent().set(&DataKey::Guardians, &guardians);
+        emit_guardian_added(&e, guardian);
+    }
+
+    /// Revoke a guardian's pause authority. Idempotent.
+    ///
+    /// # Authorization
+    /// Requires current admin authorization.
+    pub fn remove_guardian(e: Env, guardian: Address) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Admin not configured");
+        admin.require_auth();
+
+        let guardians = get_guardians(&e);
+        let mut remaining = Vec::new(&e);
+        let mut found = false;
+        for g in guardians.iter() {
+            if g == guardian {
+                found = true;
+                continue;
+            }
+            remaining.push_back(g);
+        }
+
+        if !found {
+            return;
+        }
+
+        e.storage().persistent().set(&DataKey::Guardians, &remaining);
+        emit_guardian_removed(&e, guardian);
+    }
+
+    /// Check whether `addr` currently holds guardian pause authority.
+    pub fn is_guardian(e: Env, addr: Address) -> bool {
+        is_guardian_internal(&e, &addr)
+    }
+
+    /// List all currently registered guardians (bounded to `MAX_GUARDIANS`).
+    pub fn list_guardians(e: Env) -> Vec<Address> {
+        get_guardians(&e)
+    }
+
     /// Resolve a name to a Talos ID.
     /// Returns None if the name doesn't exist.
     pub fn resolve_name(e: Env, name: String) -> Option<u32> {
@@ -660,7 +951,7 @@ mod tests {
     #[test]
     fn version_returns_compile_time_constant() {
         let (_env, _registry_contract, _contract_id, _registry_client, client) = setup();
-        assert_eq!(client.version(), (1u32, 1u32, 0u32));
+        assert_eq!(client.version(), (1u32, 2u32, 0u32));
     }
 
     #[test]
@@ -1161,5 +1452,413 @@ mod tests {
         let prop = client.get_timelock_proposal(&proposal_id).unwrap();
         assert_eq!(prop.status, ProposalStatus::Cancelled);
         assert!(client.try_execute_action(&proposal_id).is_err());
+    }
+
+    // ── Emergency Pause: helpers ───────────────────────────────────────
+
+    fn mock_pause(
+        env: &Env,
+        client: &TalosNameServiceClient,
+        contract_id: &Address,
+        caller: &Address,
+        domain: &PauseDomain,
+        duration: u64,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: caller,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "pause",
+                    args: (caller.clone(), domain.clone(), duration).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .pause(caller, domain, &duration);
+    }
+
+    /// Returns `true` if the mocked `pause` call succeeded, `false` if it errored.
+    fn try_mock_pause(
+        env: &Env,
+        client: &TalosNameServiceClient,
+        contract_id: &Address,
+        caller: &Address,
+        domain: &PauseDomain,
+        duration: u64,
+    ) -> bool {
+        client
+            .mock_auths(&[MockAuth {
+                address: caller,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "pause",
+                    args: (caller.clone(), domain.clone(), duration).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_pause(caller, domain, &duration)
+            .is_ok()
+    }
+
+    fn mock_unpause(
+        env: &Env,
+        client: &TalosNameServiceClient,
+        contract_id: &Address,
+        admin: &Address,
+        domain: &PauseDomain,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "unpause",
+                    args: (domain.clone(),).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .unpause(domain);
+    }
+
+    fn mock_add_guardian(
+        env: &Env,
+        client: &TalosNameServiceClient,
+        contract_id: &Address,
+        admin: &Address,
+        guardian: &Address,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "add_guardian",
+                    args: (guardian.clone(),).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .add_guardian(guardian);
+    }
+
+    #[test]
+    fn paused_name_registration_blocks_register_name_but_not_reads() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "marketbot");
+        client.set_admin(&admin);
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::NameRegistration,
+            0,
+        );
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &owner,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "register_name",
+                    args: (owner.clone(), talos_id, name.clone()).into_val(&env),
+                    sub_invokes: &[MockAuthInvoke {
+                        contract: &registry_contract,
+                        fn_name: "creator_of",
+                        args: (talos_id,).into_val(&env),
+                        sub_invokes: &[],
+                    }],
+                },
+            }])
+            .try_register_name(&owner, &talos_id, &name);
+        assert!(result.is_err());
+
+        // Reads are unaffected.
+        assert!(client.is_name_available(&name));
+        assert!(!client.has_name(&talos_id));
+
+        mock_unpause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::NameRegistration,
+        );
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+        assert!(!client.is_name_available(&name));
+    }
+
+    #[test]
+    fn guardian_can_pause_within_bounds_but_cannot_unpause() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.set_admin(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            3600,
+        );
+        assert!(client.is_paused(&PauseDomain::NameRegistration));
+
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &guardian,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "unpause",
+                    args: (PauseDomain::NameRegistration,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_unpause(&PauseDomain::NameRegistration);
+        assert!(res.is_err());
+
+        mock_unpause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::NameRegistration,
+        );
+        assert!(!client.is_paused(&PauseDomain::NameRegistration));
+    }
+
+    #[test]
+    fn guardian_pause_duration_must_be_bounded() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.set_admin(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        assert!(!try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            0,
+        ));
+        assert!(!try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            MAX_GUARDIAN_PAUSE_SECS + 1,
+        ));
+        assert!(try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            3600,
+        ));
+    }
+
+    #[test]
+    fn guardian_cannot_override_admin_lock_on_name_service() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.set_admin(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::NameRegistration,
+            0,
+        );
+
+        assert!(!try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            3600,
+        ));
+    }
+
+    #[test]
+    fn non_admin_non_guardian_cannot_pause_name_service() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.set_admin(&admin);
+
+        assert!(!try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &stranger,
+            &PauseDomain::NameRegistration,
+            3600,
+        ));
+    }
+
+    #[test]
+    fn name_service_pause_auto_expires() {
+        let (env, registry_contract, contract_id, registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let protocol_wallet = Address::generate(&env);
+        let name = s(&env, "vega");
+        client.set_admin(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        let talos_id = create_talos_with_auth(
+            &env,
+            &registry_client,
+            &registry_contract,
+            &owner,
+            &protocol_wallet,
+        );
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::NameRegistration,
+            3600,
+        );
+        assert!(client.is_paused(&PauseDomain::NameRegistration));
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += 3601;
+        });
+        assert!(!client.is_paused(&PauseDomain::NameRegistration));
+
+        register_name_with_auth(
+            &env,
+            &client,
+            &contract_id,
+            &registry_contract,
+            &owner,
+            talos_id,
+            &name,
+        );
+        assert!(!client.is_name_available(&name));
+    }
+
+    #[test]
+    fn unpause_without_active_pause_is_a_deterministic_noop() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        client.set_admin(&admin);
+
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration);
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration, 0);
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration);
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration);
+        assert!(!client.is_paused(&PauseDomain::NameRegistration));
+    }
+
+    #[test]
+    fn add_and_remove_guardian_are_idempotent_and_admin_only() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.set_admin(&admin);
+
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &stranger,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "add_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_add_guardian(&guardian);
+        assert!(res.is_err());
+
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+        assert!(client.is_guardian(&guardian));
+        assert_eq!(client.list_guardians().len(), 1);
+
+        client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .remove_guardian(&guardian);
+        client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .remove_guardian(&guardian);
+        assert!(!client.is_guardian(&guardian));
+    }
+
+    #[test]
+    fn pause_and_unpause_emit_events_on_name_service() {
+        let (env, _registry_contract, contract_id, _registry_client, client) = setup();
+        let admin = Address::generate(&env);
+        client.set_admin(&admin);
+
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration, 0);
+        let all_events = env.events().all();
+        let events: std::vec::Vec<_> = all_events.iter().filter(|e| e.0 == contract_id).collect();
+        let (_, topics, data) = events.last().unwrap().clone();
+        let sym: Symbol = TryFromVal::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        assert_eq!(sym, symbol_short!("pause_on"));
+        let (actor, expires_at): (Address, u64) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(actor, admin);
+        assert_eq!(expires_at, 0);
+
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::NameRegistration);
+        let all_events = env.events().all();
+        let events: std::vec::Vec<_> = all_events.iter().filter(|e| e.0 == contract_id).collect();
+        let (_, topics, data) = events.last().unwrap().clone();
+        let sym: Symbol = TryFromVal::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        assert_eq!(sym, symbol_short!("pause_off"));
+        let (actor,): (Address,) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(actor, admin);
     }
 }

--- a/contracts/talos_registry/src/lib.rs
+++ b/contracts/talos_registry/src/lib.rs
@@ -11,7 +11,9 @@
 #[cfg(all(test, not(target_arch = "wasm32")))]
 extern crate std;
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+};
 
 // ── Data Types ──────────────────────────────────────────────────────
 
@@ -90,6 +92,46 @@ pub struct TimelockConfig {
     pub grace_period: u64,
 }
 
+/// A narrowly-scoped write path that can be independently paused.
+///
+/// Reads are never gated by any pause domain — `get_talos`, `is_active`,
+/// `next_talos_id`, etc. always reflect current state regardless of pause
+/// status. Administrative entry-points (`set_protocol_fee`, admin transfer,
+/// timelock management) are intentionally **not** pausable: they already
+/// carry their own admin-auth (and optional timelock) protection, and
+/// making them pausable would risk an admin permanently locking itself out.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PauseDomain {
+    TalosCreation,
+    PatronUpdates,
+    KernelUpdates,
+    PulseUpdates,
+    Deactivation,
+}
+
+/// Persisted record of an active pause on a single [`PauseDomain`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseState {
+    pub paused_by: Address,
+    pub paused_at: u64,
+    /// Unix timestamp after which the pause automatically lifts.
+    /// `0` means indefinite — only settable by the admin, never by a guardian.
+    pub expires_at: u64,
+}
+
+/// Computed, read-friendly view of a domain's pause status.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseInfo {
+    pub active: bool,
+    pub paused_by: Option<Address>,
+    pub paused_at: Option<u64>,
+    /// `None` when not paused, or when paused indefinitely by the admin.
+    pub expires_at: Option<u64>,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -104,6 +146,10 @@ pub enum DataKey {
     TimelockConfig,
     TimelockProposal(u64),
     NextTimelockId,
+    /// Active pause record for a domain, if any. Absence means unpaused.
+    PauseState(PauseDomain),
+    /// Bounded list of guardian addresses authorized to trigger (but not lift) pauses.
+    Guardians,
 }
 
 // ── Events ──────────────────────────────────────────────────────────
@@ -119,6 +165,10 @@ pub enum DataKey {
 //   tl_exec : (symbol, proposal_id: u64)   → (action: AdminAction, executor: Address)
 //   tl_cnl  : (symbol, proposal_id: u64)   → (action: AdminAction, canceller: Address)
 //   tl_cfg  : (symbol,)                    → (old_min_delay: u64, new_min_delay: u64, grace_period: u64)
+//   pause_on  : (symbol, domain: PauseDomain) → (actor: Address, expires_at: u64)
+//   pause_off : (symbol, domain: PauseDomain) → (actor: Address,)
+//   guard_add : (symbol,)                     → (guardian: Address,)
+//   guard_rem : (symbol,)                     → (guardian: Address,)
 
 fn emit_talos_created(env: &Env, talos_id: u32, creator: Address, name: String, category: String) {
     let topics = (symbol_short!("tls_crt"), creator);
@@ -205,6 +255,28 @@ fn emit_timelock_config_changed(
         .publish(topics, (old_min_delay, new_min_delay, grace_period));
 }
 
+/// Emitted when a domain is paused (or an existing pause is refreshed/extended).
+fn emit_pause_set(env: &Env, domain: &PauseDomain, actor: &Address, expires_at: u64) {
+    let topics = (symbol_short!("pause_on"), domain.clone());
+    env.events().publish(topics, (actor.clone(), expires_at));
+}
+
+/// Emitted when an admin lifts an active pause on a domain.
+fn emit_pause_cleared(env: &Env, domain: &PauseDomain, actor: &Address) {
+    let topics = (symbol_short!("pause_off"), domain.clone());
+    env.events().publish(topics, (actor.clone(),));
+}
+
+fn emit_guardian_added(env: &Env, guardian: Address) {
+    let topics = (symbol_short!("guard_add"),);
+    env.events().publish(topics, (guardian,));
+}
+
+fn emit_guardian_removed(env: &Env, guardian: Address) {
+    let topics = (symbol_short!("guard_rem"),);
+    env.events().publish(topics, (guardian,));
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 fn validate_patron_shares(patron: &Patron) {
@@ -214,12 +286,47 @@ fn validate_patron_shares(patron: &Patron) {
     }
 }
 
+// ── Emergency Pause Helpers ────────────────────────────────────────
+
+fn get_guardians(e: &Env) -> Vec<Address> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::Guardians)
+        .unwrap_or(Vec::new(e))
+}
+
+fn is_guardian_internal(e: &Env, addr: &Address) -> bool {
+    get_guardians(e).iter().any(|g| g == *addr)
+}
+
+/// Evaluate whether `domain` is currently paused, lazily treating an expired
+/// (non-indefinite) pause record as inactive without mutating storage.
+fn is_domain_paused(e: &Env, domain: &PauseDomain) -> bool {
+    match e
+        .storage()
+        .persistent()
+        .get::<_, PauseState>(&DataKey::PauseState(domain.clone()))
+    {
+        None => false,
+        Some(state) => state.expires_at == 0 || e.ledger().timestamp() < state.expires_at,
+    }
+}
+
+fn require_not_paused(e: &Env, domain: PauseDomain) {
+    if is_domain_paused(e, &domain) {
+        panic!("Write path paused");
+    }
+}
+
 // ── Constants ───────────────────────────────────────────────────────
 
 const PROTOCOL_FEE_BPS: u32 = 300; // 3%
 const MAX_PROTOCOL_FEE_BPS: u32 = 10_000; // 100%
 const DEFAULT_GRACE_PERIOD: u64 = 604_800; // 7 days in seconds
 const MAX_MIN_DELAY: u64 = 2_592_000; // 30 days in seconds
+const MAX_GUARDIAN_PAUSE_SECS: u64 = 604_800; // 7 days — bounds guardian blast radius
+const MAX_ADMIN_PAUSE_SECS: u64 = 2_592_000; // 30 days; 0 (indefinite) is also allowed for admin
+const MAX_GUARDIANS: u32 = 10; // bounds unbounded storage growth
 
 /// Compile-time interface version of TalosRegistry.
 ///
@@ -233,7 +340,7 @@ const MAX_MIN_DELAY: u64 = 2_592_000; // 30 days in seconds
 /// This constant is embedded in the WASM binary at compile time and is
 /// therefore immutable once deployed; it cannot be altered by any admin
 /// call, storage write, or cross-contract invocation.
-pub const CONTRACT_VERSION: (u32, u32, u32) = (1, 1, 0);
+pub const CONTRACT_VERSION: (u32, u32, u32) = (1, 2, 0);
 
 // ── Contract ────────────────────────────────────────────────────────
 
@@ -265,6 +372,8 @@ impl TalosRegistry {
         pulse: Pulse,
         protocol_wallet: Address,
     ) -> u32 {
+        require_not_paused(&e, PauseDomain::TalosCreation);
+
         // Require creator authorization
         patron.creator_addr.require_auth();
 
@@ -360,6 +469,8 @@ impl TalosRegistry {
 
     /// Update patron shares for a Talos.
     pub fn update_patron(e: Env, talos_id: u32, patron: Patron) {
+        require_not_paused(&e, PauseDomain::PatronUpdates);
+
         let mut talos: Talos = e
             .storage()
             .persistent()
@@ -382,6 +493,8 @@ impl TalosRegistry {
 
     /// Update kernel policy for a Talos.
     pub fn update_kernel(e: Env, talos_id: u32, kernel: Kernel) {
+        require_not_paused(&e, PauseDomain::KernelUpdates);
+
         let mut talos: Talos = e
             .storage()
             .persistent()
@@ -399,6 +512,8 @@ impl TalosRegistry {
 
     /// Update pulse token config for a Talos.
     pub fn update_pulse(e: Env, talos_id: u32, pulse: Pulse) {
+        require_not_paused(&e, PauseDomain::PulseUpdates);
+
         let mut talos: Talos = e
             .storage()
             .persistent()
@@ -416,6 +531,8 @@ impl TalosRegistry {
 
     /// Deactivate a Talos.
     pub fn deactivate_talos(e: Env, talos_id: u32) {
+        require_not_paused(&e, PauseDomain::Deactivation);
+
         let mut talos: Talos = e
             .storage()
             .persistent()
@@ -787,6 +904,227 @@ impl TalosRegistry {
         e.storage().persistent().get(&DataKey::PendingAdmin)
     }
 
+    // ── Emergency Pause Controls ──────────────────────────────────────
+
+    /// Pause a single write-path domain, blocking it while leaving all
+    /// reads and every other domain fully functional.
+    ///
+    /// # Authorization
+    /// `caller` must be either the current admin (`ProtocolWallet`) or a
+    /// registered guardian, and must sign the transaction.
+    ///
+    /// # Duration semantics
+    /// - Admin: `duration = 0` pauses indefinitely (only the admin can lift
+    ///   it later via `unpause`). A non-zero `duration` must not exceed
+    ///   [`MAX_ADMIN_PAUSE_SECS`].
+    /// - Guardian: `duration` must be non-zero and at most
+    ///   [`MAX_GUARDIAN_PAUSE_SECS`] — guardians can never impose an
+    ///   indefinite pause, bounding the damage a compromised guardian key
+    ///   can do.
+    ///
+    /// Calling `pause` again on an already-paused domain refreshes
+    /// (overwrites) the existing record — this is intentionally idempotent
+    /// so a retried or duplicated transaction is safe. The one exception:
+    /// a guardian may never overwrite a pause that the admin established
+    /// (see `Panics`), preventing a guardian from weakening an admin lock.
+    ///
+    /// # Panics
+    /// - `"Contract not initialized"` — if `initialize` has not been called.
+    /// - `"Caller is not admin or guardian"` — unauthorized caller.
+    /// - `"Domain locked by admin; guardians cannot modify"` — a guardian
+    ///   attempted to overwrite an admin-established pause.
+    /// - `"Duration exceeds admin maximum"` / `"Guardian pause duration out of bounds"`.
+    pub fn pause(e: Env, caller: Address, domain: PauseDomain, duration: u64) {
+        caller.require_auth();
+
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+
+        let is_admin_caller = caller == admin;
+        if !is_admin_caller && !is_guardian_internal(&e, &caller) {
+            panic!("Caller is not admin or guardian");
+        }
+
+        let key = DataKey::PauseState(domain.clone());
+
+        if !is_admin_caller {
+            if let Some(existing) = e.storage().persistent().get::<_, PauseState>(&key) {
+                if existing.paused_by == admin {
+                    panic!("Domain locked by admin; guardians cannot modify");
+                }
+            }
+        }
+
+        let now = e.ledger().timestamp();
+        let expires_at = if is_admin_caller {
+            if duration == 0 {
+                0
+            } else {
+                if duration > MAX_ADMIN_PAUSE_SECS {
+                    panic!("Duration exceeds admin maximum");
+                }
+                now.saturating_add(duration)
+            }
+        } else {
+            if duration == 0 || duration > MAX_GUARDIAN_PAUSE_SECS {
+                panic!("Guardian pause duration out of bounds");
+            }
+            now.saturating_add(duration)
+        };
+
+        e.storage().persistent().set(
+            &key,
+            &PauseState {
+                paused_by: caller.clone(),
+                paused_at: now,
+                expires_at,
+            },
+        );
+
+        emit_pause_set(&e, &domain, &caller, expires_at);
+    }
+
+    /// Lift an active pause on `domain`.
+    ///
+    /// Idempotent: if the domain has no active pause record (never paused,
+    /// already lifted, or already expired), this is a deterministic no-op —
+    /// it does not panic, so duplicate or retried `unpause` calls are safe.
+    ///
+    /// # Authorization
+    /// Only the current admin (`ProtocolWallet`) may unpause, regardless of
+    /// whether the pause was originally set by the admin or a guardian.
+    ///
+    /// # Panics
+    /// - `"Contract not initialized"` — if `initialize` has not been called.
+    pub fn unpause(e: Env, domain: PauseDomain) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+        admin.require_auth();
+
+        let key = DataKey::PauseState(domain.clone());
+        if e.storage().persistent().get::<_, PauseState>(&key).is_none() {
+            return;
+        }
+
+        e.storage().persistent().remove(&key);
+        emit_pause_cleared(&e, &domain, &admin);
+    }
+
+    /// Returns `true` if `domain` is currently paused (and its pause has not
+    /// yet expired). Never requires authorization — this is a read.
+    pub fn is_paused(e: Env, domain: PauseDomain) -> bool {
+        is_domain_paused(&e, &domain)
+    }
+
+    /// Full observability view of a domain's pause status: who paused it,
+    /// when, and when it expires (or `None` for indefinite/unpaused).
+    pub fn pause_info(e: Env, domain: PauseDomain) -> PauseInfo {
+        match e
+            .storage()
+            .persistent()
+            .get::<_, PauseState>(&DataKey::PauseState(domain.clone()))
+        {
+            None => PauseInfo {
+                active: false,
+                paused_by: None,
+                paused_at: None,
+                expires_at: None,
+            },
+            Some(state) => {
+                let active = state.expires_at == 0 || e.ledger().timestamp() < state.expires_at;
+                PauseInfo {
+                    active,
+                    paused_by: Some(state.paused_by),
+                    paused_at: Some(state.paused_at),
+                    expires_at: if state.expires_at == 0 {
+                        None
+                    } else {
+                        Some(state.expires_at)
+                    },
+                }
+            }
+        }
+    }
+
+    /// Register a guardian address authorized to trigger (but never lift)
+    /// bounded-duration pauses. Bounded to [`MAX_GUARDIANS`] entries.
+    ///
+    /// Idempotent: adding an already-registered guardian is a no-op.
+    ///
+    /// # Authorization
+    /// Requires current admin (`ProtocolWallet`) authorization.
+    pub fn add_guardian(e: Env, guardian: Address) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+        admin.require_auth();
+
+        let mut guardians = get_guardians(&e);
+        if guardians.iter().any(|g| g == guardian) {
+            return;
+        }
+        if guardians.len() >= MAX_GUARDIANS {
+            panic!("Guardian limit reached");
+        }
+
+        guardians.push_back(guardian.clone());
+        e.storage().persistent().set(&DataKey::Guardians, &guardians);
+        emit_guardian_added(&e, guardian);
+    }
+
+    /// Revoke a guardian's pause authority.
+    ///
+    /// Idempotent: removing an address that is not a guardian is a no-op.
+    /// Does not affect any pause the guardian already set — use `unpause`
+    /// (admin-only) to lift it explicitly.
+    ///
+    /// # Authorization
+    /// Requires current admin (`ProtocolWallet`) authorization.
+    pub fn remove_guardian(e: Env, guardian: Address) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+        admin.require_auth();
+
+        let guardians = get_guardians(&e);
+        let mut remaining = Vec::new(&e);
+        let mut found = false;
+        for g in guardians.iter() {
+            if g == guardian {
+                found = true;
+                continue;
+            }
+            remaining.push_back(g);
+        }
+
+        if !found {
+            return;
+        }
+
+        e.storage().persistent().set(&DataKey::Guardians, &remaining);
+        emit_guardian_removed(&e, guardian);
+    }
+
+    /// Check whether `addr` currently holds guardian pause authority.
+    pub fn is_guardian(e: Env, addr: Address) -> bool {
+        is_guardian_internal(&e, &addr)
+    }
+
+    /// List all currently registered guardians (bounded to `MAX_GUARDIANS`).
+    pub fn list_guardians(e: Env) -> Vec<Address> {
+        get_guardians(&e)
+    }
+
     /// Return the contract's interface version as `(major, minor, patch)`.
     ///
     /// The value is a compile-time constant baked into the WASM binary.
@@ -916,7 +1254,7 @@ mod tests {
     fn version_returns_compile_time_constant() {
         let (env, contract_id) = setup();
         let client = TalosRegistryClient::new(&env, &contract_id);
-        assert_eq!(client.version(), (1u32, 1u32, 0u32));
+        assert_eq!(client.version(), (1u32, 2u32, 0u32));
     }
 
     #[test]
@@ -2060,5 +2398,636 @@ mod tests {
             }])
             .try_propose_admin(&new_admin);
         assert!(res_prop.is_err());
+    }
+
+    // ── Emergency Pause: helpers ───────────────────────────────────────
+
+    fn mock_pause(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        caller: &Address,
+        domain: &PauseDomain,
+        duration: u64,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: caller,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "pause",
+                    args: (caller.clone(), domain.clone(), duration).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .pause(caller, domain, &duration);
+    }
+
+    /// Returns `true` if the mocked `pause` call succeeded, `false` if it errored.
+    fn try_mock_pause(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        caller: &Address,
+        domain: &PauseDomain,
+        duration: u64,
+    ) -> bool {
+        client
+            .mock_auths(&[MockAuth {
+                address: caller,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "pause",
+                    args: (caller.clone(), domain.clone(), duration).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_pause(caller, domain, &duration)
+            .is_ok()
+    }
+
+    fn mock_unpause(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        admin: &Address,
+        domain: &PauseDomain,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "unpause",
+                    args: (domain.clone(),).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .unpause(domain);
+    }
+
+    fn mock_add_guardian(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        admin: &Address,
+        guardian: &Address,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "add_guardian",
+                    args: (guardian.clone(),).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .add_guardian(guardian);
+    }
+
+    // ── Emergency Pause: scoping ────────────────────────────────────────
+
+    #[test]
+    fn pause_blocks_only_the_targeted_domain() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        client.initialize(&admin);
+
+        let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &admin);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::TalosCreation,
+            0,
+        );
+
+        // Talos creation is blocked...
+        let ok = try_mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+        assert!(ok); // re-pausing (refresh) is allowed
+        assert!(client.is_paused(&PauseDomain::TalosCreation));
+        assert!(client
+            .mock_auths(&[MockAuth {
+                address: &creator,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "create_talos",
+                    args: (
+                        s(&env, "Second"),
+                        s(&env, "Marketing"),
+                        s(&env, "desc"),
+                        patron(&env, &creator),
+                        kernel(),
+                        pulse(&env),
+                        admin.clone(),
+                    )
+                        .into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_create_talos(
+                &s(&env, "Second"),
+                &s(&env, "Marketing"),
+                &s(&env, "desc"),
+                &patron(&env, &creator),
+                &kernel(),
+                &pulse(&env),
+                &admin,
+            )
+            .is_err());
+
+        // ...but every other write path and all reads remain functional.
+        assert!(!client.is_paused(&PauseDomain::PatronUpdates));
+        let updated_patron = Patron {
+            creator_share: 50,
+            investor_share: 30,
+            treasury_share: 20,
+            creator_addr: creator.clone(),
+            investor_addr: Address::generate(&env),
+            treasury_addr: Address::generate(&env),
+        };
+        client
+            .mock_auths(&[MockAuth {
+                address: &creator,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "update_patron",
+                    args: (id, updated_patron.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .update_patron(&id, &updated_patron);
+
+        assert!(client.get_talos(&id).is_some());
+        assert!(client.is_active(&id));
+    }
+
+    #[test]
+    fn reads_are_never_gated_by_pause() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        client.initialize(&admin);
+        let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &admin);
+
+        for domain in [
+            PauseDomain::TalosCreation,
+            PauseDomain::PatronUpdates,
+            PauseDomain::KernelUpdates,
+            PauseDomain::PulseUpdates,
+            PauseDomain::Deactivation,
+        ] {
+            mock_pause(&env, &client, &contract_id, &admin, &domain, 0);
+        }
+
+        assert!(client.get_talos(&id).is_some());
+        assert!(client.is_active(&id));
+        assert_eq!(client.creator_of(&id), Some(creator));
+        assert_eq!(client.next_talos_id(), 2);
+    }
+
+    // ── Emergency Pause: roles & duration bounds ────────────────────────
+
+    #[test]
+    fn admin_can_pause_indefinitely_with_zero_duration() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+
+        let info = client.pause_info(&PauseDomain::TalosCreation);
+        assert!(info.active);
+        assert_eq!(info.expires_at, None);
+        assert_eq!(info.paused_by, Some(admin));
+    }
+
+    #[test]
+    fn admin_pause_duration_exceeding_max_is_rejected() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let ok = try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &admin,
+            &PauseDomain::TalosCreation,
+            MAX_ADMIN_PAUSE_SECS + 1,
+        );
+        assert!(!ok);
+    }
+
+    #[test]
+    fn guardian_can_pause_within_bounded_duration() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+
+        let info = client.pause_info(&PauseDomain::TalosCreation);
+        assert!(info.active);
+        assert_eq!(info.paused_by, Some(guardian));
+        assert!(info.expires_at.is_some());
+    }
+
+    #[test]
+    fn guardian_pause_with_zero_duration_is_rejected() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        // duration = 0 would mean "indefinite" — guardians may never set that.
+        let ok = try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            0,
+        );
+        assert!(!ok);
+    }
+
+    #[test]
+    fn guardian_pause_exceeding_max_duration_is_rejected() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        let ok = try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            MAX_GUARDIAN_PAUSE_SECS + 1,
+        );
+        assert!(!ok);
+    }
+
+    #[test]
+    fn non_admin_non_guardian_cannot_pause() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.initialize(&admin);
+
+        let ok = try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &stranger,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+        assert!(!ok);
+    }
+
+    #[test]
+    fn pause_requires_caller_auth() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // No mock_auths supplied → auth check must fail.
+        let res = client.try_pause(&admin, &PauseDomain::TalosCreation, &0);
+        assert!(res.is_err());
+    }
+
+    // ── Emergency Pause: guardian containment ───────────────────────────
+
+    #[test]
+    fn guardian_cannot_override_admin_established_pause() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+
+        let ok = try_mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+        assert!(!ok);
+
+        // The admin's indefinite pause is untouched.
+        let info = client.pause_info(&PauseDomain::TalosCreation);
+        assert_eq!(info.paused_by, Some(admin));
+        assert_eq!(info.expires_at, None);
+    }
+
+    #[test]
+    fn admin_can_override_guardian_pause() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+
+        let info = client.pause_info(&PauseDomain::TalosCreation);
+        assert_eq!(info.paused_by, Some(admin));
+        assert_eq!(info.expires_at, None);
+    }
+
+    #[test]
+    fn only_admin_can_unpause_a_guardian_set_pause() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+
+        // Guardian cannot unpause its own pause.
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &guardian,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "unpause",
+                    args: (PauseDomain::TalosCreation,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_unpause(&PauseDomain::TalosCreation);
+        assert!(res.is_err());
+
+        // Admin can.
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation);
+        assert!(!client.is_paused(&PauseDomain::TalosCreation));
+    }
+
+    // ── Emergency Pause: expiration & idempotency ───────────────────────
+
+    #[test]
+    fn guardian_pause_auto_expires() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        let creator = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        mock_pause(
+            &env,
+            &client,
+            &contract_id,
+            &guardian,
+            &PauseDomain::TalosCreation,
+            3600,
+        );
+        assert!(client.is_paused(&PauseDomain::TalosCreation));
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += 3601;
+        });
+
+        assert!(!client.is_paused(&PauseDomain::TalosCreation));
+
+        // The domain is writable again without any explicit unpause call.
+        create_talos_with_auth(&env, &client, &contract_id, &creator, &admin);
+    }
+
+    #[test]
+    fn unpause_on_a_domain_with_no_active_pause_is_a_deterministic_noop() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Never paused — must not panic.
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation);
+
+        // Pause, unpause, then unpause again (duplicate/retried call) — still must not panic.
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation);
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation);
+
+        assert!(!client.is_paused(&PauseDomain::TalosCreation));
+    }
+
+    // ── Emergency Pause: guardian roster management ─────────────────────
+
+    #[test]
+    fn add_guardian_is_idempotent_and_admin_only() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.initialize(&admin);
+
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &stranger,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "add_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_add_guardian(&guardian);
+        assert!(res.is_err());
+
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+        assert!(client.is_guardian(&guardian));
+        assert_eq!(client.list_guardians().len(), 1);
+
+        // Re-adding is a no-op, not an error, and does not duplicate the entry.
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+        assert_eq!(client.list_guardians().len(), 1);
+    }
+
+    #[test]
+    fn remove_guardian_is_idempotent_and_admin_only() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &guardian,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_remove_guardian(&guardian);
+        assert!(res.is_err());
+
+        client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .remove_guardian(&guardian);
+        assert!(!client.is_guardian(&guardian));
+
+        // Removing again is a deterministic no-op.
+        client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .remove_guardian(&guardian);
+    }
+
+    #[test]
+    fn guardian_roster_is_bounded() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        for _ in 0..MAX_GUARDIANS {
+            let g = Address::generate(&env);
+            mock_add_guardian(&env, &client, &contract_id, &admin, &g);
+        }
+
+        let one_too_many = Address::generate(&env);
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "add_guardian",
+                    args: (one_too_many.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_add_guardian(&one_too_many);
+        assert!(res.is_err());
+        assert_eq!(client.list_guardians().len(), MAX_GUARDIANS);
+    }
+
+    // ── Emergency Pause: events ──────────────────────────────────────────
+
+    #[test]
+    fn pause_and_unpause_emit_events() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        mock_pause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation, 0);
+        let events = env.events().all();
+        let (_, topics, data) = events.get(events.len() - 1).unwrap();
+        assert_topic_symbol(&env, &topics, 0, symbol_short!("pause_on"));
+        let (actor, expires_at): (Address, u64) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(actor, admin);
+        assert_eq!(expires_at, 0);
+
+        mock_unpause(&env, &client, &contract_id, &admin, &PauseDomain::TalosCreation);
+        let events = env.events().all();
+        let (_, topics, data) = events.get(events.len() - 1).unwrap();
+        assert_topic_symbol(&env, &topics, 0, symbol_short!("pause_off"));
+        let (actor,): (Address,) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(actor, admin);
+    }
+
+    #[test]
+    fn guardian_management_emits_events() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let guardian = Address::generate(&env);
+        client.initialize(&admin);
+
+        mock_add_guardian(&env, &client, &contract_id, &admin, &guardian);
+        let events = env.events().all();
+        let (_, topics, data) = events.get(events.len() - 1).unwrap();
+        assert_topic_symbol(&env, &topics, 0, symbol_short!("guard_add"));
+        let (got,): (Address,) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(got, guardian);
+
+        client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "remove_guardian",
+                    args: (guardian.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .remove_guardian(&guardian);
+        let events = env.events().all();
+        let (_, topics, data) = events.get(events.len() - 1).unwrap();
+        assert_topic_symbol(&env, &topics, 0, symbol_short!("guard_rem"));
+        let (got,): (Address,) = TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(got, guardian);
     }
 }


### PR DESCRIPTION
## Summary

Implements narrowly-scoped emergency pause controls for `TalosRegistry` and `TalosNameService`, as designed in #238: individual write paths (pause *domains*) can be contained without disabling reads or any other domain, and without permanently centralizing control in a single always-on kill switch.

- **Pause domains** — `TalosRegistry`: `TalosCreation`, `PatronUpdates`, `KernelUpdates`, `PulseUpdates`, `Deactivation`. `TalosNameService`: `NameRegistration`. Reads (`get_talos`, `is_active`, `resolve_name`, etc.) and admin/timelock entry-points are never gated, by design — gating the escape hatch itself risks a permanent lockout.
- **Two roles** — admin (any domain, `duration = 0` for an indefinite pause, sole authority to `unpause`) and guardian (bounded ≤ 7-day pauses only, can never set an indefinite pause, can never `unpause`, and can never override an admin-established pause). This bounds the blast radius of a compromised guardian key to a single, temporary, auto-expiring outage.
- **Expiration & unpause** — guardian (and optional bounded admin) pauses auto-expire against ledger time with no storage write required. `pause`/`unpause`/`add_guardian`/`remove_guardian` are idempotent no-ops on duplicate or retried calls instead of panicking.
- **Observability** — new events `pause_on` / `pause_off` / `guard_add` / `guard_rem`, plus read-only `pause_info` / `is_paused` / `list_guardians`.
- **Backward compatible by default** — no domain is paused until `pause` is explicitly called; new storage keys (`PauseState`, `Guardians`) are simply absent on existing deployments, so no migration is required.
- `CONTRACT_VERSION` bumped `1.1.0 -> 1.2.0` (additive) on both contracts.

Full design rationale, roles table, state model, entry-point/storage tables, an operational runbook (containment, escalation, rollback), and known limitations are documented in `contracts/README.md` under "Emergency Pause Controls".

## Test plan

- [x] `cargo test -p talos-registry` — 57/57 passing (19 new pause/guardian tests covering per-domain scoping, admin vs. guardian authorization and duration bounds, the guardian-cannot-override-admin-lock invariant, admin-can-override-guardian, auto-expiry, idempotent pause/unpause/guardian-management, guardian roster bound, and event emission)
- [x] `cargo test -p talos-name-service` — 28/28 passing (11 new tests covering the same invariants scoped to `register_name`/`NameRegistration`)
- [x] `cargo check --tests` clean on both crates (no new warnings beyond pre-existing ones)
- [ ] `cargo build --target wasm32-unknown-unknown --release` — not run in this environment (local sandbox lacks a working Windows/MSVC or wasm-capable linker for a full release build); relies on CI (`contracts-ci.yml`) for the release WASM build step

Closes #238