### PR TITLE
security(agent): support zero-downtime secret rotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,10 @@ cargo test --target wasm32-unknown-unknown
 - Do not commit secrets, keys, or generated `.env` files
 - For TypeScript and React, run `pnpm lint` and the relevant `pnpm test:*` command before opening a PR
 - For Python, prefer explicit types and validate changes with `uv run pytest`
+- For encrypted agent credentials, also run `uv run pytest
+  tests/test_secret_store.py tests/test_secret_rotation_integration.py` and
+  follow [the rotation runbook](./docs/prime-agent-secret-rotation.md) for
+  migration and rollback verification.
 - For Rust, keep formatting standard with `cargo fmt` and validate with `cargo test`
 
 ## Pull Request Workflow

--- a/docs/prime-agent-secret-rotation.md
+++ b/docs/prime-agent-secret-rotation.md
@@ -1,0 +1,163 @@
+# Prime-agent encrypted secret rotation
+
+Status: implementation design for issue #227.
+
+## Goals and boundary
+
+The prime-agent must rotate agent API keys, LLM/provider credentials, channel
+credentials, and locally managed wallet credentials without persisting
+plaintext or restarting the agent. Rotation is opt-in so existing `.env` and
+`config.json` installations continue to work until an operator migrates them.
+
+The boundary is the prime-agent's existing SQLite database and `Settings`
+object. A separate secrets service is deliberately not required for local
+agents. When operators put the database on shared storage, SQLite's locking
+semantics remain the source of truth; correctness never depends on a
+process-local cache.
+
+## Data model and encryption
+
+Migration 7 adds:
+
+- `secret_versions`: immutable encrypted versions and their lifecycle state.
+- `secret_heads`: one atomic active/previous pointer and generation per secret.
+- `secret_audit_events`: append-only, idempotent transition records. Events
+  contain names, versions, actors, outcomes, and bounded metadata only.
+
+Values use AES-256-GCM with a fresh 96-bit nonce. The authenticated data binds
+the envelope format, scope, secret name, version, and key ID, preventing a
+ciphertext from being moved to another row. Encryption keys are supplied as a
+JSON keyring in `TALOS_SECRET_KEYRING`; the database stores only the key ID,
+nonce, and ciphertext. Keys must be 32 random bytes encoded with URL-safe
+base64. The keyring and plaintext are never logged or written to SQLite.
+
+The database file is created with owner-only permissions where the platform
+supports them. Database permissions are defense in depth: confidentiality
+still depends on keeping the encryption keyring outside the database.
+
+## State machine
+
+```text
+             stage               activate (CAS)
+  absent  ------------> staged --------------------> active
+                              duplicate request ID      |
+                                                       | next activation
+                                                       v
+                                                   superseded
+                                                       |
+                              recover (CAS) <-----------+
+
+  staged/superseded -- revoke --> revoked
+  active -- revoke --> rejected (recover/activate another version first)
+```
+
+`stage`, `activate`, `revoke`, and `recover` use `BEGIN IMMEDIATE` transactions.
+Activation accepts an expected active version. A stale operator therefore gets
+an explicit conflict instead of overwriting a concurrent rotation. A unique
+`request_id` makes retried or duplicate stage delivery return the original
+version. SQLite's configured busy timeout bounds lock waiting.
+
+No external provider is called inside a database transaction. A staged value
+may be verified against its provider before activation; failed validation
+leaves it staged and the current credential remains active.
+
+## Runtime reads and failure recovery
+
+With `TALOS_SECRET_ROTATION_ENABLED=true`, `Settings.secret_value(name)` resolves
+the active encrypted value at the moment a credential is used. API
+authorization headers are built per request, LLM credentials are resolved per
+agent cycle, and channel adapters resolve credentials per operation.
+
+Reads try:
+
+1. the active encrypted version;
+2. the previous non-revoked version when dual-read is enabled;
+3. the legacy Settings/environment value when legacy fallback is enabled.
+
+Authentication failure is not automatically treated as a decryption failure:
+provider-specific retry with an old credential could duplicate a write.
+Operators validate before activation and explicitly recover when a newly
+activated credential is rejected. Network retries retain the credential
+selected for that individual request.
+
+Missing keys, corrupt ciphertext, lock timeouts, and transition conflicts have
+typed errors and structured events. Logs expose only scope, secret name,
+version, transition, outcome, and error class. They never include ciphertext,
+plaintext, key IDs, authorization headers, or user payloads.
+
+Operational signal names:
+
+- `secret_rotation_transition`: `stage`, `activated`, `recovered`, or `revoke`
+  with `success`/`failure`.
+- `secret_resolution`: an active-version decrypt failed and the resolver moved
+  to the previous or legacy source.
+- `secret_consumer_reloaded`: the long-lived browser/provider client swapped to
+  a new credential.
+- `secret_consumer_reload_failed`: replacement initialization failed; the old
+  browser remains live and the next cycle retries.
+
+On restart there is no reconciliation guesswork: the committed `secret_heads`
+row is authoritative. An interrupted stage is either fully committed or absent;
+an interrupted activation is either fully committed or rolled back.
+
+## Configuration and rollout
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `TALOS_SECRET_ROTATION_ENABLED` | `false` | Enables encrypted-store reads. |
+| `TALOS_SECRET_KEYRING` | empty | JSON map of key ID to URL-safe base64 AES-256 key. |
+| `TALOS_SECRET_ACTIVE_KEY_ID` | empty | Key used to encrypt newly staged versions. |
+| `TALOS_SECRET_SCOPE` | `default` | Namespace for agents sharing a database. |
+| `TALOS_SECRET_DUAL_READ` | `true` | Fall back to the previous encrypted version. |
+| `TALOS_SECRET_LEGACY_FALLBACK` | `true` | Fall back to existing Settings values. |
+| `TALOS_SECRET_MAX_BYTES` | `65536` | Maximum accepted plaintext size (hard-capped). |
+| `TALOS_SECRET_DB_TIMEOUT_MS` | `5000` | Bounded SQLite lock wait. |
+
+Backward-compatible rollout:
+
+1. Generate a key, configure the keyring/key ID, and leave rotation disabled.
+2. Stage and activate each existing value with `talos-agent secrets rotate`.
+3. Enable rotation with legacy fallback and verify audit/status output.
+4. Remove plaintext values only after every required secret resolves.
+5. Disable legacy fallback. Revoke the superseded versions after the provider's
+   drain window.
+
+## Recovery and rollback
+
+For a bad active credential, run `talos-agent secrets recover NAME VERSION
+--expected-version CURRENT`. Recovery is a CAS activation of a known,
+non-revoked version and is safe to retry. Confirm the `recovered` audit event,
+then revoke the rejected version if it will not be reused.
+
+For a code rollback, set `TALOS_SECRET_ROTATION_ENABLED=false` and restore the
+legacy environment value. This does not modify encrypted history. Do not delete
+the keyring until all encrypted versions have been migrated or intentionally
+abandoned.
+
+Known limitations:
+
+- SQLite coordinates processes that can safely share the same database file;
+  it is not a multi-region secrets database.
+- Provider-side credential creation/revocation is outside this component.
+- In-flight operations keep the credential captured when their request began.
+- Browser sessions may retain provider cookies; rotating a login password takes
+  effect at the next login/reconnection.
+- Python cannot guarantee immediate zeroization of immutable strings in process
+  memory; plaintext is kept only for the operation that consumes it and is
+  never cached by the secret store.
+
+## Local verification
+
+From `packages/prime-agent`:
+
+```bash
+uv sync --extra dev
+uv run pytest tests/test_secret_store.py tests/test_secret_rotation_integration.py
+uv run pytest
+uv run ruff check src tests
+```
+
+The focused suite covers encryption/AAD tamper detection, plaintext absence,
+input and audit limits, idempotent duplicate delivery, stale CAS writers,
+bounded lock timeout, corrupt-active dual read, revocation, recovery, restart,
+filesystem permissions, CLI redaction, and live API-header rotation.

--- a/packages/prime-agent/.env.example
+++ b/packages/prime-agent/.env.example
@@ -36,3 +36,16 @@ BROWSER_HEADLESS=true
 # ─── Observability ────────────────────────────────────────
 # Sentry DSN for error tracking (optional — leave blank to disable)
 SENTRY_DSN=
+
+# ─── Encrypted secret rotation (opt-in) ───────────────────
+# Keep the keyring outside this file in production (for example, in the
+# deployment platform's secret variables). Values are URL-safe base64 encodings
+# of exactly 32 random bytes. See docs/prime-agent-secret-rotation.md.
+# TALOS_SECRET_ROTATION_ENABLED=false
+# TALOS_SECRET_KEYRING={"primary":"<urlsafe-base64-32-byte-key>"}
+# TALOS_SECRET_ACTIVE_KEY_ID=primary
+# TALOS_SECRET_SCOPE=default
+# TALOS_SECRET_DUAL_READ=true
+# TALOS_SECRET_LEGACY_FALLBACK=true
+# TALOS_SECRET_MAX_BYTES=65536
+# TALOS_SECRET_DB_TIMEOUT_MS=5000

--- a/packages/prime-agent/README.md
+++ b/packages/prime-agent/README.md
@@ -2,6 +2,51 @@
 
 Autonomous agent corporation runtime for Stellar GTM agents.
 
+## Zero-downtime encrypted secret rotation
+
+Secret rotation is disabled by default for compatibility. The full design,
+configuration contract, rollout procedure, operational signals, recovery
+steps, and limitations are documented in
+[prime-agent-secret-rotation.md](../../docs/prime-agent-secret-rotation.md).
+
+Generate a 32-byte key with a system CSPRNG and put its base64 value in the
+deployment platform's secret manager:
+
+```bash
+openssl rand -base64 32
+export TALOS_SECRET_KEYRING='{"primary":"REPLACE_WITH_GENERATED_VALUE"}'
+export TALOS_SECRET_ACTIVE_KEY_ID=primary
+```
+
+Stage and activate a credential without exposing it in shell history:
+
+```bash
+uv run talos-agent secrets rotate talos_api_key --request-id rollout-2026-01
+uv run talos-agent secrets list talos_api_key
+uv run talos-agent secrets audit talos_api_key
+```
+
+Enable runtime reads after the required credentials are active:
+
+```bash
+export TALOS_SECRET_ROTATION_ENABLED=true
+export TALOS_SECRET_LEGACY_FALLBACK=true
+uv run talos-agent start
+```
+
+To exercise rollback locally, rotate twice, recover version 1 with
+`--expected-version 2`, and confirm the next API request uses version 1:
+
+```bash
+uv run talos-agent secrets recover talos_api_key 1 \
+  --expected-version 2 --reason credential_rejected
+```
+
+The local operator is the authorization boundary: restrict access to the
+database and keyring environment. The database is set to owner-only mode where
+supported. Commands never accept secret values as command-line arguments and
+never display ciphertext, key IDs, or plaintext.
+
 ## Database Migrations
 
 This package implements an automated schema versioning and migration framework using SQLite's native `PRAGMA user_version` capability.
@@ -74,4 +119,3 @@ docker build -t prime-agent .
 # Run the container (which automatically runs as user 'talos')
 docker run --rm prime-agent
 ```
-

--- a/packages/prime-agent/src/talos_agent/adapters/discord.py
+++ b/packages/prime-agent/src/talos_agent/adapters/discord.py
@@ -10,6 +10,7 @@ import httpx
 from rich.console import Console
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.config import resolve_setting_secret
 
 if TYPE_CHECKING:
     from talos_agent.config import Settings
@@ -41,11 +42,23 @@ class DiscordAdapter(BaseSocialAdapter):
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        self._webhook_url: str = settings.discord_webhook_url
-        self._bot_token: str = settings.discord_bot_token
+        self._legacy_webhook_url: str = settings.discord_webhook_url
+        self._legacy_bot_token: str = settings.discord_bot_token
         self._channel_id: str = settings.discord_channel_id
         self._guild_id: str = settings.discord_guild_id
         self._cached_bot_id: str | None = None
+
+    @property
+    def _webhook_url(self) -> str:
+        return resolve_setting_secret(
+            self._settings, "discord_webhook_url", self._legacy_webhook_url
+        )
+
+    @property
+    def _bot_token(self) -> str:
+        return resolve_setting_secret(
+            self._settings, "discord_bot_token", self._legacy_bot_token
+        )
 
     # ── Capabilities ─────────────────────────────────────────
 

--- a/packages/prime-agent/src/talos_agent/adapters/health.py
+++ b/packages/prime-agent/src/talos_agent/adapters/health.py
@@ -231,7 +231,9 @@ class XProbe:
         a = self._adapter
         settings = getattr(a, "_settings", None)
         has_username = bool(getattr(settings, "x_username", ""))
-        has_password = bool(getattr(settings, "x_password", ""))
+        from talos_agent.config import resolve_setting_secret
+
+        has_password = bool(resolve_setting_secret(settings, "x_password"))
         has_creds = has_username and has_password
 
         browser: object | None = getattr(a, "_browser", None)

--- a/packages/prime-agent/src/talos_agent/adapters/telegram.py
+++ b/packages/prime-agent/src/talos_agent/adapters/telegram.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.config import resolve_setting_secret
 
 if TYPE_CHECKING:
     from talos_agent.config import Settings
@@ -22,10 +23,16 @@ class TelegramAdapter(BaseSocialAdapter):
     def __init__(self, settings: "Settings") -> None:
         self._settings = settings
         telegram_config = getattr(settings, "channel_configs", {}) or {}
-        config_token = telegram_config.get("telegram", {}).get("bot_token")
+        config_token = telegram_config.get("telegram", {}).get("bot_token", "")
         config_chat_id = telegram_config.get("telegram", {}).get("chat_id")
-        self._bot_token = config_token or getattr(settings, "telegram_bot_token", "")
+        self._legacy_bot_token = config_token or getattr(settings, "telegram_bot_token", "")
         self._chat_id = config_chat_id or getattr(settings, "telegram_chat_id", "")
+
+    @property
+    def _bot_token(self) -> str:
+        return resolve_setting_secret(
+            self._settings, "telegram_bot_token", self._legacy_bot_token
+        )
 
     def get_capabilities(self) -> ChannelCapabilities:
         return ChannelCapabilities(

--- a/packages/prime-agent/src/talos_agent/adapters/x.py
+++ b/packages/prime-agent/src/talos_agent/adapters/x.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.config import resolve_setting_secret
 
 if TYPE_CHECKING:
     from talos_agent.browser.session import BrowserSession
@@ -63,7 +64,8 @@ class XAdapter(BaseSocialAdapter):
         if self._logged_in:
             return
 
-        if not self._settings.x_username or not self._settings.x_password:
+        password = resolve_setting_secret(self._settings, "x_password")
+        if not self._settings.x_username or not password:
             console.print("[yellow]X credentials not configured — skipping login.[/yellow]")
             return
 
@@ -115,7 +117,7 @@ class XAdapter(BaseSocialAdapter):
             await asyncio.sleep(4)
 
         await self._browser.act(
-            f"Click on the password input field and type: {self._settings.x_password}"
+            f"Click on the password input field and type: {password}"
         )
         await asyncio.sleep(1)
         await self._browser.act("Click the Log in button")

--- a/packages/prime-agent/src/talos_agent/api_client.py
+++ b/packages/prime-agent/src/talos_agent/api_client.py
@@ -17,24 +17,34 @@ class TalosAPIClient:
         self._client = httpx.AsyncClient(
             base_url=self._base,
             headers={
-                "Authorization": f"Bearer {settings.talos_api_key}",
                 "Content-Type": "application/json",
             },
             timeout=30.0,
         )
+        self._settings = settings
+
+    def _request_headers(self, supplied: dict[str, str] | None = None) -> dict[str, str]:
+        """Capture one credential for the complete retry lifecycle of a request."""
+        headers = {"Authorization": f"Bearer {self._settings.secret_value('talos_api_key')}"}
+        headers.update(supplied or {})
+        return headers
 
     # ── Retry-wrapped HTTP verbs ──────────────────────────
 
     async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
+        kwargs["headers"] = self._request_headers(kwargs.get("headers"))
         return await request_with_retry(lambda: self._client.get(url, **kwargs))
 
     async def _post(self, url: str, **kwargs: Any) -> httpx.Response:
+        kwargs["headers"] = self._request_headers(kwargs.get("headers"))
         return await request_with_retry(lambda: self._client.post(url, **kwargs))
 
     async def _put(self, url: str, **kwargs: Any) -> httpx.Response:
+        kwargs["headers"] = self._request_headers(kwargs.get("headers"))
         return await request_with_retry(lambda: self._client.put(url, **kwargs))
 
     async def _patch(self, url: str, **kwargs: Any) -> httpx.Response:
+        kwargs["headers"] = self._request_headers(kwargs.get("headers"))
         return await request_with_retry(lambda: self._client.patch(url, **kwargs))
 
     # ── Talos Config ──────────────────────────────────────
@@ -313,7 +323,7 @@ class TalosAPIClient:
 
     async def get_distribution_preview(self, talos_id: str) -> dict | None:
         """Preview dividend distribution without executing."""
-        r = await self._client.get(f"/api/talos/{talos_id}/revenue/distribute")
+        r = await self._get(f"/api/talos/{talos_id}/revenue/distribute")
         if r.status_code == 200:
             return r.json()
         return None
@@ -322,7 +332,7 @@ class TalosAPIClient:
         self, talos_id: str, *, requester_public_key: str
     ) -> dict | None:
         """Execute dividend distribution to patrons."""
-        r = await self._client.post(
+        r = await self._post(
             f"/api/talos/{talos_id}/revenue/distribute",
             json={"requesterPublicKey": requester_public_key},
         )

--- a/packages/prime-agent/src/talos_agent/cli.py
+++ b/packages/prime-agent/src/talos_agent/cli.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import asdict
 import json
 import os
+from pathlib import Path
 import sys
+import uuid
 
 import click
 from rich.console import Console
@@ -28,8 +31,6 @@ def main():
 @click.option("--env-file", default=".env", help="Path to .env file")
 def start(talos_id: str | None, env_file: str):
     """Start the Prime Agent for a Talos."""
-    from pathlib import Path
-
     ensure_app_dir()
 
     # Load .env into os.environ so child processes (Stagehand SEA) inherit them
@@ -99,6 +100,11 @@ def start(talos_id: str | None, env_file: str):
 @click.option("--openai-key", prompt="OpenAI API Key", help="OpenAI API key")
 def config(api_key: str, openai_key: str):
     """Configure agent credentials (saved to ~/.talos-agent/config.json)."""
+    if Settings().secret_rotation_enabled:
+        raise click.ClickException(
+            "plaintext config writes are disabled while secret rotation is enabled; "
+            "use `talos-agent secrets rotate`"
+        )
     ensure_app_dir()
     cfg_path = APP_DIR / "config.json"
 
@@ -197,3 +203,198 @@ def status():
     console.print(f"[bold]Pending approvals:[/bold] {len(pending)}")
 
     db.close()
+
+
+@main.group()
+@click.option(
+    "--db-path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Secret database path (defaults to the prime-agent database)",
+)
+@click.pass_context
+def secrets(ctx: click.Context, db_path: Path | None):
+    """Manage encrypted, versioned runtime secrets."""
+    from talos_agent.db import DB_PATH, LocalDB
+    from talos_agent.secret_store import SecretStore, decode_keyring
+
+    settings = Settings()
+    try:
+        db = LocalDB(
+            path=db_path or DB_PATH,
+            timeout_ms=settings.secret_db_timeout_ms,
+        )
+        store = SecretStore(
+            db,
+            keyring=decode_keyring(settings.secret_keyring),
+            active_key_id=settings.secret_active_key_id,
+            scope=settings.secret_scope,
+            max_value_bytes=settings.secret_max_bytes,
+            dual_read=settings.secret_dual_read,
+            legacy_fallback=settings.secret_legacy_fallback,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    ctx.obj = {"db": db, "store": store}
+    ctx.call_on_close(db.close)
+
+
+@secrets.command("stage")
+@click.argument("name")
+@click.option("--request-id", default=None, help="Idempotency key (generated if omitted)")
+@click.option("--actor", default="operator", show_default=True)
+@click.option("--reason", default=None, help="Lowercase audit reason code")
+@click.pass_obj
+def stage_secret(obj: dict, name: str, request_id: str | None, actor: str, reason: str | None):
+    """Prompt for and stage an encrypted value without activating it."""
+    value = click.prompt("Secret value", hide_input=True, confirmation_prompt=True)
+    try:
+        version = obj["store"].stage(
+            name,
+            value,
+            request_id=request_id or str(uuid.uuid4()),
+            actor=actor,
+            reason=reason,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=asdict(version))
+
+
+@secrets.command("activate")
+@click.argument("name")
+@click.argument("version", type=click.IntRange(min=1))
+@click.option("--expected-version", type=click.IntRange(min=1), default=None)
+@click.option("--actor", default="operator", show_default=True)
+@click.option("--reason", default=None, help="Lowercase audit reason code")
+@click.pass_obj
+def activate_secret(
+    obj: dict,
+    name: str,
+    version: int,
+    expected_version: int | None,
+    actor: str,
+    reason: str | None,
+):
+    """Atomically activate a staged version using compare-and-swap."""
+    store = obj["store"]
+    expected = expected_version if expected_version is not None else store.current_version(name)
+    try:
+        result = store.activate(
+            name,
+            version,
+            expected_active_version=expected,
+            actor=actor,
+            reason=reason,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=asdict(result))
+
+
+@secrets.command("rotate")
+@click.argument("name")
+@click.option("--request-id", default=None, help="Idempotency key (generated if omitted)")
+@click.option("--expected-version", type=click.IntRange(min=1), default=None)
+@click.option("--actor", default="operator", show_default=True)
+@click.option("--reason", default="routine_rotation", show_default=True)
+@click.pass_obj
+def rotate_secret(
+    obj: dict,
+    name: str,
+    request_id: str | None,
+    expected_version: int | None,
+    actor: str,
+    reason: str,
+):
+    """Prompt for, stage, and atomically activate a new encrypted version."""
+    store = obj["store"]
+    expected = expected_version if expected_version is not None else store.current_version(name)
+    value = click.prompt("New secret value", hide_input=True, confirmation_prompt=True)
+    try:
+        staged = store.stage(
+            name,
+            value,
+            request_id=request_id or str(uuid.uuid4()),
+            actor=actor,
+            reason=reason,
+        )
+        active = store.activate(
+            name,
+            staged.version,
+            expected_active_version=expected,
+            actor=actor,
+            reason=reason,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=asdict(active))
+
+
+@secrets.command("recover")
+@click.argument("name")
+@click.argument("version", type=click.IntRange(min=1))
+@click.option("--expected-version", type=click.IntRange(min=1), required=True)
+@click.option("--actor", default="operator", show_default=True)
+@click.option("--reason", default="credential_rejected", show_default=True)
+@click.pass_obj
+def recover_secret(
+    obj: dict,
+    name: str,
+    version: int,
+    expected_version: int,
+    actor: str,
+    reason: str,
+):
+    """Recover a prior non-revoked version with an atomic CAS."""
+    try:
+        result = obj["store"].recover(
+            name,
+            version,
+            expected_active_version=expected_version,
+            actor=actor,
+            reason=reason,
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=asdict(result))
+
+
+@secrets.command("revoke")
+@click.argument("name")
+@click.argument("version", type=click.IntRange(min=1))
+@click.option("--actor", default="operator", show_default=True)
+@click.option("--reason", default="rotation_complete", show_default=True)
+@click.pass_obj
+def revoke_secret(obj: dict, name: str, version: int, actor: str, reason: str):
+    """Permanently exclude a non-active version from runtime reads."""
+    try:
+        result = obj["store"].revoke(name, version, actor=actor, reason=reason)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=asdict(result))
+
+
+@secrets.command("list")
+@click.argument("name")
+@click.pass_obj
+def list_secrets(obj: dict, name: str):
+    """List lifecycle metadata. Ciphertext and key IDs are never displayed."""
+    try:
+        versions = obj["store"].list_versions(name)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=[asdict(version) for version in versions])
+
+
+@secrets.command("audit")
+@click.argument("name")
+@click.option("--limit", type=click.IntRange(min=1, max=500), default=50)
+@click.pass_obj
+def audit_secrets(obj: dict, name: str, limit: int):
+    """Show bounded secret lifecycle audit events."""
+    try:
+        events = obj["store"].audit_events(name, limit)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    console.print_json(data=events)

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -6,7 +6,7 @@ import json
 from decimal import Decimal
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 APP_DIR = Path.home() / ".talos-agent"
@@ -20,10 +20,13 @@ def _json_config_source() -> dict:
 
 
 class Settings(BaseSettings):
+    _secret_store: object | None = PrivateAttr(default=None)
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
+        populate_by_name=True,
     )
 
     # Talos Web API
@@ -53,15 +56,16 @@ class Settings(BaseSettings):
 
     @property
     def llm_api_key(self) -> str:
-        return self.groq_api_key or self.openai_api_key
+        groq_key = self.secret_value("groq_api_key")
+        return groq_key or self.secret_value("openai_api_key")
 
     @property
     def llm_model(self) -> str:
-        return self.groq_model if self.groq_api_key else self.openai_model
+        return self.groq_model if self.secret_value("groq_api_key") else self.openai_model
 
     @property
     def llm_base_url(self) -> str | None:
-        return "https://api.groq.com/openai/v1" if self.groq_api_key else None
+        return "https://api.groq.com/openai/v1" if self.secret_value("groq_api_key") else None
 
     # X (Twitter)
     x_username: str = ""
@@ -79,6 +83,36 @@ class Settings(BaseSettings):
     # Per-channel credential configs for additional adapters.
     # Set as JSON in env: CHANNEL_CONFIGS={"telegram": {"bot_token": "...", "chat_id": "@channel"}}
     channel_configs: dict = Field(default_factory=dict, description="Per-channel credentials map")
+    telegram_bot_token: str = ""
+    telegram_chat_id: str = ""
+
+    # Versioned encrypted secret rotation (opt-in for backward compatibility).
+    secret_rotation_enabled: bool = Field(
+        default=False, validation_alias="TALOS_SECRET_ROTATION_ENABLED"
+    )
+    secret_keyring: str = Field(default="", validation_alias="TALOS_SECRET_KEYRING")
+    secret_active_key_id: str = Field(
+        default="", validation_alias="TALOS_SECRET_ACTIVE_KEY_ID"
+    )
+    secret_scope: str = Field(default="default", validation_alias="TALOS_SECRET_SCOPE")
+    secret_dual_read: bool = Field(
+        default=True, validation_alias="TALOS_SECRET_DUAL_READ"
+    )
+    secret_legacy_fallback: bool = Field(
+        default=True, validation_alias="TALOS_SECRET_LEGACY_FALLBACK"
+    )
+    secret_max_bytes: int = Field(
+        default=65536,
+        ge=1,
+        le=1048576,
+        validation_alias="TALOS_SECRET_MAX_BYTES",
+    )
+    secret_db_timeout_ms: int = Field(
+        default=5000,
+        ge=1,
+        le=60000,
+        validation_alias="TALOS_SECRET_DB_TIMEOUT_MS",
+    )
 
     # Agent behaviour
     agent_cycle_interval: int = Field(default=30, description="Seconds between agent cycles")
@@ -98,8 +132,34 @@ class Settings(BaseSettings):
         overrides.update(kwargs)
         super().__init__(**overrides)
 
+    def bind_secret_store(self, store: object) -> None:
+        """Attach the runtime resolver after the local database is available."""
+        self._secret_store = store
+
+    def secret_value(self, name: str, legacy_value: str | None = None) -> str:
+        """Resolve a credential at point of use, preserving legacy defaults."""
+        legacy = legacy_value
+        if legacy is None:
+            value = getattr(self, name, "")
+            legacy = value if isinstance(value, str) else ""
+        if not self.secret_rotation_enabled or self._secret_store is None:
+            return legacy or ""
+        resolution = self._secret_store.resolve(name, legacy or "")
+        return resolution.value
+
 
 def ensure_app_dir() -> Path:
     APP_DIR.mkdir(parents=True, exist_ok=True)
     (APP_DIR / "logs").mkdir(exist_ok=True)
     return APP_DIR
+
+
+def resolve_setting_secret(settings: object, name: str, legacy_value: str | None = None) -> str:
+    """Resolve secrets on real Settings while remaining friendly to test doubles."""
+    resolver = getattr(type(settings), "secret_value", None)
+    if callable(resolver):
+        return resolver(settings, name, legacy_value)
+    if legacy_value is not None:
+        return legacy_value
+    value = getattr(settings, name, "")
+    return value if isinstance(value, str) else ""

--- a/packages/prime-agent/src/talos_agent/db.py
+++ b/packages/prime-agent/src/talos_agent/db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -211,17 +212,71 @@ CREATE TABLE IF NOT EXISTS retry_state (
 );
         """,
     ),
+    (
+        7,
+        """
+CREATE TABLE IF NOT EXISTS secret_versions (
+    scope           TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    version         INTEGER NOT NULL,
+    ciphertext      TEXT NOT NULL,
+    key_id          TEXT NOT NULL,
+    status          TEXT NOT NULL CHECK (status IN ('staged', 'active', 'superseded', 'revoked')),
+    request_id      TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    activated_at    TEXT,
+    revoked_at      TEXT,
+    PRIMARY KEY (scope, name, version),
+    UNIQUE (scope, name, request_id)
+);
+
+CREATE TABLE IF NOT EXISTS secret_heads (
+    scope             TEXT NOT NULL,
+    name              TEXT NOT NULL,
+    active_version    INTEGER NOT NULL,
+    previous_version  INTEGER,
+    generation        INTEGER NOT NULL DEFAULT 1,
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (scope, name)
+);
+
+CREATE TABLE IF NOT EXISTS secret_audit_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id    TEXT NOT NULL UNIQUE,
+    scope       TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    version     INTEGER,
+    event_type  TEXT NOT NULL,
+    outcome     TEXT NOT NULL,
+    actor       TEXT NOT NULL,
+    reason      TEXT,
+    metadata    TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_versions_status
+    ON secret_versions(scope, name, status);
+CREATE INDEX IF NOT EXISTS idx_secret_audit_lookup
+    ON secret_audit_events(scope, name, id);
+        """,
+    ),
 ]
 
 
 class LocalDB:
-    def __init__(self, path: Path = DB_PATH):
+    def __init__(self, path: Path = DB_PATH, *, timeout_ms: int = 5000):
         self._path = path
         path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(path))
+        self._conn = sqlite3.connect(str(path), timeout=max(timeout_ms, 1) / 1000)
         self._conn.row_factory = sqlite3.Row
+        self._conn.execute(f"PRAGMA busy_timeout = {max(timeout_ms, 1)}")
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._run_migrations()
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            # Some platforms/filesystems do not expose POSIX permissions.
+            pass
 
     def _run_migrations(self) -> None:
         """Run all pending migrations in a single transaction."""

--- a/packages/prime-agent/src/talos_agent/scheduler.py
+++ b/packages/prime-agent/src/talos_agent/scheduler.py
@@ -377,7 +377,23 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
     from talos_agent.api_client import TalosAPIClient
     from talos_agent.db import LocalDB, get_db_path
 
-    db = LocalDB(path=get_db_path(settings.talos_api_key[:16] if agent_slot > 0 else None))
+    db = LocalDB(
+        path=get_db_path(settings.talos_api_key[:16] if agent_slot > 0 else None),
+        timeout_ms=settings.secret_db_timeout_ms,
+    )
+    if settings.secret_rotation_enabled:
+        from talos_agent.secret_store import SecretStore, decode_keyring
+
+        secret_store = SecretStore(
+            db,
+            keyring=decode_keyring(settings.secret_keyring),
+            active_key_id=settings.secret_active_key_id,
+            scope=settings.secret_scope,
+            max_value_bytes=settings.secret_max_bytes,
+            dual_read=settings.secret_dual_read,
+            legacy_fallback=settings.secret_legacy_fallback,
+        )
+        settings.bind_secret_store(secret_store)
     api = TalosAPIClient(settings)
 
     # Download Talos config
@@ -408,7 +424,8 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
 
     # Start browser session
     console.print("[bold]Starting browser session...[/bold]")
-    browser = await BrowserSession.start(model_api_key=settings.llm_api_key)
+    browser_model_key = settings.llm_api_key
+    browser = await BrowserSession.start(model_api_key=browser_model_key)
     console.print("[green]Browser ready.[/green]")
 
     # Build tools
@@ -426,8 +443,45 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
 
     async def ensure_browser_healthy() -> bool:
         """Checks browser health, attempts automatic recovery, and updates tools reference."""
-        nonlocal browser, tools, browser_restart_attempts, is_degraded
-        
+        nonlocal browser, tools, browser_model_key, browser_restart_attempts, is_degraded
+
+        current_model_key = settings.llm_api_key
+        if current_model_key != browser_model_key:
+            # Start the replacement before swapping references. A failed
+            # credential never tears down the still-working browser session.
+            try:
+                replacement = await BrowserSession.start(model_api_key=current_model_key)
+                replacement_tools = build_all_tools(
+                    api=api,
+                    db=db,
+                    browser=replacement,
+                    settings=settings,
+                )
+                previous = browser
+                browser = replacement
+                tools = replacement_tools
+                browser_model_key = current_model_key
+                browser_restart_attempts = 0
+                is_degraded = False
+                log.info(
+                    "secret_consumer_reloaded",
+                    consumer="browser",
+                    secret_name="llm_api_key",
+                    outcome="success",
+                )
+                try:
+                    await asyncio.wait_for(previous.close(), timeout=5)
+                except Exception:
+                    pass
+            except Exception as exc:
+                log.warning(
+                    "secret_consumer_reload_failed",
+                    consumer="browser",
+                    secret_name="llm_api_key",
+                    outcome="failure",
+                    error_type=type(exc).__name__,
+                )
+
         if is_degraded:
             return False
 
@@ -454,7 +508,8 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                     except Exception:
                         pass
                 
-                browser = await BrowserSession.start(model_api_key=settings.llm_api_key)
+                browser_model_key = settings.llm_api_key
+                browser = await BrowserSession.start(model_api_key=browser_model_key)
                 tools = build_all_tools(api=api, db=db, browser=browser, settings=settings)
                 
                 console.print(f"[bold green]Browser reconnection event logged successfully on attempt {browser_restart_attempts}.[/bold green]")

--- a/packages/prime-agent/src/talos_agent/secret_store.py
+++ b/packages/prime-agent/src/talos_agent/secret_store.py
@@ -1,0 +1,606 @@
+"""Versioned encrypted secret storage with transactional activation.
+
+Plaintext exists only in caller memory and is never persisted or included in
+logs/audit events. SQLite transactions provide cross-process compare-and-swap
+semantics; no correctness decision relies on process-local state.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from typing import Mapping
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from talos_agent.observability import log
+
+_ENVELOPE_PREFIX = "TALOS-SECRET::1::"
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_REASON_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_MAX_HARD_LIMIT = 1024 * 1024
+_ACTIVATABLE = {"staged", "superseded"}
+
+
+class SecretStoreError(Exception):
+    """Base class for errors safe to report without sensitive context."""
+
+
+class SecretConfigurationError(SecretStoreError):
+    pass
+
+
+class SecretValidationError(SecretStoreError):
+    pass
+
+
+class SecretNotFoundError(SecretStoreError):
+    pass
+
+
+class SecretConflictError(SecretStoreError):
+    pass
+
+
+class SecretBusyError(SecretStoreError):
+    pass
+
+
+class SecretDecryptionError(SecretStoreError):
+    pass
+
+
+class ActiveSecretRevocationError(SecretStoreError):
+    pass
+
+
+@dataclass(frozen=True)
+class SecretVersion:
+    name: str
+    version: int
+    status: str
+    created_at: str
+    activated_at: str | None
+    revoked_at: str | None
+
+
+@dataclass(frozen=True)
+class SecretResolution:
+    value: str
+    source: str
+    version: int | None = None
+
+
+def decode_keyring(raw: str | Mapping[str, str]) -> dict[str, bytes]:
+    """Decode and validate a key-id -> URL-safe-base64 AES-256 key mapping."""
+    if isinstance(raw, str):
+        if not raw.strip():
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SecretConfigurationError("TALOS_SECRET_KEYRING must be valid JSON") from exc
+    else:
+        parsed = dict(raw)
+    if not isinstance(parsed, dict) or len(parsed) > 32:
+        raise SecretConfigurationError("secret keyring must be an object with at most 32 keys")
+
+    result: dict[str, bytes] = {}
+    for key_id, encoded in parsed.items():
+        if not isinstance(key_id, str) or not _NAME_RE.fullmatch(key_id):
+            raise SecretConfigurationError("secret key IDs must use lowercase safe identifiers")
+        if not isinstance(encoded, str) or len(encoded) > 128:
+            raise SecretConfigurationError("keyring contains an invalid encoded key")
+        try:
+            padded = encoded + "=" * (-len(encoded) % 4)
+            key = base64.urlsafe_b64decode(padded.encode("ascii"))
+        except (ValueError, UnicodeEncodeError, binascii.Error) as exc:
+            raise SecretConfigurationError("keyring contains invalid base64") from exc
+        if len(key) != 32:
+            raise SecretConfigurationError("every keyring key must contain exactly 32 bytes")
+        result[key_id] = key
+    return result
+
+
+class SecretStore:
+    """Encrypted versions and atomic lifecycle transitions for one scope."""
+
+    def __init__(
+        self,
+        db,
+        *,
+        keyring: Mapping[str, bytes],
+        active_key_id: str,
+        scope: str = "default",
+        max_value_bytes: int = 65536,
+        dual_read: bool = True,
+        legacy_fallback: bool = True,
+    ) -> None:
+        self._db = db
+        self._conn: sqlite3.Connection = db._conn
+        self._keyring = dict(keyring)
+        self._active_key_id = active_key_id
+        self._scope = self._validate_identifier(scope, "scope")
+        self._max_value_bytes = min(max(max_value_bytes, 1), _MAX_HARD_LIMIT)
+        self._dual_read = dual_read
+        self._legacy_fallback = legacy_fallback
+        if active_key_id not in self._keyring:
+            raise SecretConfigurationError("active secret key ID is missing from the keyring")
+
+    @staticmethod
+    def _validate_identifier(value: str, label: str) -> str:
+        if not isinstance(value, str) or not _NAME_RE.fullmatch(value):
+            raise SecretValidationError(
+                f"{label} must match {_NAME_RE.pattern} and be at most 128 characters"
+            )
+        return value
+
+    def _validate_value(self, value: str) -> bytes:
+        if not isinstance(value, str):
+            raise SecretValidationError("secret value must be a string")
+        encoded = value.encode("utf-8")
+        if not encoded:
+            raise SecretValidationError("secret value cannot be empty")
+        if len(encoded) > self._max_value_bytes:
+            raise SecretValidationError(
+                f"secret value exceeds configured {self._max_value_bytes}-byte limit"
+            )
+        return encoded
+
+    def _aad(self, name: str, version: int, key_id: str) -> bytes:
+        return json.dumps(
+            {
+                "format": 1,
+                "scope": self._scope,
+                "name": name,
+                "version": version,
+                "key_id": key_id,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def _encrypt(self, name: str, version: int, plaintext: bytes) -> str:
+        import os
+
+        nonce = os.urandom(12)
+        key = self._keyring[self._active_key_id]
+        ciphertext = AESGCM(key).encrypt(
+            nonce, plaintext, self._aad(name, version, self._active_key_id)
+        )
+        return _ENVELOPE_PREFIX + base64.urlsafe_b64encode(nonce + ciphertext).decode("ascii")
+
+    def _decrypt(self, row: sqlite3.Row) -> str:
+        key_id = row["key_id"]
+        key = self._keyring.get(key_id)
+        if key is None:
+            raise SecretDecryptionError("encryption key is unavailable")
+        envelope = row["ciphertext"]
+        if not isinstance(envelope, str) or not envelope.startswith(_ENVELOPE_PREFIX):
+            raise SecretDecryptionError("unsupported encrypted envelope")
+        try:
+            raw = base64.b64decode(
+                envelope[len(_ENVELOPE_PREFIX):],
+                altchars=b"-_",
+                validate=True,
+            )
+            if len(raw) < 12 + 16:
+                raise ValueError("short envelope")
+            plaintext = AESGCM(key).decrypt(
+                raw[:12],
+                raw[12:],
+                self._aad(row["name"], row["version"], key_id),
+            )
+            return plaintext.decode("utf-8")
+        except Exception as exc:
+            raise SecretDecryptionError("secret envelope authentication failed") from exc
+
+    def _audit(
+        self,
+        *,
+        name: str,
+        version: int | None,
+        event_type: str,
+        outcome: str,
+        actor: str,
+        reason: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        if not _REQUEST_ID_RE.fullmatch(actor):
+            raise SecretValidationError("actor must be a safe identifier of at most 128 characters")
+        if reason is not None and not _REASON_RE.fullmatch(reason):
+            raise SecretValidationError("reason must be a lowercase reason code of at most 64 characters")
+        safe_metadata = json.dumps(dict(metadata or {}), sort_keys=True)
+        if len(safe_metadata.encode("utf-8")) > 2048:
+            raise SecretValidationError("audit metadata exceeds 2048-byte limit")
+        self._conn.execute(
+            """
+            INSERT INTO secret_audit_events
+                (event_id, scope, name, version, event_type, outcome, actor, reason, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                self._scope,
+                name,
+                version,
+                event_type,
+                outcome,
+                actor,
+                reason,
+                safe_metadata,
+            ),
+        )
+
+    def _transition_log(
+        self, name: str, version: int | None, transition: str, outcome: str, error: Exception | None = None
+    ) -> None:
+        fields = {
+            "scope": self._scope,
+            "secret_name": name,
+            "secret_version": version,
+            "transition": transition,
+            "outcome": outcome,
+        }
+        try:
+            if error is not None:
+                fields["error_type"] = type(error).__name__
+                log.warning("secret_rotation_transition", **fields)
+            else:
+                log.info("secret_rotation_transition", **fields)
+        except Exception:
+            # Logging must never change a committed secret transition.
+            pass
+
+    def stage(
+        self,
+        name: str,
+        value: str,
+        *,
+        request_id: str,
+        actor: str = "operator",
+        reason: str | None = None,
+    ) -> SecretVersion:
+        """Persist one encrypted staged version; duplicate request IDs are idempotent."""
+        name = self._validate_identifier(name, "secret name")
+        plaintext = self._validate_value(value)
+        if not isinstance(request_id, str) or not _REQUEST_ID_RE.fullmatch(request_id):
+            raise SecretValidationError("request ID must be a safe identifier of at most 128 characters")
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            existing = self._conn.execute(
+                """
+                SELECT name, version, status, created_at, activated_at, revoked_at
+                FROM secret_versions WHERE scope = ? AND name = ? AND request_id = ?
+                """,
+                (self._scope, name, request_id),
+            ).fetchone()
+            if existing:
+                self._conn.commit()
+                return SecretVersion(**dict(existing))
+            row = self._conn.execute(
+                "SELECT COALESCE(MAX(version), 0) + 1 AS version "
+                "FROM secret_versions WHERE scope = ? AND name = ?",
+                (self._scope, name),
+            ).fetchone()
+            version = int(row["version"])
+            ciphertext = self._encrypt(name, version, plaintext)
+            self._conn.execute(
+                """
+                INSERT INTO secret_versions
+                    (scope, name, version, ciphertext, key_id, status, request_id)
+                VALUES (?, ?, ?, ?, ?, 'staged', ?)
+                """,
+                (self._scope, name, version, ciphertext, self._active_key_id, request_id),
+            )
+            self._audit(
+                name=name,
+                version=version,
+                event_type="staged",
+                outcome="success",
+                actor=actor,
+                reason=reason,
+            )
+            result_row = self._conn.execute(
+                """
+                SELECT name, version, status, created_at, activated_at, revoked_at
+                FROM secret_versions WHERE scope = ? AND name = ? AND version = ?
+                """,
+                (self._scope, name, version),
+            ).fetchone()
+            self._conn.commit()
+            result = SecretVersion(**dict(result_row))
+            self._transition_log(name, version, "stage", "success")
+            return result
+        except Exception as exc:
+            self._conn.rollback()
+            self._transition_log(name, None, "stage", "failure", exc)
+            if isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower():
+                raise SecretBusyError("secret store is busy; retry the idempotent operation") from exc
+            raise
+
+    def current_version(self, name: str) -> int | None:
+        name = self._validate_identifier(name, "secret name")
+        row = self._conn.execute(
+            "SELECT active_version FROM secret_heads WHERE scope = ? AND name = ?",
+            (self._scope, name),
+        ).fetchone()
+        return int(row["active_version"]) if row else None
+
+    def activate(
+        self,
+        name: str,
+        version: int,
+        *,
+        expected_active_version: int | None,
+        actor: str = "operator",
+        reason: str | None = None,
+        event_type: str = "activated",
+    ) -> SecretVersion:
+        """Atomically activate a version if the caller's head is still current."""
+        name = self._validate_identifier(name, "secret name")
+        if version < 1:
+            raise SecretValidationError("version must be positive")
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            head = self._conn.execute(
+                "SELECT active_version, generation FROM secret_heads WHERE scope = ? AND name = ?",
+                (self._scope, name),
+            ).fetchone()
+            actual = int(head["active_version"]) if head else None
+            if actual == version:
+                self._conn.commit()
+                row = self._get_version_row(name, version)
+                return self._public_version(row)
+            if actual != expected_active_version:
+                raise SecretConflictError(
+                    f"active version changed: expected {expected_active_version}, found {actual}"
+                )
+            target = self._get_version_row(name, version)
+            if target["status"] not in _ACTIVATABLE:
+                raise SecretConflictError(
+                    f"version {version} cannot be activated from state {target['status']}"
+                )
+            # Prove the target can be decrypted before changing the head.
+            self._decrypt(target)
+            if actual is not None:
+                self._conn.execute(
+                    """
+                    UPDATE secret_versions SET status = 'superseded'
+                    WHERE scope = ? AND name = ? AND version = ? AND status = 'active'
+                    """,
+                    (self._scope, name, actual),
+                )
+            self._conn.execute(
+                """
+                UPDATE secret_versions
+                SET status = 'active', activated_at = datetime('now'), revoked_at = NULL
+                WHERE scope = ? AND name = ? AND version = ?
+                """,
+                (self._scope, name, version),
+            )
+            if head:
+                self._conn.execute(
+                    """
+                    UPDATE secret_heads
+                    SET active_version = ?, previous_version = ?, generation = generation + 1,
+                        updated_at = datetime('now')
+                    WHERE scope = ? AND name = ?
+                    """,
+                    (version, actual, self._scope, name),
+                )
+            else:
+                self._conn.execute(
+                    """
+                    INSERT INTO secret_heads (scope, name, active_version, previous_version)
+                    VALUES (?, ?, ?, NULL)
+                    """,
+                    (self._scope, name, version),
+                )
+            self._audit(
+                name=name,
+                version=version,
+                event_type=event_type,
+                outcome="success",
+                actor=actor,
+                reason=reason,
+                metadata={"previous_version": actual},
+            )
+            row = self._get_version_row(name, version)
+            self._conn.commit()
+            result = self._public_version(row)
+            self._transition_log(name, version, event_type, "success")
+            return result
+        except Exception as exc:
+            self._conn.rollback()
+            self._transition_log(name, version, event_type, "failure", exc)
+            if isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower():
+                raise SecretBusyError("secret store is busy; retry the idempotent operation") from exc
+            raise
+
+    def recover(
+        self,
+        name: str,
+        version: int,
+        *,
+        expected_active_version: int,
+        actor: str = "operator",
+        reason: str | None = None,
+    ) -> SecretVersion:
+        return self.activate(
+            name,
+            version,
+            expected_active_version=expected_active_version,
+            actor=actor,
+            reason=reason,
+            event_type="recovered",
+        )
+
+    def revoke(
+        self,
+        name: str,
+        version: int,
+        *,
+        actor: str = "operator",
+        reason: str | None = None,
+    ) -> SecretVersion:
+        """Revoke a non-active version. Active revocation is deliberately rejected."""
+        name = self._validate_identifier(name, "secret name")
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            row = self._get_version_row(name, version)
+            if row["status"] == "revoked":
+                self._conn.commit()
+                return self._public_version(row)
+            head = self._conn.execute(
+                "SELECT active_version FROM secret_heads WHERE scope = ? AND name = ?",
+                (self._scope, name),
+            ).fetchone()
+            if head and int(head["active_version"]) == version:
+                raise ActiveSecretRevocationError(
+                    "cannot revoke the active version; activate or recover another version first"
+                )
+            self._conn.execute(
+                """
+                UPDATE secret_versions
+                SET status = 'revoked', revoked_at = datetime('now')
+                WHERE scope = ? AND name = ? AND version = ?
+                """,
+                (self._scope, name, version),
+            )
+            self._conn.execute(
+                """
+                UPDATE secret_heads SET previous_version = NULL, updated_at = datetime('now')
+                WHERE scope = ? AND name = ? AND previous_version = ?
+                """,
+                (self._scope, name, version),
+            )
+            self._audit(
+                name=name,
+                version=version,
+                event_type="revoked",
+                outcome="success",
+                actor=actor,
+                reason=reason,
+            )
+            updated = self._get_version_row(name, version)
+            self._conn.commit()
+            result = self._public_version(updated)
+            self._transition_log(name, version, "revoke", "success")
+            return result
+        except Exception as exc:
+            self._conn.rollback()
+            self._transition_log(name, version, "revoke", "failure", exc)
+            if isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower():
+                raise SecretBusyError("secret store is busy; retry the idempotent operation") from exc
+            raise
+
+    def _get_version_row(self, name: str, version: int) -> sqlite3.Row:
+        row = self._conn.execute(
+            """
+            SELECT name, version, status, created_at, activated_at, revoked_at,
+                   ciphertext, key_id
+            FROM secret_versions WHERE scope = ? AND name = ? AND version = ?
+            """,
+            (self._scope, name, version),
+        ).fetchone()
+        if not row:
+            raise SecretNotFoundError(f"secret version {version} does not exist")
+        return row
+
+    @staticmethod
+    def _public_version(row: sqlite3.Row) -> SecretVersion:
+        return SecretVersion(
+            name=row["name"],
+            version=int(row["version"]),
+            status=row["status"],
+            created_at=row["created_at"],
+            activated_at=row["activated_at"],
+            revoked_at=row["revoked_at"],
+        )
+
+    def resolve(self, name: str, legacy_value: str = "") -> SecretResolution:
+        """Resolve active -> previous -> legacy according to rollout configuration."""
+        name = self._validate_identifier(name, "secret name")
+        head = self._conn.execute(
+            """
+            SELECT active_version, previous_version
+            FROM secret_heads WHERE scope = ? AND name = ?
+            """,
+            (self._scope, name),
+        ).fetchone()
+        candidates: list[tuple[str, int]] = []
+        if head:
+            candidates.append(("active", int(head["active_version"])))
+            if self._dual_read and head["previous_version"] is not None:
+                candidates.append(("previous", int(head["previous_version"])))
+
+        last_error: Exception | None = None
+        for source, version in candidates:
+            try:
+                row = self._get_version_row(name, version)
+                if row["status"] == "revoked":
+                    continue
+                return SecretResolution(self._decrypt(row), source, version)
+            except (SecretNotFoundError, SecretDecryptionError) as exc:
+                last_error = exc
+                log.warning(
+                    "secret_resolution",
+                    scope=self._scope,
+                    secret_name=name,
+                    secret_version=version,
+                    source=source,
+                    outcome="fallback",
+                    error_type=type(exc).__name__,
+                )
+        if self._legacy_fallback and legacy_value:
+            return SecretResolution(legacy_value, "legacy", None)
+        if last_error:
+            raise last_error
+        raise SecretNotFoundError(f"no active value for secret {name!r}")
+
+    def list_versions(self, name: str) -> list[SecretVersion]:
+        name = self._validate_identifier(name, "secret name")
+        rows = self._conn.execute(
+            """
+            SELECT name, version, status, created_at, activated_at, revoked_at
+            FROM secret_versions WHERE scope = ? AND name = ? ORDER BY version DESC
+            """,
+            (self._scope, name),
+        ).fetchall()
+        return [SecretVersion(**dict(row)) for row in rows]
+
+    def audit_events(self, name: str, limit: int = 50) -> list[dict]:
+        name = self._validate_identifier(name, "secret name")
+        bounded_limit = min(max(limit, 1), 500)
+        rows = self._conn.execute(
+            """
+            SELECT event_id, name, version, event_type, outcome, actor, reason, metadata, created_at
+            FROM secret_audit_events
+            WHERE scope = ? AND name = ? ORDER BY id DESC LIMIT ?
+            """,
+            (self._scope, name, bounded_limit),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+__all__ = [
+    "ActiveSecretRevocationError",
+    "SecretConfigurationError",
+    "SecretBusyError",
+    "SecretConflictError",
+    "SecretDecryptionError",
+    "SecretNotFoundError",
+    "SecretResolution",
+    "SecretStore",
+    "SecretStoreError",
+    "SecretValidationError",
+    "SecretVersion",
+    "decode_keyring",
+]

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -6,7 +6,7 @@ import inspect
 from dataclasses import dataclass, field
 from typing import Any, Callable, get_type_hints
 
-from talos_agent.config import Settings
+from talos_agent.config import Settings, resolve_setting_secret
 
 
 @dataclass
@@ -152,7 +152,10 @@ def build_all_tools(
 
     adapter_registry = AdapterRegistry()
     adapter_registry.register(XAdapter(browser, settings))
-    if settings.discord_webhook_url or settings.discord_bot_token:
+    if (
+        resolve_setting_secret(settings, "discord_webhook_url")
+        or resolve_setting_secret(settings, "discord_bot_token")
+    ):
         adapter_registry.register(DiscordAdapter(settings))
 
     # Inject dependencies into tool modules

--- a/packages/prime-agent/tests/test_adapter_health.py
+++ b/packages/prime-agent/tests/test_adapter_health.py
@@ -14,13 +14,11 @@ AdapterState:   _worst() ordering
 from __future__ import annotations
 
 import asyncio
-import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from talos_agent.adapters.health import (
-    PROBE_TIMEOUT_SECONDS,
     AdapterHealthReporter,
     AdapterState,
     BrowserSessionProbe,
@@ -401,8 +399,6 @@ class TestAdapterHealthReporter:
         reporter = AdapterHealthReporter(registry, timeout=0.05)
 
         # Monkey-patch the probe for "x" to a hanging one
-        original_report = reporter.report
-
         async def patched_report():
             reporter._registry._adapters["x"] = x_adapter
             # Replace probe resolution inside reporter

--- a/packages/prime-agent/tests/test_migration.py
+++ b/packages/prime-agent/tests/test_migration.py
@@ -142,3 +142,33 @@ def test_transaction_safety(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert cursor.fetchone() is None
 
     conn.close()
+
+
+def test_secret_rotation_upgrade_from_version_6_preserves_existing_data(tmp_path: Path):
+    """Migration 7 adds secret tables without rewriting legacy agent state."""
+    db_file = tmp_path / "secret-upgrade.db"
+    db = LocalDB(path=db_file)
+    db._conn.execute(
+        "INSERT INTO talos_config (key, value) VALUES ('name', 'legacy-agent')"
+    )
+    db._conn.execute("DROP TABLE secret_audit_events")
+    db._conn.execute("DROP TABLE secret_heads")
+    db._conn.execute("DROP TABLE secret_versions")
+    db._conn.execute("PRAGMA user_version = 6")
+    db._conn.commit()
+    db.close()
+
+    upgraded = LocalDB(path=db_file)
+    tables = {
+        row[0]
+        for row in upgraded._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+
+    assert {"secret_versions", "secret_heads", "secret_audit_events"} <= tables
+    assert upgraded._conn.execute(
+        "SELECT value FROM talos_config WHERE key = 'name'"
+    ).fetchone()[0] == "legacy-agent"
+    assert upgraded._conn.execute("PRAGMA user_version").fetchone()[0] == 7
+    upgraded.close()

--- a/packages/prime-agent/tests/test_secret_rotation_integration.py
+++ b/packages/prime-agent/tests/test_secret_rotation_integration.py
@@ -1,0 +1,45 @@
+"""Real module-boundary checks for live API credential rotation."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from talos_agent.api_client import TalosAPIClient
+from talos_agent.secret_store import SecretStore
+
+
+@pytest.mark.asyncio
+async def test_api_client_observes_atomic_rotation_without_recreation(mock_db, mock_settings):
+    store = SecretStore(
+        mock_db,
+        keyring={"primary": b"k" * 32},
+        active_key_id="primary",
+        scope="integration",
+    )
+    first = store.stage("talos_api_key", "rotated-one", request_id="one")
+    store.activate("talos_api_key", first.version, expected_active_version=None)
+    mock_settings.secret_rotation_enabled = True
+    mock_settings.bind_secret_store(store)
+    client = TalosAPIClient(mock_settings)
+
+    seen: list[str] = []
+
+    def handler(request):
+        seen.append(request.headers["Authorization"])
+        return Response(200, json={"id": "test-talos-id"})
+
+    with respx.mock:
+        respx.get("http://test.local/api/talos/me").mock(side_effect=handler)
+        await client.get_talos_me()
+        second = store.stage("talos_api_key", "rotated-two", request_id="two")
+        store.activate(
+            "talos_api_key",
+            second.version,
+            expected_active_version=first.version,
+        )
+        await client.get_talos_me()
+
+    await client.close()
+    assert seen == ["Bearer rotated-one", "Bearer rotated-two"]

--- a/packages/prime-agent/tests/test_secret_store.py
+++ b/packages/prime-agent/tests/test_secret_store.py
@@ -1,0 +1,303 @@
+"""Security, lifecycle, concurrency, and recovery tests for encrypted secrets."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from talos_agent.cli import main
+from talos_agent.db import LocalDB
+from talos_agent.secret_store import (
+    ActiveSecretRevocationError,
+    SecretBusyError,
+    SecretConflictError,
+    SecretDecryptionError,
+    SecretStore,
+    SecretValidationError,
+    decode_keyring,
+)
+
+
+def _key(byte: int) -> bytes:
+    return bytes([byte]) * 32
+
+
+def _store(
+    db: LocalDB,
+    *,
+    keyring: dict[str, bytes] | None = None,
+    active_key_id: str = "primary",
+    dual_read: bool = True,
+    legacy_fallback: bool = True,
+    max_value_bytes: int = 65536,
+) -> SecretStore:
+    return SecretStore(
+        db,
+        keyring=keyring or {"primary": _key(1)},
+        active_key_id=active_key_id,
+        scope="test",
+        dual_read=dual_read,
+        legacy_fallback=legacy_fallback,
+        max_value_bytes=max_value_bytes,
+    )
+
+
+def _stage_activate(
+    store: SecretStore, name: str, value: str, request_id: str
+) -> int:
+    expected = store.current_version(name)
+    staged = store.stage(name, value, request_id=request_id)
+    store.activate(name, staged.version, expected_active_version=expected)
+    return staged.version
+
+
+def test_keyring_decoding_requires_exactly_32_bytes():
+    encoded = base64.urlsafe_b64encode(_key(9)).decode().rstrip("=")
+    assert decode_keyring(f'{{"primary":"{encoded}"}}') == {"primary": _key(9)}
+
+    short = base64.urlsafe_b64encode(b"short").decode()
+    with pytest.raises(Exception, match="exactly 32 bytes"):
+        decode_keyring(f'{{"primary":"{short}"}}')
+
+
+def test_plaintext_is_never_persisted_and_audit_is_redacted(mock_db: LocalDB):
+    store = _store(mock_db)
+    plaintext = "super-secret-provider-token"
+
+    version = _stage_activate(store, "provider.api_key", plaintext, "request-1")
+
+    row = mock_db._conn.execute(
+        "SELECT ciphertext, key_id FROM secret_versions WHERE version = ?", (version,)
+    ).fetchone()
+    assert plaintext not in row["ciphertext"]
+    assert row["ciphertext"].startswith("TALOS-SECRET::1::")
+
+    audit_rows = mock_db._conn.execute(
+        """
+        SELECT event_id, scope, name, version, event_type, outcome, actor, reason, metadata
+        FROM secret_audit_events
+        """
+    ).fetchall()
+    persisted = json.dumps([dict(row) for row in audit_rows], sort_keys=True)
+    assert plaintext not in persisted
+    assert row["ciphertext"] not in persisted
+    assert row["key_id"] not in persisted
+
+
+def test_duplicate_stage_delivery_is_idempotent(mock_db: LocalDB):
+    store = _store(mock_db)
+    first = store.stage("openai_api_key", "value-one", request_id="same-request")
+    duplicate = store.stage("openai_api_key", "ignored-retry-value", request_id="same-request")
+
+    assert duplicate.version == first.version
+    assert len(store.list_versions("openai_api_key")) == 1
+    store.activate("openai_api_key", first.version, expected_active_version=None)
+    assert store.resolve("openai_api_key").value == "value-one"
+
+
+def test_atomic_activation_rejects_stale_concurrent_operator(tmp_path: Path):
+    path = tmp_path / "shared.db"
+    db_a = LocalDB(path=path)
+    db_b = LocalDB(path=path)
+    store_a = _store(db_a)
+    store_b = _store(db_b)
+    first = store_a.stage("talos_api_key", "one", request_id="first")
+    second = store_b.stage("talos_api_key", "two", request_id="second")
+
+    store_a.activate("talos_api_key", first.version, expected_active_version=None)
+    with pytest.raises(SecretConflictError, match="expected None, found 1"):
+        store_b.activate("talos_api_key", second.version, expected_active_version=None)
+
+    assert store_b.resolve("talos_api_key").value == "one"
+    db_a.close()
+    db_b.close()
+
+
+def test_dual_read_falls_back_to_previous_on_corrupt_active(mock_db: LocalDB):
+    store = _store(mock_db)
+    old_version = _stage_activate(store, "groq_api_key", "old-key", "old")
+    new_version = _stage_activate(store, "groq_api_key", "new-key", "new")
+    mock_db._conn.execute(
+        "UPDATE secret_versions SET ciphertext = ? WHERE scope = 'test' AND name = ? AND version = ?",
+        ("TALOS-SECRET::1::broken", "groq_api_key", new_version),
+    )
+    mock_db._conn.commit()
+
+    resolved = store.resolve("groq_api_key")
+
+    assert resolved.value == "old-key"
+    assert resolved.source == "previous"
+    assert resolved.version == old_version
+
+
+def test_missing_decryption_key_uses_legacy_only_when_enabled(tmp_path: Path):
+    path = tmp_path / "keys.db"
+    db = LocalDB(path=path)
+    original = _store(db)
+    _stage_activate(original, "discord_bot_token", "encrypted", "original")
+
+    replacement = _store(
+        db,
+        keyring={"replacement": _key(2)},
+        active_key_id="replacement",
+        legacy_fallback=True,
+    )
+    assert replacement.resolve("discord_bot_token", "legacy").value == "legacy"
+
+    strict = _store(
+        db,
+        keyring={"replacement": _key(2)},
+        active_key_id="replacement",
+        legacy_fallback=False,
+    )
+    with pytest.raises(SecretDecryptionError):
+        strict.resolve("discord_bot_token", "legacy")
+    db.close()
+
+
+def test_revoke_active_rejected_then_old_version_can_be_revoked(mock_db: LocalDB):
+    store = _store(mock_db)
+    first = _stage_activate(store, "x_password", "old-password", "old")
+    second = _stage_activate(store, "x_password", "new-password", "new")
+
+    with pytest.raises(ActiveSecretRevocationError):
+        store.revoke("x_password", second)
+    revoked = store.revoke("x_password", first)
+
+    assert revoked.status == "revoked"
+    assert store.resolve("x_password").value == "new-password"
+
+
+def test_recovery_is_atomic_and_survives_restart(tmp_path: Path):
+    path = tmp_path / "recovery.db"
+    db = LocalDB(path=path)
+    store = _store(db)
+    first = _stage_activate(store, "wallet.secret_key", "wallet-old", "wallet-old")
+    second = _stage_activate(store, "wallet.secret_key", "wallet-bad", "wallet-new")
+
+    recovered = store.recover(
+        "wallet.secret_key",
+        first,
+        expected_active_version=second,
+        reason="credential_rejected",
+    )
+    assert recovered.status == "active"
+    db.close()
+
+    reopened = LocalDB(path=path)
+    assert _store(reopened).resolve("wallet.secret_key").value == "wallet-old"
+    reopened.close()
+
+
+def test_failed_stage_rolls_back_without_partial_row(mock_db: LocalDB, monkeypatch):
+    store = _store(mock_db)
+
+    def fail_encrypt(*args, **kwargs):
+        raise RuntimeError("simulated encryption failure")
+
+    monkeypatch.setattr(store, "_encrypt", fail_encrypt)
+    with pytest.raises(RuntimeError, match="simulated"):
+        store.stage("provider.api_key", "never-persist", request_id="failure")
+
+    count = mock_db._conn.execute("SELECT COUNT(*) FROM secret_versions").fetchone()[0]
+    assert count == 0
+
+
+def test_input_boundaries_are_enforced(mock_db: LocalDB):
+    store = _store(mock_db, max_value_bytes=8)
+
+    with pytest.raises(SecretValidationError, match="secret name"):
+        store.stage("../escape", "value", request_id="request")
+    with pytest.raises(SecretValidationError, match="cannot be empty"):
+        store.stage("valid_name", "", request_id="request")
+    with pytest.raises(SecretValidationError, match="byte limit"):
+        store.stage("valid_name", "123456789", request_id="request")
+    with pytest.raises(SecretValidationError, match="request ID"):
+        store.stage("valid_name", "value", request_id="contains whitespace")
+    with pytest.raises(SecretValidationError, match="actor"):
+        store.stage("valid_name", "value", request_id="request", actor="bad actor")
+
+
+def test_authenticated_metadata_prevents_ciphertext_row_swapping(mock_db: LocalDB):
+    store = _store(mock_db, legacy_fallback=False)
+    source = store.stage("provider.first", "first-value", request_id="first")
+    target = store.stage("provider.second", "second-value", request_id="second")
+    source_row = mock_db._conn.execute(
+        """
+        SELECT ciphertext, key_id FROM secret_versions
+        WHERE scope = 'test' AND name = 'provider.first' AND version = ?
+        """,
+        (source.version,),
+    ).fetchone()
+    mock_db._conn.execute(
+        """
+        UPDATE secret_versions SET ciphertext = ?, key_id = ?
+        WHERE scope = 'test' AND name = 'provider.second' AND version = ?
+        """,
+        (source_row["ciphertext"], source_row["key_id"], target.version),
+    )
+    mock_db._conn.commit()
+
+    with pytest.raises(SecretDecryptionError, match="authentication failed"):
+        store.activate(
+            "provider.second",
+            target.version,
+            expected_active_version=None,
+        )
+
+
+def test_sqlite_lock_wait_is_bounded(tmp_path: Path):
+    path = tmp_path / "locked.db"
+    holder = LocalDB(path=path, timeout_ms=50)
+    contender = LocalDB(path=path, timeout_ms=50)
+    holder._conn.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(SecretBusyError, match="retry"):
+            _store(contender).stage("openai_api_key", "value", request_id="locked")
+    finally:
+        holder._conn.rollback()
+        holder.close()
+        contender.close()
+
+
+def test_database_file_is_owner_only_where_supported(tmp_path: Path):
+    path = tmp_path / "permissions.db"
+    db = LocalDB(path=path)
+    mode = os.stat(path).st_mode & 0o777
+    db.close()
+    assert mode & 0o077 == 0
+
+
+def test_operator_cli_never_echoes_secret_or_envelope(tmp_path: Path):
+    runner = CliRunner()
+    encoded = base64.urlsafe_b64encode(_key(7)).decode().rstrip("=")
+    secret = "cli-sensitive-value"
+
+    result = runner.invoke(
+        main,
+        [
+            "secrets",
+            "--db-path",
+            str(tmp_path / "cli.db"),
+            "rotate",
+            "provider.api_key",
+            "--request-id",
+            "cli-request",
+        ],
+        input=f"{secret}\n{secret}\n",
+        env={
+            "TALOS_SECRET_KEYRING": json.dumps({"primary": encoded}),
+            "TALOS_SECRET_ACTIVE_KEY_ID": "primary",
+            "TALOS_SECRET_SCOPE": "cli",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    assert secret not in result.output
+    assert "TALOS-SECRET" not in result.output
+    assert '"status": "active"' in result.output


### PR DESCRIPTION
Closes #227

## Summary

Adds opt-in, zero-downtime encrypted rotation for wallet, API, provider, and agent credentials without persisting plaintext values.

- Adds versioned AES-256-GCM secret envelopes with authenticated scope/name/version metadata.
- Adds atomic stage, activate, revoke, recover, and audit operations backed by SQLite transactions.
- Resolves credentials at point of use so running API clients and adapters observe an activated version without process recreation.
- Supports dual-read recovery from the previous version and a controlled legacy-environment fallback for backward-compatible rollout.
- Rejects stale activation generations, duplicate deliveries, active-version revocation, oversized input, ciphertext row swapping, and unbounded database lock waits with explicit errors.
- Emits structured audit events without secret values, ciphertext, or user payloads.
- Adds migration 7 and operator documentation covering configuration, migration, observability, recovery, and rollback.
- Keeps the feature disabled by default through TALOS_SECRET_ROTATION_ENABLED=false.

## Security and failure-path evidence

The following focused tests pass against PR head 2f1c3aa:

- **Concurrent rotation and stale-version rejection:** test_atomic_activation_rejects_stale_concurrent_operator proves generation-based compare-and-swap rejects a second operator using stale state.
- **Zero-downtime activation:** test_api_client_observes_atomic_rotation_without_recreation proves an existing API client observes the activated credential without being rebuilt.
- **Rollback and dual-read recovery:** test_dual_read_falls_back_to_previous_on_corrupt_active, test_missing_decryption_key_uses_legacy_only_when_enabled, and test_failed_stage_rolls_back_without_partial_row cover corrupt active data, explicitly configured legacy fallback, and transactional rollback after partial failure.
- **Restart recovery:** test_recovery_is_atomic_and_survives_restart closes and reopens the database and proves recovery remains atomic and durable.
- **Revocation safety:** test_revoke_active_rejected_then_old_version_can_be_revoked proves the active secret cannot be revoked and an older version can be revoked safely.
- **Redaction/no plaintext persistence:** test_plaintext_is_never_persisted_and_audit_is_redacted and test_operator_cli_never_echoes_secret_or_envelope inspect persistence, audit events, and CLI output for secret material.
- **Idempotency and authorization boundaries:** test_duplicate_stage_delivery_is_idempotent, test_authenticated_metadata_prevents_ciphertext_row_swapping, and test_input_boundaries_are_enforced cover duplicate delivery, authenticated row identity, and bounded inputs.
- **Bounded failure handling:** test_sqlite_lock_wait_is_bounded proves lock contention fails within the configured timeout.

## Test Plan

Run from packages/prime-agent:

    env PYTHONPATH=src uv run --extra dev pytest -v tests/test_secret_store.py tests/test_secret_rotation_integration.py

Result: **15 passed in 1.30s**.

    env PYTHONPATH=src uv run --extra dev pytest -q

Result: **273 passed in 2.26s**.

    env PYTHONPATH=src uv run --extra dev ruff check src tests

Result: **All checks passed**.

Verification was repeated from an isolated archive of PR head 2f1c3aa, separate from later work.

## Documentation and rollback

- Updated packages/prime-agent/.env.example with opt-in rotation settings.
- Added docs/prime-agent-secret-rotation.md with rollout, operational signals, recovery, known limitations, and rollback guidance.
- Added contributor verification commands to CONTRIBUTING.md.
- Rollback is performed by disabling TALOS_SECRET_ROTATION_ENABLED; migration 7 is additive and encrypted version/audit history is retained.

## Visual Changes

Not applicable; this PR changes Prime Agent security and operator surfaces only.

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] My code follows the project style guidelines.
- [x] I updated .env.example and operator/contributor documentation.
- [x] Focused security tests cover concurrent rotation, rollback, restart recovery, stale-version rejection, idempotency, resource bounds, and redaction.
- [x] New and existing Prime Agent tests pass locally.
- [x] Prime Agent lint passes without new warnings or errors.
- [x] No real secrets or plaintext credentials are committed.