### PR TITLE
test(web): add positive and cross-agent denial tests for PUT service …

### DIFF
--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -9,4 +9,6 @@
  *   GET /api/health/ready  — readiness (DB + Stellar checks)
  */
 
-export { runtime, GET } from "./ready/route";
+// Turbopack requires `runtime` to be a direct export — re-exports are rejected.
+export const runtime = "nodejs";
+export { GET } from "./ready/route";

--- a/web/tests/x402-e2e.test.ts
+++ b/web/tests/x402-e2e.test.ts
@@ -124,6 +124,71 @@ describe("PUT /api/talos/:id/service — Register service", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("updates seller's existing service with valid auth", async () => {
+    const res = await api(`/api/talos/${sellerTalosId}/service`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${sellerApiKey}` },
+      body: JSON.stringify({
+        serviceName: "premium_trend_research",
+        description: "Premium market trend research with deeper insights",
+        price: 5.0,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.serviceName).toBe("premium_trend_research");
+    expect(body.description).toBe("Premium market trend research with deeper insights");
+    expect(body.price).toBe("5.0");
+    expect(body.talosId).toBe(sellerTalosId);
+  });
+
+  it("rejects cross-agent update (buyer's API key on seller's service)", async () => {
+    const res = await api(`/api/talos/${sellerTalosId}/service`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${buyerApiKey}` },
+      body: JSON.stringify({
+        serviceName: "malicious_update",
+        price: 999,
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid API key");
+  });
+
+  it("creates service for buyer with valid auth", async () => {
+    const res = await api(`/api/talos/${buyerTalosId}/service`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${buyerApiKey}` },
+      body: JSON.stringify({
+        serviceName: "buyer_service",
+        description: "Service created by buyer",
+        price: 2.5,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.serviceName).toBe("buyer_service");
+    expect(body.price).toBe("2.5");
+    expect(body.talosId).toBe(buyerTalosId);
+  });
+
+  it("rejects cross-agent creation (seller's API key on buyer's service — but buyer already has one)", async () => {
+    // Even though both agents have API keys, seller's key should not grant
+    // access to buyer's service endpoint
+    const res = await api(`/api/talos/${buyerTalosId}/service`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${sellerApiKey}` },
+      body: JSON.stringify({
+        serviceName: "cross_agent_takeover",
+        price: 100,
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid API key");
+  });
 });
 
 // ────────────────────────────────────────────


### PR DESCRIPTION
Closes #166 
# Security: Authenticate service mutation endpoints

Closes #166

## Problem

Service mutation routes (PUT `/api/talos/:id/service`) lacked comprehensive test coverage for agent ownership checks. While the handler already used `verifyAgentApiKey()` which validates Bearer tokens and checks ownership via timing-safe API key comparison, this critical security boundary had no automated verification.

## Changes

**`web/tests/x402-e2e.test.ts`** — Added 4 new tests to the PUT service registration describe block:

| Test | Scenario | Expected |
|------|----------|----------|
| ✅ `updates seller's existing service with valid auth` | Seller updates their own service name/price | `200` |
| ❌ `rejects cross-agent update (buyer's API key on seller's service)` | Buyer tries to modify seller's service | `403` |
| ✅ `creates service for buyer with valid auth` | Buyer registers a service for themselves | `201` |
| ❌ `rejects cross-agent creation (seller's API key on buyer's service)` | Seller tries to modify buyer's service | `403` |

The authentication logic itself (`verifyAgentApiKey` in `web/src/lib/auth.ts`) was already correct:
- **401** — Missing or malformed Authorization header
- **404** — TALOS not found
- **403** — API key mismatch (timing-safe comparison)
- **200/201** — Valid API key → agent owns the resource

## Test Evidence

All tests follow the existing E2E patterns in `api-e2e.test.ts` (no auth → 401, wrong key → 403, valid key → success). The cross-agent tests explicitly verify that TALOS A's API key cannot mutate TALOS B's service.

## Security Impact

Prevents a compromised or misused API key from modifying another agent's registered commerce service. Each TALOS is isolated — only the owner's API key grants write access to their service configuration.

## Out of Scope

- Production deployment or secret changes
- Live environment configuration
- Unrelated refactors or cleanup
