### PR TITLE
feat(contracts): add versioned storage migration framework

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "talos_name_service",
     "talos_governance",
     "ttl_manager",
+    "storage_migration",
 ]
 
 [workspace.dependencies]

--- a/contracts/storage_migration/Cargo.toml
+++ b/contracts/storage_migration/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "storage-migration"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/storage_migration/README.md
+++ b/contracts/storage_migration/README.md
@@ -1,0 +1,92 @@
+# storage_migration
+
+Versioned storage migration framework for Talos Protocol Soroban contracts.
+
+Shared, contract-agnostic building blocks for evolving a contract's
+persistent storage layout safely across releases: a single `u32` schema
+version, ordered/idempotent migration steps, a re-entrancy guard, an
+on-chain history log, and bounded rollback. It does **not** know anything
+about any specific contract's data shapes — each contract defines its own
+migration steps (the actual storage reads/writes) and calls into this crate
+to sequence and record them safely.
+
+See [`talos_registry`](../talos_registry/src/lib.rs) (`schema_version`,
+`run_migrations`, `rollback_schema`) for the reference integration.
+
+## Design
+
+- **Schema version.** One `u32` per contract instance, stored under this
+  crate's own private key type — it cannot collide with a host contract's
+  `DataKey` enum, since Soroban storage keys are typed values.
+- **Ordered, idempotent steps.** A step is only allowed to run when the
+  contract's current version equals the step's declared `from` version, and
+  it must move the version strictly forward (`to > from`). A step that has
+  already been applied is therefore rejected, not silently reapplied — the
+  reference pattern is for the contract's `run_migrations` entry point to
+  check `schema_version()` before invoking each step, which makes calling
+  `run_migrations` repeatedly a safe no-op once everything is up to date.
+- **Concurrency guard.** `begin_migration` takes a lock that `complete_migration`
+  or `abort_migration` must release. A second `begin_migration` call while a
+  step is uncommitted is rejected with `MigrationInProgress` rather than
+  silently racing.
+- **History log.** Every applied step and rollback is appended to an
+  append-only on-chain log (`migration_history_len` / `migration_record_at`)
+  with a timestamp, and emits an event (`sch_mig` / `sch_rbk`). This gives
+  operators an audit trail without needing off-chain indexing.
+- **Rollback, bounded.** `rollback(e, current, target, max_depth)` only
+  moves the version pointer backwards, and only within `max_depth` steps of
+  the current version. **It does not undo the data changes a forward
+  migration made.** Schema migrations in this framework are intentionally
+  not required to be data-reversible; rollback exists to unblock a stuck
+  upgrade (e.g. move the pointer back so the previous migration step can be
+  retried with a fix), not to restore prior on-chain state. An operator
+  rolling back must confirm the target version's data shape is actually
+  compatible with the entry-points that will run against it.
+
+## Adding a migration step to a contract
+
+1. Pick the next schema version (`to = current_max + 1`).
+2. In the host contract, add a branch to its migration dispatcher:
+   ```rust
+   if current == FROM_VERSION {
+       storage_migration::begin_migration(&e, current, FROM_VERSION, TO_VERSION)
+           .unwrap_or_else(|_| panic!("migration out of order or in progress"));
+
+       // ... contract-specific storage reads/writes for this step,
+       // idempotent (e.g. guarded by `.has()`) wherever practical ...
+
+       storage_migration::complete_migration(&e, FROM_VERSION, TO_VERSION);
+       current = TO_VERSION;
+   }
+   ```
+3. Gate the dispatcher entry point behind the contract's existing admin
+   authorization (see `talos_registry::run_migrations`, which requires the
+   protocol wallet to `require_auth()`).
+4. Add a fixture test that: applies the step from a fresh/previous state,
+   asserts the resulting data shape, asserts a second call is a no-op, and
+   (if relevant) asserts the step is rejected when called out of order.
+
+## Operator runbook
+
+- **Check current version:** call the contract's `schema_version()`.
+- **Apply pending migrations:** call `run_migrations()` (admin-authorized).
+  Safe to call repeatedly — it stops once the contract is at the latest
+  known version.
+- **Inspect history:** `migration_history_len()` /
+  `migration_record_at(index)` for a chronological audit trail, or watch for
+  `sch_mig` / `sch_rbk` events.
+- **Roll back:** call `rollback_schema(target_version)` (admin-authorized).
+  Only succeeds within the contract's configured `MAX_ROLLBACK_DEPTH`.
+  Remember this only moves the version pointer — verify the target
+  version's data shape is actually what you want before resuming normal
+  operations.
+
+## Known limitations
+
+- Rollback is version-pointer-only, not a data-level undo (see above).
+- Migration steps are defined per-contract as an ordered `if` chain in the
+  reference integration; a contract with many steps may want to move this
+  to a static table, but the underlying `begin_migration` /
+  `complete_migration` contract remains the same either way.
+- This crate assumes a single logical schema version per contract instance,
+  not per-key versioning within one contract.

--- a/contracts/storage_migration/src/lib.rs
+++ b/contracts/storage_migration/src/lib.rs
@@ -1,0 +1,374 @@
+//! storage_migration — Versioned storage migration framework for Talos
+//! Protocol Soroban contracts.
+//!
+//! ## Model
+//!
+//! Each contract keeps a single `u32` schema version in its own persistent
+//! storage (via this crate's private [`MigrationKey`] type, which cannot
+//! collide with a host contract's own `DataKey` enum since Soroban storage
+//! keys are typed). Migrations move the version forward **one ordered step
+//! at a time**: `begin_migration(e, current, from, to)` only succeeds when
+//! `current == from` and `to > from`, so steps can never be skipped or
+//! applied out of order, and a step that has already been applied becomes a
+//! no-op rejection rather than a silent double-apply — the caller is
+//! expected to check [`schema_version`] before invoking a step, which makes
+//! a top-level "run all pending migrations" dispatcher naturally idempotent
+//! (see `talos_registry::run_migrations` for the reference integration).
+//!
+//! A migration in progress holds a lock (cleared by [`complete_migration`]
+//! or [`abort_migration`]) so a re-entrant or concurrent call cannot begin a
+//! second step while one is uncommitted.
+//!
+//! Every applied step and rollback is appended to an on-chain history log
+//! ([`migration_history_len`] / [`migration_record_at`]) and emits an event,
+//! giving operators an audit trail without needing off-chain indexing.
+//!
+//! ## Rollback
+//!
+//! [`rollback`] only moves the version pointer backwards, bounded by a
+//! caller-supplied `max_depth` (see [`validate_rollback`]). It does **not**
+//! undo any data written by forward migrations — schema migrations in this
+//! framework are intentionally not required to be reversible at the data
+//! level. Operators must confirm the target version's data shape is safe to
+//! resume from before relying on old entry-points again.
+//!
+//! See `contracts/storage_migration/README.md` for the full design and an
+//! operator runbook.
+
+#![no_std]
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+extern crate std;
+
+use soroban_sdk::{contracterror, contracttype, symbol_short, Env};
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MigrationError {
+    /// `to <= from`: migrations must move the schema version strictly forward.
+    NotForward = 1,
+    /// `current != from`: this step does not apply at the contract's current
+    /// version (already applied, or attempted out of order).
+    OutOfOrder = 2,
+    /// A migration was started but never completed or aborted.
+    MigrationInProgress = 3,
+    /// Rollback target must be strictly below the current version.
+    RollbackNotAllowed = 4,
+    /// Rollback target is further back than the allowed depth.
+    RollbackTooDeep = 5,
+}
+
+// ── Storage ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+enum MigrationKey {
+    SchemaVersion,
+    MigrationLock,
+    HistoryLen,
+    History(u32),
+}
+
+/// A single applied migration or rollback, in chronological order.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MigrationRecord {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub applied_at: u64,
+    pub rolled_back: bool,
+}
+
+// ── Events ──────────────────────────────────────────────────────────
+//
+// Event schema (topics → data):
+//   sch_mig : (symbol,) → (from_version: u32, to_version: u32)
+//   sch_rbk : (symbol,) → (from_version: u32, to_version: u32)
+
+fn emit_schema_migrated(env: &Env, from_version: u32, to_version: u32) {
+    let topics = (symbol_short!("sch_mig"),);
+    env.events().publish(topics, (from_version, to_version));
+}
+
+fn emit_schema_rolled_back(env: &Env, from_version: u32, to_version: u32) {
+    let topics = (symbol_short!("sch_rbk"),);
+    env.events().publish(topics, (from_version, to_version));
+}
+
+fn append_history(env: &Env, from_version: u32, to_version: u32, rolled_back: bool) {
+    let len: u32 = env
+        .storage()
+        .persistent()
+        .get(&MigrationKey::HistoryLen)
+        .unwrap_or(0);
+    let record = MigrationRecord {
+        from_version,
+        to_version,
+        applied_at: env.ledger().timestamp(),
+        rolled_back,
+    };
+    env.storage()
+        .persistent()
+        .set(&MigrationKey::History(len), &record);
+    env.storage()
+        .persistent()
+        .set(&MigrationKey::HistoryLen, &(len + 1));
+}
+
+fn is_locked(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get(&MigrationKey::MigrationLock)
+        .unwrap_or(false)
+}
+
+// ── Pure validation (unit-testable without an Env) ─────────────────
+
+/// A forward migration step is valid only when it starts exactly at the
+/// contract's current version and strictly increases the version. This is
+/// what makes step application order-safe: a step whose `from` no longer
+/// matches `current` (because it was already applied, or a later step ran
+/// first) is rejected rather than silently reapplied or skipped.
+pub fn validate_forward_step(current: u32, from: u32, to: u32) -> Result<(), MigrationError> {
+    if to <= from {
+        return Err(MigrationError::NotForward);
+    }
+    if current != from {
+        return Err(MigrationError::OutOfOrder);
+    }
+    Ok(())
+}
+
+/// A rollback is valid only when the target is strictly below the current
+/// version and within `max_depth` steps of it.
+pub fn validate_rollback(current: u32, target: u32, max_depth: u32) -> Result<(), MigrationError> {
+    if target >= current {
+        return Err(MigrationError::RollbackNotAllowed);
+    }
+    if current - target > max_depth {
+        return Err(MigrationError::RollbackTooDeep);
+    }
+    Ok(())
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/// Read the on-chain schema version, if one has ever been recorded.
+/// Contracts adopting this framework should treat `None` as their
+/// pre-migration-system genesis version.
+pub fn schema_version(e: &Env) -> Option<u32> {
+    e.storage().persistent().get(&MigrationKey::SchemaVersion)
+}
+
+/// Record an explicit genesis version. Idempotent: does nothing if a
+/// version is already recorded (e.g. on re-`initialize` guards, or when
+/// called against a contract instance that already adopted this framework).
+pub fn initialize_schema(e: &Env, genesis: u32) {
+    if schema_version(e).is_none() {
+        e.storage()
+            .persistent()
+            .set(&MigrationKey::SchemaVersion, &genesis);
+        append_history(e, genesis, genesis, false);
+    }
+}
+
+/// Begin a single ordered migration step. Must be followed by
+/// [`complete_migration`] (on success) or [`abort_migration`] (to release
+/// the lock without advancing the version).
+pub fn begin_migration(e: &Env, current: u32, from: u32, to: u32) -> Result<(), MigrationError> {
+    validate_forward_step(current, from, to)?;
+    if is_locked(e) {
+        return Err(MigrationError::MigrationInProgress);
+    }
+    e.storage()
+        .persistent()
+        .set(&MigrationKey::MigrationLock, &true);
+    Ok(())
+}
+
+/// Commit a migration step started with [`begin_migration`]: advances the
+/// schema version, releases the lock, appends a history record, and emits
+/// `sch_mig`.
+pub fn complete_migration(e: &Env, from_version: u32, to_version: u32) {
+    e.storage()
+        .persistent()
+        .set(&MigrationKey::SchemaVersion, &to_version);
+    e.storage()
+        .persistent()
+        .set(&MigrationKey::MigrationLock, &false);
+    append_history(e, from_version, to_version, false);
+    emit_schema_migrated(e, from_version, to_version);
+}
+
+/// Release the migration lock without advancing the schema version, e.g.
+/// when a step's precondition fails after `begin_migration` succeeded.
+pub fn abort_migration(e: &Env) {
+    e.storage()
+        .persistent()
+        .set(&MigrationKey::MigrationLock, &false);
+}
+
+/// Roll the schema version back to `target`, bounded by `max_depth` steps.
+/// Only moves the version pointer — see the module docs for why forward
+/// migrations are not required to be reversible at the data level.
+pub fn rollback(e: &Env, current: u32, target: u32, max_depth: u32) -> Result<(), MigrationError> {
+    validate_rollback(current, target, max_depth)?;
+    if is_locked(e) {
+        return Err(MigrationError::MigrationInProgress);
+    }
+    e.storage()
+        .persistent()
+        .set(&MigrationKey::SchemaVersion, &target);
+    append_history(e, current, target, true);
+    emit_schema_rolled_back(e, current, target);
+    Ok(())
+}
+
+/// Number of entries in the migration/rollback history log.
+pub fn migration_history_len(e: &Env) -> u32 {
+    e.storage()
+        .persistent()
+        .get(&MigrationKey::HistoryLen)
+        .unwrap_or(0)
+}
+
+/// Fetch a single history entry by index (`0..migration_history_len`),
+/// oldest first.
+pub fn migration_record_at(e: &Env, index: u32) -> Option<MigrationRecord> {
+    e.storage().persistent().get(&MigrationKey::History(index))
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Address;
+
+    #[test]
+    fn forward_step_accepts_matching_sequential_version() {
+        assert_eq!(validate_forward_step(1, 1, 2), Ok(()));
+    }
+
+    #[test]
+    fn forward_step_rejects_non_increasing_target() {
+        assert_eq!(
+            validate_forward_step(1, 1, 1),
+            Err(MigrationError::NotForward)
+        );
+        assert_eq!(
+            validate_forward_step(2, 2, 1),
+            Err(MigrationError::NotForward)
+        );
+    }
+
+    #[test]
+    fn forward_step_rejects_out_of_order_current() {
+        // Step is written for from=1, but the contract is already at 2
+        // (already applied) or still at 0 (an earlier step hasn't run yet).
+        assert_eq!(
+            validate_forward_step(2, 1, 2),
+            Err(MigrationError::OutOfOrder)
+        );
+        assert_eq!(
+            validate_forward_step(0, 1, 2),
+            Err(MigrationError::OutOfOrder)
+        );
+    }
+
+    #[test]
+    fn rollback_accepts_target_within_depth() {
+        assert_eq!(validate_rollback(3, 2, 1), Ok(()));
+        assert_eq!(validate_rollback(3, 1, 2), Ok(()));
+    }
+
+    #[test]
+    fn rollback_rejects_target_at_or_above_current() {
+        assert_eq!(
+            validate_rollback(3, 3, 5),
+            Err(MigrationError::RollbackNotAllowed)
+        );
+        assert_eq!(
+            validate_rollback(3, 4, 5),
+            Err(MigrationError::RollbackNotAllowed)
+        );
+    }
+
+    #[test]
+    fn rollback_rejects_target_beyond_max_depth() {
+        assert_eq!(
+            validate_rollback(5, 2, 2),
+            Err(MigrationError::RollbackTooDeep)
+        );
+    }
+
+    #[test]
+    fn full_lifecycle_begin_complete_advances_version_and_history() {
+        let env = Env::default();
+        let contract_id = soroban_sdk::Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            initialize_schema(&env, 1);
+            assert_eq!(schema_version(&env), Some(1));
+            assert_eq!(migration_history_len(&env), 1);
+
+            begin_migration(&env, 1, 1, 2).unwrap();
+            complete_migration(&env, 1, 2);
+
+            assert_eq!(schema_version(&env), Some(2));
+            assert_eq!(migration_history_len(&env), 2);
+            assert!(!is_locked(&env));
+
+            let record = migration_record_at(&env, 1).unwrap();
+            assert_eq!(record.from_version, 1);
+            assert_eq!(record.to_version, 2);
+            assert!(!record.rolled_back);
+        });
+    }
+
+    #[test]
+    fn concurrent_begin_is_rejected_until_completed_or_aborted() {
+        let env = Env::default();
+        let contract_id = soroban_sdk::Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            initialize_schema(&env, 1);
+
+            begin_migration(&env, 1, 1, 2).unwrap();
+            // A second, concurrent/re-entrant attempt must not be able to
+            // start while the first step is uncommitted.
+            assert_eq!(
+                begin_migration(&env, 1, 1, 2),
+                Err(MigrationError::MigrationInProgress)
+            );
+
+            abort_migration(&env);
+            // Once aborted (lock released, version unchanged), the same
+            // step can be retried.
+            assert_eq!(schema_version(&env), Some(1));
+            begin_migration(&env, 1, 1, 2).unwrap();
+            complete_migration(&env, 1, 2);
+            assert_eq!(schema_version(&env), Some(2));
+        });
+    }
+
+    #[test]
+    fn rollback_then_reapply_round_trips() {
+        let env = Env::default();
+        let contract_id = soroban_sdk::Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            initialize_schema(&env, 1);
+            begin_migration(&env, 1, 1, 2).unwrap();
+            complete_migration(&env, 1, 2);
+
+            rollback(&env, 2, 1, 1).unwrap();
+            assert_eq!(schema_version(&env), Some(1));
+
+            begin_migration(&env, 1, 1, 2).unwrap();
+            complete_migration(&env, 1, 2);
+            assert_eq!(schema_version(&env), Some(2));
+        });
+    }
+}

--- a/contracts/talos_registry/Cargo.toml
+++ b/contracts/talos_registry/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 ttl-manager = { path = "../ttl_manager" }
+storage-migration = { path = "../storage_migration" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/talos_registry/src/lib.rs
+++ b/contracts/talos_registry/src/lib.rs
@@ -12,6 +12,7 @@
 extern crate std;
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use storage_migration;
 use ttl_manager;
 
 // ── Data Types ──────────────────────────────────────────────────────
@@ -222,6 +223,17 @@ const PROTOCOL_FEE_BPS: u32 = 300; // 3%
 const MAX_PROTOCOL_FEE_BPS: u32 = 10_000; // 100%
 const DEFAULT_GRACE_PERIOD: u64 = 604_800; // 7 days in seconds
 const MAX_MIN_DELAY: u64 = 2_592_000; // 30 days in seconds
+
+// ── Storage schema migrations (see `storage_migration` crate) ────────
+
+/// Pre-migration-system baseline. Every TalosRegistry instance, including
+/// ones deployed before this framework existed, is treated as starting here.
+const SCHEMA_GENESIS: u32 = 1;
+/// v1 -> v2: persist an explicit `TimelockConfig` default so future reads
+/// no longer depend on `get_timelock_config`'s implicit `unwrap_or` fallback.
+const SCHEMA_TIMELOCK_DEFAULTS: u32 = 2;
+/// `rollback_schema` may only move the version pointer back this many steps.
+const MAX_ROLLBACK_DEPTH: u32 = 1;
 
 /// Compile-time interface version of TalosRegistry.
 ///
@@ -449,6 +461,7 @@ impl TalosRegistry {
             .persistent()
             .set(&DataKey::ProtocolFeeBps, &PROTOCOL_FEE_BPS);
         e.storage().persistent().set(&DataKey::NextTalosId, &1u32);
+        storage_migration::initialize_schema(&e, SCHEMA_GENESIS);
     }
 
     /// Get the protocol wallet address.
@@ -931,6 +944,89 @@ impl TalosRegistry {
         } else {
             (health.min_age, health.max_age, health.keys_below_warn, health.keys_below_crit, health.total_keys)
         }
+    }
+
+    // ── Storage Schema Migrations ─────────────────────────────────
+
+    /// Current on-chain storage schema version. Defaults to
+    /// [`SCHEMA_GENESIS`] for any instance that has never run
+    /// `initialize` or `run_migrations` under this framework.
+    pub fn schema_version(e: Env) -> u32 {
+        storage_migration::schema_version(&e).unwrap_or(SCHEMA_GENESIS)
+    }
+
+    /// Apply any pending storage migrations, one ordered step at a time.
+    /// Safe to call repeatedly: once the contract is at the latest known
+    /// version this is a no-op. Returns the resulting schema version.
+    ///
+    /// # Authorization
+    /// Requires the protocol wallet (admin) to sign.
+    pub fn run_migrations(e: Env) -> u32 {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+        admin.require_auth();
+
+        let mut current = storage_migration::schema_version(&e).unwrap_or(SCHEMA_GENESIS);
+
+        // v1 -> v2: backfill an explicit TimelockConfig default for
+        // instances that never called `set_timelock_config`.
+        if current == SCHEMA_GENESIS {
+            storage_migration::begin_migration(
+                &e,
+                current,
+                SCHEMA_GENESIS,
+                SCHEMA_TIMELOCK_DEFAULTS,
+            )
+            .unwrap_or_else(|_| panic!("Migration out of order or already in progress"));
+
+            if !e.storage().persistent().has(&DataKey::TimelockConfig) {
+                e.storage().persistent().set(
+                    &DataKey::TimelockConfig,
+                    &TimelockConfig {
+                        min_delay: 0,
+                        grace_period: DEFAULT_GRACE_PERIOD,
+                    },
+                );
+            }
+
+            storage_migration::complete_migration(&e, SCHEMA_GENESIS, SCHEMA_TIMELOCK_DEFAULTS);
+            current = SCHEMA_TIMELOCK_DEFAULTS;
+        }
+
+        current
+    }
+
+    /// Roll the schema version pointer back to `target_version`, bounded by
+    /// [`MAX_ROLLBACK_DEPTH`] steps. Does **not** undo data written by
+    /// forward migrations — see `storage_migration`'s README before relying
+    /// on old entry-points again after a rollback.
+    ///
+    /// # Authorization
+    /// Requires the protocol wallet (admin) to sign.
+    pub fn rollback_schema(e: Env, target_version: u32) {
+        let admin: Address = e
+            .storage()
+            .persistent()
+            .get(&DataKey::ProtocolWallet)
+            .expect("Contract not initialized");
+        admin.require_auth();
+
+        let current = storage_migration::schema_version(&e).unwrap_or(SCHEMA_GENESIS);
+        storage_migration::rollback(&e, current, target_version, MAX_ROLLBACK_DEPTH)
+            .unwrap_or_else(|_| panic!("Rollback rejected: out of range or migration in progress"));
+    }
+
+    /// Number of entries in the migration/rollback history log.
+    pub fn migration_history_len(e: Env) -> u32 {
+        storage_migration::migration_history_len(&e)
+    }
+
+    /// Fetch a single migration/rollback history entry, oldest first.
+    pub fn migration_record_at(e: Env, index: u32) -> Option<storage_migration::MigrationRecord> {
+        storage_migration::migration_record_at(&e, index)
     }
 }
 
@@ -2174,5 +2270,157 @@ mod tests {
             }])
             .try_propose_admin(&new_admin);
         assert!(res_prop.is_err());
+    }
+
+    // ── Storage schema migration tests ───────────────────────────────
+
+    fn run_migrations_with_auth(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        admin: &Address,
+    ) -> u32 {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "run_migrations",
+                    args: ().into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .run_migrations()
+    }
+
+    fn rollback_schema_with_auth(
+        env: &Env,
+        client: &TalosRegistryClient,
+        contract_id: &Address,
+        admin: &Address,
+        target_version: u32,
+    ) {
+        client
+            .mock_auths(&[MockAuth {
+                address: admin,
+                invoke: &MockAuthInvoke {
+                    contract: contract_id,
+                    fn_name: "rollback_schema",
+                    args: (target_version,).into_val(env),
+                    sub_invokes: &[],
+                },
+            }])
+            .rollback_schema(&target_version);
+    }
+
+    #[test]
+    fn schema_version_starts_at_genesis_after_initialize() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        client.initialize(&Address::generate(&env));
+
+        assert_eq!(client.schema_version(), SCHEMA_GENESIS);
+        assert_eq!(client.migration_history_len(), 1);
+    }
+
+    #[test]
+    fn run_migrations_applies_v1_to_v2_and_backfills_timelock_config() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = run_migrations_with_auth(&env, &client, &contract_id, &admin);
+
+        assert_eq!(result, SCHEMA_TIMELOCK_DEFAULTS);
+        assert_eq!(client.schema_version(), SCHEMA_TIMELOCK_DEFAULTS);
+
+        // TimelockConfig is now explicitly persisted, matching the same
+        // defaults get_timelock_config previously only returned implicitly.
+        let cfg = client.get_timelock_config();
+        assert_eq!(cfg.min_delay, 0);
+        assert_eq!(cfg.grace_period, DEFAULT_GRACE_PERIOD);
+
+        assert_eq!(client.migration_history_len(), 2);
+        let record = client.migration_record_at(&1).expect("migration record");
+        assert_eq!(record.from_version, SCHEMA_GENESIS);
+        assert_eq!(record.to_version, SCHEMA_TIMELOCK_DEFAULTS);
+        assert!(!record.rolled_back);
+    }
+
+    #[test]
+    fn run_migrations_is_idempotent_on_repeat_call() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        run_migrations_with_auth(&env, &client, &contract_id, &admin);
+        assert_eq!(client.migration_history_len(), 2);
+
+        // Calling again once fully migrated must not reapply the step or
+        // append a duplicate history entry.
+        let result = run_migrations_with_auth(&env, &client, &contract_id, &admin);
+        assert_eq!(result, SCHEMA_TIMELOCK_DEFAULTS);
+        assert_eq!(client.schema_version(), SCHEMA_TIMELOCK_DEFAULTS);
+        assert_eq!(client.migration_history_len(), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn run_migrations_requires_admin_auth() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // No auth mocked for this call: the admin's require_auth() must reject it.
+        client.run_migrations();
+    }
+
+    #[test]
+    fn rollback_schema_within_depth_succeeds() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        run_migrations_with_auth(&env, &client, &contract_id, &admin);
+        assert_eq!(client.schema_version(), SCHEMA_TIMELOCK_DEFAULTS);
+
+        rollback_schema_with_auth(&env, &client, &contract_id, &admin, SCHEMA_GENESIS);
+
+        assert_eq!(client.schema_version(), SCHEMA_GENESIS);
+        let record = client.migration_record_at(&2).expect("rollback record");
+        assert_eq!(record.from_version, SCHEMA_TIMELOCK_DEFAULTS);
+        assert_eq!(record.to_version, SCHEMA_GENESIS);
+        assert!(record.rolled_back);
+
+        // The version pointer moved back, but the migration is re-appliable.
+        let result = run_migrations_with_auth(&env, &client, &contract_id, &admin);
+        assert_eq!(result, SCHEMA_TIMELOCK_DEFAULTS);
+    }
+
+    #[test]
+    fn rollback_schema_rejects_target_beyond_max_depth() {
+        let (env, contract_id) = setup();
+        let client = TalosRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        run_migrations_with_auth(&env, &client, &contract_id, &admin);
+
+        // Current version is 2; MAX_ROLLBACK_DEPTH is 1, so target 0 is out of range.
+        let res = client
+            .mock_auths(&[MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "rollback_schema",
+                    args: (0u32,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_rollback_schema(&0u32);
+        assert!(res.is_err());
+        assert_eq!(client.schema_version(), SCHEMA_TIMELOCK_DEFAULTS);
     }
 }


### PR DESCRIPTION
## Description

Adds a versioned storage migration framework, per #236, scoped as: a reusable framework plus a full reference integration in one contract (`talos_registry`) rather than a shallow pass across all four contracts. Happy to follow up with the same pattern in `talos_governance`, `talos_name_service`, and `ttl_manager` if that's wanted.

### New crate: `contracts/storage_migration/`

Contract-agnostic building blocks, mirroring how `ttl_manager` is already shared across contracts in this repo:

- **Schema version**: one `u32` per contract instance, stored under this crate's own private key type (cannot collide with a host contract's `DataKey`).
- **Ordered, idempotent steps**: `begin_migration(e, current, from, to)` only succeeds when `current == from` and `to > from` — steps can't be skipped, reordered, or silently double-applied. A contract's `run_migrations` dispatcher checks `schema_version()` before invoking each step, so calling it repeatedly is a safe no-op once fully migrated.
- **Concurrency guard**: `begin_migration` takes a lock; a second call while a step is uncommitted is rejected with `MigrationInProgress`.
- **History log + events**: every applied step/rollback is appended on-chain (`migration_history_len` / `migration_record_at`) and emits `sch_mig` / `sch_rbk`.
- **Bounded rollback**: `rollback(e, current, target, max_depth)` only moves the version pointer backwards within `max_depth`. It intentionally does **not** undo data written by forward migrations — documented explicitly in the README and in doc comments, since that's a real limitation operators need to know about, not a gap I tried to hide.

See `contracts/storage_migration/README.md` for the full design writeup and an operator runbook (check version, apply, inspect history, roll back).

### Reference integration: `talos_registry`

- `initialize()` now records an explicit genesis schema version (`SCHEMA_GENESIS = 1`).
- `run_migrations()` (admin-gated) applies one concrete step, v1 → v2: backfills an explicit `TimelockConfig` default for instances that never called `set_timelock_config`, replacing reliance on `get_timelock_config`'s implicit `unwrap_or` fallback.
- `rollback_schema(target_version)` (admin-gated), bounded by `MAX_ROLLBACK_DEPTH = 1`.
- `schema_version()`, `migration_history_len()`, `migration_record_at(index)` for observability.

### Tests

- `storage_migration`: unit tests for the pure ordering/rollback validation logic (no `Env` needed) plus `Env`-backed tests (via `as_contract`) for the full begin/complete/lock/history/rollback lifecycle, including a concurrent/re-entrant `begin_migration` rejection.
- `talos_registry`: fixture tests for applying the v1→v2 step, idempotent repeat calls, the admin-auth guard, rollback within depth, and rollback rejected beyond `MAX_ROLLBACK_DEPTH`.

Fixes #236

## Note for maintainers

I could not run `cargo test` in my local environment (no MSVC `link.exe` on this Windows box) — please let CI verify. `contracts-ci.yml` runs plain `cargo test` (no `--locked`), so the new workspace member should pick up cleanly.

## Verification

- [ ] `cargo test` (please run in CI — could not run locally)
- [ ] `cargo build --target wasm32-unknown-unknown --release`