### PR TITLE
fix(web): add serialization-failure retries for critical database tra…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,41 @@ cargo test --target wasm32-unknown-unknown
 - For Python, prefer explicit types and validate changes with `uv run pytest`
 - For Rust, keep formatting standard with `cargo fmt` and validate with `cargo test`
 
+## Database Transaction Retry & Serialization Hardening
+
+Critical database state transitions (money, token purchases, patron creation, job state transitions, agent genesis) use `withTransactionRetry` from `web/src/db/db-retry.ts` to automatically recover from PostgreSQL serialization conflicts (`40001`), deadlocks (`40P01`), lock timeouts (`55P03`), and transient connection failures.
+
+### Environment Configuration
+
+- `DB_TRANSACTION_RETRY_ENABLED`: Controls transaction retry behavior (default: `true`). Set to `false` to disable retries instantly.
+- `DB_TRANSACTION_RETRY_MAX_RETRIES`: Maximum number of retry attempts (default: `5`).
+- `DB_TRANSACTION_RETRY_INITIAL_DELAY_MS`: Initial exponential backoff delay in milliseconds (default: `50`).
+- `DB_TRANSACTION_RETRY_MAX_DELAY_MS`: Maximum exponential backoff cap in milliseconds (default: `1000`).
+
+### Operational Signals & Observability
+
+Retries emit structured Pino log events with domain categories (`MONEY`, `TOKEN`, `PATRON`, `JOB`, `GENESIS`):
+
+- `db_transaction_retry_attempt` (`logger.warn`): Logged when a retryable serialization/connection error triggers a retry attempt.
+- `db_transaction_retry_success` (`logger.info`): Logged when a transaction succeeds after prior failed attempts.
+- `db_transaction_retry_exhausted` (`logger.error`): Logged when maximum retry attempts are exceeded.
+
+Sensitive data (keys, passphrases, raw payloads) are excluded from log context.
+
+### Local Verification
+
+To run unit and concurrency contention tests:
+
+```bash
+pnpm --filter web exec vitest run tests/db-retry.unit.test.ts tests/db-retry.contention.test.ts
+```
+
+### Rollback Guidance
+
+If operational issues or database performance degradation occur:
+1. Set `DB_TRANSACTION_RETRY_ENABLED=false` in `web/.env.local` or application environment variables.
+2. Restart the web server. This immediately falls back to single-attempt database transactions without requiring application redeployments or code rollbacks.
+
 ## Pull Request Workflow
 
 1. Create a branch from the latest `main`

--- a/web/src/app/api/commerce/cross-chain-webhook/route.ts
+++ b/web/src/app/api/commerce/cross-chain-webhook/route.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextRequest } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsCommerceJobs, tlsCommerceServices, tlsRevenues, tlsTalos } from "@/db/schema";
 import { fulfillInstant } from "@/lib/fulfillment";
 import { crossChainWebhookSchema } from "@/lib/schemas";
@@ -264,39 +265,42 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const [job] = await db.transaction(async (tx) => {
-      const values = {
-        talosId,
-        requesterTalosId,
-        serviceName: service.serviceName,
-        payload: payload ?? {},
-        result: fulfillmentResult,
-        paymentSig,
-        txHash: sourceTxHash,
-        amount: String(service.price),
-        status: nextStatus,
-      };
-
-      const [savedJob] = existingJob
-        ? await tx
-            .update(tlsCommerceJobs)
-            .set(values)
-            .where(eq(tlsCommerceJobs.id, existingJob.id))
-            .returning()
-        : await tx.insert(tlsCommerceJobs).values(values).returning();
-
-      if (nextStatus === "completed" && existingJob?.status !== "completed") {
-        await tx.insert(tlsRevenues).values({
+    const [job] = await withTransactionRetry(
+      async (tx) => {
+        const values = {
           talosId,
-          amount: String(service.price),
-          currency: service.currency ?? "USDC",
-          source: "commerce",
+          requesterTalosId,
+          serviceName: service.serviceName,
+          payload: payload ?? {},
+          result: fulfillmentResult,
+          paymentSig,
           txHash: sourceTxHash,
-        });
-      }
+          amount: String(service.price),
+          status: nextStatus,
+        };
 
-      return [savedJob];
-    });
+        const [savedJob] = existingJob
+          ? await tx
+              .update(tlsCommerceJobs)
+              .set(values)
+              .where(eq(tlsCommerceJobs.id, existingJob.id))
+              .returning()
+          : await tx.insert(tlsCommerceJobs).values(values).returning();
+
+        if (nextStatus === "completed" && existingJob?.status !== "completed") {
+          await tx.insert(tlsRevenues).values({
+            talosId,
+            amount: String(service.price),
+            currency: service.currency ?? "USDC",
+            source: "commerce",
+            txHash: sourceTxHash,
+          });
+        }
+
+        return [savedJob];
+      },
+      { category: "JOB" }
+    );
 
     return Response.json(
       {

--- a/web/src/app/api/jobs/[id]/result/route.ts
+++ b/web/src/app/api/jobs/[id]/result/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsCommerceJobs, tlsRevenues, tlsCommerceServices } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { logger } from "@/lib/logger";
@@ -73,43 +74,46 @@ export async function POST(
       }, { status: 409 });
     }
 
-    const updated = await db.transaction(async (tx) => {
-      // Use a WHERE with fencing token to prevent stale-worker completion
-      const [updatedJob] = await tx
-        .update(tlsCommerceJobs)
-        .set({
-          result,
-          status: "completed",
-        })
-        .where(
-          and(
-            eq(tlsCommerceJobs.id, id),
-            eq(tlsCommerceJobs.fencingToken, effectiveFencingToken),
-          ),
-        )
-        .returning();
+    const updated = await withTransactionRetry(
+      async (tx) => {
+        // Use a WHERE with fencing token to prevent stale-worker completion
+        const [updatedJob] = await tx
+          .update(tlsCommerceJobs)
+          .set({
+            result,
+            status: "completed",
+          })
+          .where(
+            and(
+              eq(tlsCommerceJobs.id, id),
+              eq(tlsCommerceJobs.fencingToken, effectiveFencingToken),
+            ),
+          )
+          .returning();
 
-      if (!updatedJob) {
-        return null;
-      }
+        if (!updatedJob) {
+          return null;
+        }
 
-      const service = await tx
-        .select({ currency: tlsCommerceServices.currency })
-        .from(tlsCommerceServices)
-        .where(eq(tlsCommerceServices.talosId, job.talosId))
-        .limit(1)
-        .then((r) => r[0] ?? null);
+        const service = await tx
+          .select({ currency: tlsCommerceServices.currency })
+          .from(tlsCommerceServices)
+          .where(eq(tlsCommerceServices.talosId, job.talosId))
+          .limit(1)
+          .then((r: { currency: string }[]) => r[0] ?? null);
 
-      await tx.insert(tlsRevenues).values({
-        talosId: job.talosId,
-        amount: job.amount,
-        currency: service?.currency ?? "USDC",
-        source: "commerce",
-        txHash: job.txHash,
-      });
+        await tx.insert(tlsRevenues).values({
+          talosId: job.talosId,
+          amount: job.amount,
+          currency: service?.currency ?? "USDC",
+          source: "commerce",
+          txHash: job.txHash,
+        });
 
-      return updatedJob;
-    });
+        return updatedJob;
+      },
+      { category: "JOB" }
+    );
 
     if (!updated) {
       return Response.json({

--- a/web/src/app/api/talos/[id]/buy-token/route.ts
+++ b/web/src/app/api/talos/[id]/buy-token/route.ts
@@ -1,4 +1,5 @@
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsPatrons, tlsRevenues, tlsTokenPurchases } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
@@ -321,50 +322,53 @@ export async function POST(
   // flip to "completed" — are committed in one transaction. A crash before
   // commit rolls back every write; the purchase row stays "pending" and the
   // next retry can proceed safely.
-  await db.transaction(async (tx) => {
-    // 1. Patron upsert
-    if (becomesPatron) {
-      if (existingPatron) {
+  await withTransactionRetry(
+    async (tx) => {
+      // 1. Patron upsert
+      if (becomesPatron) {
+        if (existingPatron) {
+          await tx
+            .update(tlsPatrons)
+            .set({ pulseAmount: newPulseAmount, updatedAt: new Date() })
+            .where(eq(tlsPatrons.id, existingPatron.id));
+        } else {
+          await tx.insert(tlsPatrons).values({
+            talosId: id,
+            stellarPublicKey: buyerPublicKey,
+            role: "patron",
+            share: "0",
+            pulseAmount: newPulseAmount,
+            status: "active",
+          });
+        }
+      } else if (existingPatron) {
         await tx
           .update(tlsPatrons)
           .set({ pulseAmount: newPulseAmount, updatedAt: new Date() })
           .where(eq(tlsPatrons.id, existingPatron.id));
-      } else {
-        await tx.insert(tlsPatrons).values({
-          talosId: id,
-          stellarPublicKey: buyerPublicKey,
-          role: "patron",
-          share: "0",
-          pulseAmount: newPulseAmount,
-          status: "active",
-        });
       }
-    } else if (existingPatron) {
+
+      // 2. Revenue record
+      await tx.insert(tlsRevenues).values({
+        talosId: id,
+        amount: String(totalCost),
+        currency: "USDC",
+        source: "token_sale",
+        txHash,
+      });
+
+      // 3. Flip idempotency row to completed with cached response
       await tx
-        .update(tlsPatrons)
-        .set({ pulseAmount: newPulseAmount, updatedAt: new Date() })
-        .where(eq(tlsPatrons.id, existingPatron.id));
-    }
-
-    // 2. Revenue record
-    await tx.insert(tlsRevenues).values({
-      talosId: id,
-      amount: String(totalCost),
-      currency: "USDC",
-      source: "token_sale",
-      txHash,
-    });
-
-    // 3. Flip idempotency row to completed with cached response
-    await tx
-      .update(tlsTokenPurchases)
-      .set({
-        status: "completed",
-        responseBody,
-        updatedAt: new Date(),
-      })
-      .where(eq(tlsTokenPurchases.txHash, txHash));
-  });
+        .update(tlsTokenPurchases)
+        .set({
+          status: "completed",
+          responseBody,
+          updatedAt: new Date(),
+        })
+        .where(eq(tlsTokenPurchases.txHash, txHash));
+    },
+    { category: "TOKEN" }
+  );
 
   return NextResponse.json(responseBody);
 }

--- a/web/src/app/api/talos/[id]/jobs/route.ts
+++ b/web/src/app/api/talos/[id]/jobs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsCommerceServices, tlsCommerceJobs, tlsRevenues } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { fulfillInstant } from "@/lib/fulfillment";
@@ -210,39 +211,42 @@ export async function POST(
         txHash,
       };
 
-      const [job] = await db.transaction(async (tx) => {
-        const [job] = await tx.insert(tlsCommerceJobs).values({
-          talosId: id,
-          requesterTalosId: `human:${buyerPublicKey}`,
-          serviceName: service.serviceName,
-          payload: payload ?? {},
-          result,
-          paymentSig: txHash,
-          txHash,
-          amount: service.price,
-          status: "completed",
-          ...(idempotencyKey ? { idempotencyKey } : {}),
-        }).returning();
+      const [job] = await withTransactionRetry(
+        async (tx) => {
+          const [job] = await tx.insert(tlsCommerceJobs).values({
+            talosId: id,
+            requesterTalosId: `human:${buyerPublicKey}`,
+            serviceName: service.serviceName,
+            payload: payload ?? {},
+            result,
+            paymentSig: txHash,
+            txHash,
+            amount: service.price,
+            status: "completed",
+            ...(idempotencyKey ? { idempotencyKey } : {}),
+          }).returning();
 
-        await tx.insert(tlsRevenues).values({
-          talosId: id,
-          amount: service.price,
-          currency: service.currency ?? "USDC",
-          source: "commerce",
-          txHash,
-        });
+          await tx.insert(tlsRevenues).values({
+            talosId: id,
+            amount: service.price,
+            currency: service.currency ?? "USDC",
+            source: "commerce",
+            txHash,
+          });
 
-        // Cache the response body for future idempotent replays.
-        if (idempotencyKey) {
-          const finalResponse = { ...responseBody, jobId: job.id };
-          await tx
-            .update(tlsCommerceJobs)
-            .set({ idempotencyResponse: finalResponse })
-            .where(eq(tlsCommerceJobs.id, job.id));
-        }
+          // Cache the response body for future idempotent replays.
+          if (idempotencyKey) {
+            const finalResponse = { ...responseBody, jobId: job.id };
+            await tx
+              .update(tlsCommerceJobs)
+              .set({ idempotencyResponse: finalResponse })
+              .where(eq(tlsCommerceJobs.id, job.id));
+          }
 
-        return [job];
-      });
+          return [job];
+        },
+        { category: "JOB" }
+      );
 
       const finalBody = { ...responseBody, jobId: job.id };
       return Response.json(finalBody, { status: 201 });
@@ -258,30 +262,33 @@ export async function POST(
       message: `Job queued. The agent will process your request and you can poll for results.`,
     };
 
-    const [job] = await db.transaction(async (tx) => {
-      const [job] = await tx.insert(tlsCommerceJobs).values({
-        talosId: id,
-        requesterTalosId: `human:${buyerPublicKey}`,
-        serviceName: service.serviceName,
-        payload: payload ?? {},
-        paymentSig: txHash,
-        txHash,
-        amount: service.price,
-        status: "pending",
-        ...(idempotencyKey ? { idempotencyKey } : {}),
-      }).returning();
+    const [job] = await withTransactionRetry(
+      async (tx) => {
+        const [job] = await tx.insert(tlsCommerceJobs).values({
+          talosId: id,
+          requesterTalosId: `human:${buyerPublicKey}`,
+          serviceName: service.serviceName,
+          payload: payload ?? {},
+          paymentSig: txHash,
+          txHash,
+          amount: service.price,
+          status: "pending",
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        }).returning();
 
-      // Cache the response body for future idempotent replays.
-      if (idempotencyKey) {
-        const finalResponse = { ...responseBody, jobId: job.id };
-        await tx
-          .update(tlsCommerceJobs)
-          .set({ idempotencyResponse: finalResponse })
-          .where(eq(tlsCommerceJobs.id, job.id));
-      }
+        // Cache the response body for future idempotent replays.
+        if (idempotencyKey) {
+          const finalResponse = { ...responseBody, jobId: job.id };
+          await tx
+            .update(tlsCommerceJobs)
+            .set({ idempotencyResponse: finalResponse })
+            .where(eq(tlsCommerceJobs.id, job.id));
+        }
 
-      return [job];
-    });
+        return [job];
+      },
+      { category: "JOB" }
+    );
 
     const finalBody = { ...responseBody, jobId: job.id };
     return Response.json(finalBody, { status: 201 });

--- a/web/src/app/api/talos/[id]/revenue/buyback/route.ts
+++ b/web/src/app/api/talos/[id]/revenue/buyback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsRevenues } from "@/db/schema";
 import { and, eq, sum } from "drizzle-orm";
 import { OPERATOR_PUBLIC_KEY, USDC_ISSUER } from "@/lib/stellar-config";
@@ -94,13 +95,18 @@ export async function POST(
     const txHash = result.hash;
 
     // Record as negative revenue (treasury expense)
-    await db.insert(tlsRevenues).values({
-      talosId: id,
-      amount: String(-usdcAmount),
-      currency: "USDC",
-      source: "buyback",
-      txHash,
-    });
+    await withTransactionRetry(
+      async (tx) => {
+        await tx.insert(tlsRevenues).values({
+          talosId: id,
+          amount: String(-usdcAmount),
+          currency: "USDC",
+          source: "buyback",
+          txHash,
+        });
+      },
+      { category: "MONEY" }
+    );
 
     return Response.json({
       success: true,

--- a/web/src/app/api/talos/[id]/service/route.ts
+++ b/web/src/app/api/talos/[id]/service/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsCommerceServices, tlsCommerceJobs, tlsRevenues } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { verifyAgentApiKey } from "@/lib/auth";
@@ -205,33 +206,36 @@ export async function POST(
 
       // Atomic: job + revenue recorded together — if either fails, both roll back.
       // Payment (on-chain) already happened; DB must not partially record it.
-      const [job] = await db.transaction(async (tx) => {
-        const [job] = await tx
-          .insert(tlsCommerceJobs)
-          .values({
+      const [job] = await withTransactionRetry(
+        async (tx) => {
+          const [job] = await tx
+            .insert(tlsCommerceJobs)
+            .values({
+              talosId: id,
+              requesterTalosId: requester.id,
+              serviceName: service.serviceName,
+              payload: payload ?? undefined,
+              result,
+              paymentSig: paymentToken,
+              txHash,
+              amount: service.price,
+              bidPrice: bidData.bidPrice ? String(bidData.bidPrice) : undefined,
+              status: bidData.status ?? "completed",
+            })
+            .returning();
+
+          await tx.insert(tlsRevenues).values({
             talosId: id,
-            requesterTalosId: requester.id,
-            serviceName: service.serviceName,
-            payload: payload ?? undefined,
-            result,
-            paymentSig: paymentToken,
-            txHash,
             amount: service.price,
-            bidPrice: bidData.bidPrice ? String(bidData.bidPrice) : undefined,
-            status: bidData.status ?? "completed",
-          })
-          .returning();
+            currency: service.currency ?? "USDC",
+            source: "commerce",
+            txHash,
+          });
 
-        await tx.insert(tlsRevenues).values({
-          talosId: id,
-          amount: service.price,
-          currency: service.currency ?? "USDC",
-          source: "commerce",
-          txHash,
-        });
-
-        return [job];
-      });
+          return [job];
+        },
+        { category: "JOB" }
+      );
 
       return Response.json(
         { id: job.id, jobId: job.id, status: "completed", result, txHash },

--- a/web/src/app/api/talos/route.ts
+++ b/web/src/app/api/talos/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
+import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsPatrons, tlsCommerceServices } from "@/db/schema";
 import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 import { randomBytes } from "crypto";
@@ -159,65 +160,68 @@ export async function POST(request: NextRequest) {
     }
 
     // Atomic genesis: TALOS + Patron + Service created together or not at all
-    const { talos, generatedKey } = await db.transaction(async (tx) => {
-      const [talos] = await tx
-        .insert(tlsTalos)
-        .values({
-          name,
-          category,
-          description,
-          apiKey,
-          totalSupply: supply,
-          creatorShare: 0,
-          investorShare: 0,
-          treasuryShare: 100,
-          persona,
-          targetAudience,
-          channels: channels ?? [],
-          toneVoice: toneVoice ?? null,
-          approvalThreshold: String(approvalThreshold ?? 10),
-          gtmBudget: String(gtmBudget ?? 200),
-          pulsePrice: String(initialPrice ?? 0),
-          minPatronPulse: minPatronPulse ?? null,
-          creatorPublicKey,
-          walletPublicKey,
-          onChainId: onChainId ?? null,
-          agentName: agentName ?? null,
-          stellarAssetCode: stellarAssetCode ?? null,
-          tokenSymbol: tokenSymbol ?? null,
-          agentWalletId,
-          agentWalletAddress,
-        })
-        .returning();
+    const { talos, generatedKey } = await withTransactionRetry(
+      async (tx) => {
+        const [talos] = await tx
+          .insert(tlsTalos)
+          .values({
+            name,
+            category,
+            description,
+            apiKey,
+            totalSupply: supply,
+            creatorShare: 0,
+            investorShare: 0,
+            treasuryShare: 100,
+            persona,
+            targetAudience,
+            channels: channels ?? [],
+            toneVoice: toneVoice ?? null,
+            approvalThreshold: String(approvalThreshold ?? 10),
+            gtmBudget: String(gtmBudget ?? 200),
+            pulsePrice: String(initialPrice ?? 0),
+            minPatronPulse: minPatronPulse ?? null,
+            creatorPublicKey,
+            walletPublicKey,
+            onChainId: onChainId ?? null,
+            agentName: agentName ?? null,
+            stellarAssetCode: stellarAssetCode ?? null,
+            tokenSymbol: tokenSymbol ?? null,
+            agentWalletId,
+            agentWalletAddress,
+          })
+          .returning();
 
-      // Create initial Patron (Creator)
-      const CREATOR_GOVERNANCE_FRACTION = 0.6;
-      if (creatorPublicKey) {
-        await tx.insert(tlsPatrons).values({
-          talosId: talos.id,
-          stellarPublicKey: creatorPublicKey,
-          role: "Creator",
-          pulseAmount: Math.floor(supply * CREATOR_GOVERNANCE_FRACTION),
-          share: "0",
-        });
-      }
-
-      // Create Commerce Service if provided
-      if (serviceName && servicePrice) {
-        const serviceWallet = agentWalletAddress || creatorPublicKey || walletPublicKey;
-        if (serviceWallet) {
-          await tx.insert(tlsCommerceServices).values({
+        // Create initial Patron (Creator)
+        const CREATOR_GOVERNANCE_FRACTION = 0.6;
+        if (creatorPublicKey) {
+          await tx.insert(tlsPatrons).values({
             talosId: talos.id,
-            serviceName,
-            description: serviceDescription ?? description,
-            price: String(servicePrice),
-            stellarPublicKey: serviceWallet,
+            stellarPublicKey: creatorPublicKey,
+            role: "Creator",
+            pulseAmount: Math.floor(supply * CREATOR_GOVERNANCE_FRACTION),
+            share: "0",
           });
         }
-      }
 
-      return { talos, generatedKey: apiKey };
-    });
+        // Create Commerce Service if provided
+        if (serviceName && servicePrice) {
+          const serviceWallet = agentWalletAddress || creatorPublicKey || walletPublicKey;
+          if (serviceWallet) {
+            await tx.insert(tlsCommerceServices).values({
+              talosId: talos.id,
+              serviceName,
+              description: serviceDescription ?? description,
+              price: String(servicePrice),
+              stellarPublicKey: serviceWallet,
+            });
+          }
+        }
+
+        return { talos, generatedKey: apiKey };
+      },
+      { category: "GENESIS" }
+    );
 
     // DB transaction succeeded — now fund the testnet wallet (best-effort, non-blocking).
     // Kept outside the transaction deliberately: Friendbot is an external call and

--- a/web/src/db/db-retry.ts
+++ b/web/src/db/db-retry.ts
@@ -1,0 +1,205 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { db as defaultDb } from "@/db";
+import { logger } from "@/lib/logger";
+
+export type TransactionCategory = "MONEY" | "TOKEN" | "PATRON" | "JOB" | "GENESIS";
+
+export interface TransactionRetryOptions {
+  category?: TransactionCategory;
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  enabled?: boolean;
+  dbInstance?: { transaction: (cb: (tx: any) => Promise<any>) => Promise<any> };
+}
+
+export class SerializationRetryExhaustedError extends Error {
+  public readonly category: TransactionCategory;
+  public readonly attempts: number;
+  public readonly durationMs: number;
+  public readonly originalError: unknown;
+
+  constructor(category: TransactionCategory, attempts: number, durationMs: number, originalError: unknown) {
+    const msg = (originalError as { message?: string })?.message ?? String(originalError);
+    super(`Transaction retry exhausted for category ${category} after ${attempts} attempts (${durationMs}ms): ${msg}`);
+    this.name = "SerializationRetryExhaustedError";
+    this.category = category;
+    this.attempts = attempts;
+    this.durationMs = durationMs;
+    this.originalError = originalError;
+  }
+}
+
+const RETRYABLE_SQLSTATES = new Set([
+  "40001", // serialization_failure
+  "40P01", // deadlock_detected
+  "55P03", // lock_not_available
+  "08000", // connection_exception
+  "08001", // sqlclient_unable_to_establish_sqlconnection
+  "08003", // connection_does_not_exist
+  "08004", // sqlserver_rejected_establishment_of_sqlconnection
+  "08006", // connection_failure
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+]);
+
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+]);
+
+/**
+ * Classify whether an error is a retryable database error (serialization conflict,
+ * deadlock, lock timeout, or transient database connection failure).
+ */
+export function isRetryableDbError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+
+  const errorObj = err as Record<string, unknown>;
+  const code = String(errorObj.code ?? errorObj.sqlState ?? "");
+  const causeCode = String((errorObj.cause as Record<string, unknown> | undefined)?.code ?? "");
+
+  if (RETRYABLE_SQLSTATES.has(code) || RETRYABLE_SQLSTATES.has(causeCode)) {
+    return true;
+  }
+
+  if (RETRYABLE_NETWORK_CODES.has(code) || RETRYABLE_NETWORK_CODES.has(causeCode)) {
+    return true;
+  }
+
+  const message = String(errorObj.message ?? "").toLowerCase();
+  if (
+    message.includes("serialization failure") ||
+    message.includes("deadlock detected") ||
+    message.includes("could not serialize access due to concurrent update") ||
+    message.includes("could not serialize access due to read/write dependencies") ||
+    message.includes("lock not available") ||
+    message.includes("connection terminated") ||
+    message.includes("connection closed") ||
+    message.includes("connection refused")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Calculate exponential backoff delay with full jitter.
+ */
+export function calculateJitteredDelay(
+  attempt: number,
+  initialDelayMs: number,
+  maxDelayMs: number
+): number {
+  const cappedAttempt = Math.min(attempt, 30);
+  const exponential = initialDelayMs * Math.pow(2, cappedAttempt - 1);
+  const capped = Math.min(maxDelayMs, exponential);
+  return Math.floor(Math.random() * capped);
+}
+
+function getEnvBoolean(key: string, defaultValue: boolean): boolean {
+  const val = process.env[key];
+  if (val === undefined || val === "") return defaultValue;
+  return val.toLowerCase() !== "false" && val !== "0";
+}
+
+function getEnvNumber(key: string, defaultValue: number): number {
+  const val = process.env[key];
+  if (!val) return defaultValue;
+  const parsed = parseInt(val, 10);
+  return isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Executes a database transaction with bounded, jittered retries for
+ * serialization conflicts and transient DB errors.
+ */
+export async function withTransactionRetry<T>(
+  txCallback: (tx: any) => Promise<T>,
+  options: TransactionRetryOptions = {}
+): Promise<T> {
+  const category = options.category ?? "JOB";
+  const enabled = options.enabled ?? getEnvBoolean("DB_TRANSACTION_RETRY_ENABLED", true);
+  const maxRetries = options.maxRetries ?? getEnvNumber("DB_TRANSACTION_RETRY_MAX_RETRIES", 5);
+  const initialDelayMs = options.initialDelayMs ?? getEnvNumber("DB_TRANSACTION_RETRY_INITIAL_DELAY_MS", 50);
+  const maxDelayMs = options.maxDelayMs ?? getEnvNumber("DB_TRANSACTION_RETRY_MAX_DELAY_MS", 1000);
+  const database = options.dbInstance ?? defaultDb;
+
+  if (!enabled) {
+    return database.transaction(txCallback);
+  }
+
+  const startTime = Date.now();
+  let attempt = 1;
+
+  while (true) {
+    try {
+      const result = await database.transaction(txCallback);
+
+      if (attempt > 1) {
+        const durationMs = Date.now() - startTime;
+        logger.info(
+          {
+            category,
+            attempts: attempt,
+            durationMs,
+          },
+          "db_transaction_retry_success"
+        );
+      }
+
+      return result;
+    } catch (err: unknown) {
+      const durationMs = Date.now() - startTime;
+      const retryable = isRetryableDbError(err);
+      const errObj = err as Record<string, unknown> | null;
+
+      if (retryable && attempt <= maxRetries) {
+        const delayMs = calculateJitteredDelay(attempt, initialDelayMs, maxDelayMs);
+        const errorCode = String(
+          errObj?.code ?? errObj?.sqlState ?? (errObj?.cause as Record<string, unknown> | undefined)?.code ?? "UNKNOWN"
+        );
+
+        logger.warn(
+          {
+            category,
+            attempt,
+            maxRetries,
+            delayMs,
+            durationMs,
+            errorCode,
+            errorMessage: errObj?.message ?? String(err),
+          },
+          "db_transaction_retry_attempt"
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        attempt++;
+      } else if (retryable && attempt > maxRetries) {
+        const errorCode = String(
+          errObj?.code ?? errObj?.sqlState ?? (errObj?.cause as Record<string, unknown> | undefined)?.code ?? "UNKNOWN"
+        );
+
+        logger.error(
+          {
+            category,
+            attempts: attempt,
+            maxRetries,
+            durationMs,
+            errorCode,
+          },
+          "db_transaction_retry_exhausted"
+        );
+
+        throw new SerializationRetryExhaustedError(category, attempt, durationMs, err);
+      } else {
+        throw err;
+      }
+    }
+  }
+}

--- a/web/tests/db-retry.contention.test.ts
+++ b/web/tests/db-retry.contention.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect } from "vitest";
+import { withTransactionRetry } from "../src/db/db-retry";
+
+describe("db-retry contention & concurrency integration tests", () => {
+  it("resolves concurrent serialization conflicts deterministically across parallel tasks", async () => {
+    const totalWorkers = 10;
+    let conflictCount = 0;
+    const completedWorkers: number[] = [];
+
+    // Shared row counter state
+    let sharedCounter = 0;
+    const activeLocks = new Set<string>();
+
+    const mockDb = {
+      transaction: async (cb: (tx: any) => Promise<any>): Promise<any> => {
+        const lockKey = "counter_row";
+
+        // Simulate PostgreSQL repeatable read / serializable row isolation conflict
+        if (activeLocks.has(lockKey)) {
+          conflictCount++;
+          const err = new Error("could not serialize access due to concurrent update");
+          (err as any).code = "40001";
+          throw err;
+        }
+
+        activeLocks.add(lockKey);
+        try {
+          // Artificial processing delay simulating DB operation
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          const tx = {
+            increment: () => {
+              sharedCounter += 1;
+              return sharedCounter;
+            },
+          };
+          const res = await cb(tx);
+          return res;
+        } finally {
+          activeLocks.delete(lockKey);
+        }
+      },
+    };
+
+    const workerTasks = Array.from({ length: totalWorkers }, (_, i) => {
+      return withTransactionRetry(
+        async (tx: any) => {
+          const val = tx.increment();
+          completedWorkers.push(i);
+          return val;
+        },
+        {
+          category: "MONEY",
+          maxRetries: 20,
+          initialDelayMs: 2,
+          maxDelayMs: 20,
+          dbInstance: mockDb,
+        }
+      );
+    });
+
+    const results = await Promise.all(workerTasks);
+
+    expect(results.length).toBe(totalWorkers);
+    expect(sharedCounter).toBe(totalWorkers);
+    expect(completedWorkers.length).toBe(totalWorkers);
+    expect(conflictCount).toBeGreaterThan(0);
+  });
+
+  it("handles duplicate delivery & retry contention cleanly", async () => {
+    let attempts = 0;
+    const executionLog: string[] = [];
+
+    const mockDb = {
+      transaction: async (cb: (tx: any) => Promise<any>): Promise<any> => {
+        attempts++;
+        if (attempts === 1) {
+          const err = new Error("lock not available");
+          (err as any).code = "55P03";
+          throw err;
+        }
+        return cb({
+          recordJob: (id: string) => executionLog.push(`job_${id}_recorded`),
+        });
+      },
+    };
+
+    const result = await withTransactionRetry(
+      async (tx: any) => {
+        tx.recordJob("123");
+        return { status: "completed" };
+      },
+      {
+        category: "JOB",
+        initialDelayMs: 5,
+        maxDelayMs: 10,
+        dbInstance: mockDb,
+      }
+    );
+
+    expect(result).toEqual({ status: "completed" });
+    expect(attempts).toBe(2);
+    // Verified that the side effect ran in the winning transaction
+    expect(executionLog).toEqual(["job_123_recorded"]);
+  });
+});

--- a/web/tests/db-retry.unit.test.ts
+++ b/web/tests/db-retry.unit.test.ts
@@ -1,0 +1,273 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  isRetryableDbError,
+  calculateJitteredDelay,
+  withTransactionRetry,
+  SerializationRetryExhaustedError,
+} from "../src/db/db-retry";
+import { logger } from "../src/lib/logger";
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("db-retry unit tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("isRetryableDbError classification", () => {
+    it("identifies PostgreSQL serialization failure (40001)", () => {
+      expect(isRetryableDbError({ code: "40001" })).toBe(true);
+      expect(isRetryableDbError({ sqlState: "40001" })).toBe(true);
+      expect(isRetryableDbError({ cause: { code: "40001" } })).toBe(true);
+    });
+
+    it("identifies PostgreSQL deadlock (40P01)", () => {
+      expect(isRetryableDbError({ code: "40P01" })).toBe(true);
+    });
+
+    it("identifies PostgreSQL lock not available (55P03)", () => {
+      expect(isRetryableDbError({ code: "55P03" })).toBe(true);
+    });
+
+    it("identifies transient connection error codes", () => {
+      expect(isRetryableDbError({ code: "08000" })).toBe(true);
+      expect(isRetryableDbError({ code: "08006" })).toBe(true);
+      expect(isRetryableDbError({ code: "57P01" })).toBe(true);
+      expect(isRetryableDbError({ code: "ECONNRESET" })).toBe(true);
+      expect(isRetryableDbError({ code: "ETIMEDOUT" })).toBe(true);
+    });
+
+    it("identifies retryable error messages", () => {
+      expect(
+        isRetryableDbError(new Error("could not serialize access due to concurrent update"))
+      ).toBe(true);
+      expect(isRetryableDbError(new Error("deadlock detected"))).toBe(true);
+      expect(isRetryableDbError(new Error("connection terminated abruptly"))).toBe(true);
+    });
+
+    it("rejects non-retryable errors", () => {
+      expect(isRetryableDbError({ code: "23505" })).toBe(false); // unique_violation
+      expect(isRetryableDbError({ code: "23503" })).toBe(false); // foreign_key_violation
+      expect(isRetryableDbError({ code: "42703" })).toBe(false); // undefined_column
+      expect(isRetryableDbError(new Error("syntax error at or near WHERE"))).toBe(false);
+      expect(isRetryableDbError(null)).toBe(false);
+      expect(isRetryableDbError(undefined)).toBe(false);
+      expect(isRetryableDbError("string error")).toBe(false);
+    });
+  });
+
+  describe("calculateJitteredDelay", () => {
+    it("returns a bounded integer delay within [0, maxDelay]", () => {
+      for (let i = 0; i < 50; i++) {
+        const delay = calculateJitteredDelay(1, 50, 1000);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(50);
+      }
+
+      for (let i = 0; i < 50; i++) {
+        const delay = calculateJitteredDelay(5, 50, 200);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(200);
+      }
+    });
+  });
+
+  describe("withTransactionRetry execution flow", () => {
+    it("executes successfully on first attempt when no error occurs", async () => {
+      const mockTx = vi.fn().mockImplementation(async (cb: (tx: any) => Promise<any>) => cb({ tx: "instance" }));
+
+      const result = await withTransactionRetry(
+        async () => {
+          return "success";
+        },
+        { category: "TOKEN", dbInstance: { transaction: mockTx } }
+      );
+
+      expect(result).toBe("success");
+      expect(mockTx).toHaveBeenCalledTimes(1);
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("retries on serialization failure and returns result on retry success", async () => {
+      let attempts = 0;
+      const mockTx = vi.fn().mockImplementation(async (cb: (tx: any) => Promise<any>) => {
+        attempts++;
+        if (attempts === 1) {
+          const err = new Error("could not serialize access due to concurrent update");
+          (err as any).code = "40001";
+          throw err;
+        }
+        return cb({ tx: "instance" });
+      });
+
+      const result = await withTransactionRetry(
+        async () => {
+          return { done: true };
+        },
+        {
+          category: "MONEY",
+          initialDelayMs: 10,
+          maxDelayMs: 20,
+          dbInstance: { transaction: mockTx },
+        }
+      );
+
+      expect(result).toEqual({ done: true });
+      expect(attempts).toBe(2);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "MONEY",
+          attempt: 1,
+          maxRetries: 5,
+          errorCode: "40001",
+        }),
+        "db_transaction_retry_attempt"
+      );
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "MONEY",
+          attempts: 2,
+        }),
+        "db_transaction_retry_success"
+      );
+    });
+
+    it("throws SerializationRetryExhaustedError when maxRetries is exceeded", async () => {
+      let attempts = 0;
+      const mockTx = vi.fn().mockImplementation(async () => {
+        attempts++;
+        const err = new Error("serialization failure");
+        (err as any).code = "40001";
+        throw err;
+      });
+
+      await expect(
+        withTransactionRetry(
+          async () => {},
+          {
+            category: "PATRON",
+            maxRetries: 3,
+            initialDelayMs: 5,
+            maxDelayMs: 10,
+            dbInstance: { transaction: mockTx },
+          }
+        )
+      ).rejects.toThrow(SerializationRetryExhaustedError);
+
+      expect(attempts).toBe(4); // 1 initial + 3 retries
+      expect(logger.warn).toHaveBeenCalledTimes(3);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "PATRON",
+          attempts: 4,
+          maxRetries: 3,
+          errorCode: "40001",
+        }),
+        "db_transaction_retry_exhausted"
+      );
+    });
+
+    it("immediately throws non-retryable error without retrying", async () => {
+      let attempts = 0;
+      const mockTx = vi.fn().mockImplementation(async () => {
+        attempts++;
+        const err = new Error("duplicate key value violates unique constraint");
+        (err as any).code = "23505";
+        throw err;
+      });
+
+      await expect(
+        withTransactionRetry(
+          async () => {},
+          {
+            category: "JOB",
+            dbInstance: { transaction: mockTx },
+          }
+        )
+      ).rejects.toThrow("duplicate key value violates unique constraint");
+
+      expect(attempts).toBe(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("bypasses retry logic when enabled: false", async () => {
+      let attempts = 0;
+      const mockTx = vi.fn().mockImplementation(async () => {
+        attempts++;
+        const err = new Error("serialization failure");
+        (err as any).code = "40001";
+        throw err;
+      });
+
+      await expect(
+        withTransactionRetry(
+          async () => {},
+          {
+            category: "GENESIS",
+            enabled: false,
+            dbInstance: { transaction: mockTx },
+          }
+        )
+      ).rejects.toThrow("serialization failure");
+
+      expect(attempts).toBe(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("verifies rollback isolation: mutated state in aborted callback is not committed", async () => {
+      const dbState: string[] = [];
+      let attempts = 0;
+
+      const mockTx = vi.fn().mockImplementation(async (cb: (tx: any) => Promise<any>) => {
+        attempts++;
+        const currentTxState: string[] = [];
+        try {
+          const res = await cb({
+            insert: (item: string) => currentTxState.push(item),
+          });
+          // Commit tx state to dbState on transaction success
+          dbState.push(...currentTxState);
+          return res;
+        } catch (txErr) {
+          // Roll back: tx state discarded
+          throw txErr;
+        }
+      });
+
+      const result = await withTransactionRetry(
+        async (tx: any) => {
+          tx.insert(`attempt_${attempts}_item`);
+          if (attempts === 1) {
+            const err = new Error("serialization failure");
+            (err as any).code = "40001";
+            throw err;
+          }
+          return "committed";
+        },
+        {
+          category: "JOB",
+          initialDelayMs: 5,
+          maxDelayMs: 10,
+          dbInstance: { transaction: mockTx },
+        }
+      );
+
+      expect(result).toBe("committed");
+      expect(attempts).toBe(2);
+      // Attempt 1 item was rolled back, only attempt 2 item was committed
+      expect(dbState).toEqual(["attempt_2_item"]);
+    });
+  });
+});


### PR DESCRIPTION
#closes #220 
# PR Documentation: fix(web): add serialization-failure retries for critical database transactions (#220)

## Title
`fix(web): add serialization-failure retries for critical database transactions (#220)`

## Summary
Hardens money, token, patron, and job state transitions against PostgreSQL serialization conflicts (`40001`), deadlocks (`40P01`), lock timeouts (`55P03`), and transient database connection errors across the `web` workspace.

## Motivation & Problem
Under concurrent operations (e.g. multiple agents or humans purchasing tokens, completing jobs, or updating patron holdings simultaneously), database transactions can encounter serialization failures or lock acquisition timeouts. Without automatic retry handling, these transient conflicts bubble up as HTTP 500 errors or failed API requests.

## Key Changes
1. **Transaction Retry Engine (`web/src/db/db-retry.ts`)**:
   - `withTransactionRetry`: Executes database transactions with exponential backoff and full jitter.
   - `isRetryableDbError`: Classifies PostgreSQL SQLSTATE codes (`40001`, `40P01`, `55P03`, connection codes `08000`-`08006`, `57P01`-`57P03`) and system network errors (`ECONNRESET`, `ETIMEDOUT`, `EPIPE`, etc.), while fast-failing non-retryable errors (such as `23505` unique violation).
   - Structured Pino Telemetry: Emits `db_transaction_retry_attempt` (`warn`), `db_transaction_retry_success` (`info`), and `db_transaction_retry_exhausted` (`error`) with domain category context (`MONEY`, `TOKEN`, `PATRON`, `JOB`, `GENESIS`) without leaking sensitive payloads or keys.
   - Zero-Downtime Feature Flag: Configurable via `DB_TRANSACTION_RETRY_ENABLED=false` for instant opt-out.

2. **Endpoint Integration**:
   - `web/src/app/api/talos/[id]/buy-token/route.ts` (category: `TOKEN`)
   - `web/src/app/api/talos/[id]/jobs/route.ts` (category: `JOB`)
   - `web/src/app/api/talos/[id]/service/route.ts` (category: `JOB`)
   - `web/src/app/api/jobs/[id]/result/route.ts` (category: `JOB`)
   - `web/src/app/api/commerce/cross-chain-webhook/route.ts` (category: `JOB`)
   - `web/src/app/api/talos/route.ts` (category: `GENESIS`)
   - `web/src/app/api/talos/[id]/revenue/buyback/route.ts` (category: `MONEY`)

3. **Side-Effect Isolation**:
   - External blockchain submissions (Stellar Horizon RPC calls) remain strictly outside retryable database transaction blocks to prevent duplicate submissions or double-payouts.

4. **Testing**:
   - `web/tests/db-retry.unit.test.ts`: 13 unit tests covering classification, jitter bounds, single attempt, retry success, retry exhaustion, fast failure, and rollback isolation.
   - `web/tests/db-retry.contention.test.ts`: 2 concurrency contention tests verifying deterministic resolution under simulated row contention and lock timeouts.

5. **Documentation**:
   - Updated `CONTRIBUTING.md` with environment configuration, observability events, local verification commands, and rollback guidance.

## Testing Matrix
- `npx vitest run`: Passed (67/67 unit & integration tests)
- `npx tsc --noEmit`: Passed (0 errors)
- `npx eslint`: Passed (0 errors)

## How to Verify Locally
```bash
export PATH=$HOME/.nvm/versions/node/v24.18.0/bin:$PATH
cd web
npx vitest run tests/db-retry.unit.test.ts tests/db-retry.contention.test.ts
```

## Rollback Plan
Set `DB_TRANSACTION_RETRY_ENABLED=false` in application environment variables and restart the web service.
#closes 