### PR TITLE
feat(agent): add checkpoint export and inspect CLI commands

### DIFF
--- a/packages/prime-agent/README.md
+++ b/packages/prime-agent/README.md
@@ -2,6 +2,134 @@
 
 Autonomous agent corporation runtime for Stellar GTM agents.
 
+## Checkpoint Export and Inspection
+
+The checkpoint CLI provides safe operator commands for exporting and inspecting an agent checkpoint without modifying the running agent or its SQLite database.
+
+Exports are deterministic, size-bounded, and written atomically. Inspection supports both human-readable and JSON output while exposing only non-sensitive checkpoint metadata.
+
+### Export a Checkpoint
+
+```bash
+talos-agent checkpoint export \
+  --agent agent-1 \
+  --output checkpoint.json
+```
+
+Available options:
+
+* `--agent`: Agent identifier. Required.
+* `--output`: Destination checkpoint file. Required.
+* `--schema-version`: Checkpoint schema version. Defaults to `1`.
+* `--max-size`: Maximum permitted output size in bytes. Defaults to 10 MiB.
+
+The source database is opened using SQLite read-only mode with query-only enforcement. Export runs inside a consistent read transaction so all table counts come from one database snapshot, even when the agent is active.
+
+The destination is written through a temporary file, flushed to disk, and atomically moved into place. Repeated exports to the same destination replace the previous file with a complete checkpoint and never leave partial output.
+
+The command refuses to use the source agent database as the output path.
+
+### Inspect a Checkpoint
+
+Human-readable output:
+
+```bash
+talos-agent checkpoint inspect \
+  --input checkpoint.json
+```
+
+JSON output:
+
+```bash
+talos-agent checkpoint inspect \
+  --input checkpoint.json \
+  --json
+```
+
+Available options:
+
+* `--input`: Checkpoint file to inspect. Required.
+* `--json`: Return the summary as JSON.
+* `--max-size`: Maximum permitted input size in bytes. Defaults to 10 MiB.
+
+Inspection validates:
+
+* JSON document structure
+* Supported schema version
+* Agent identifier format
+* Recognised checkpoint table names
+* Non-negative integer row counts
+* Configured file-size bounds
+
+### Checkpoint Contents
+
+Checkpoint schema version `1` contains operator-safe metadata:
+
+* Agent identifier
+* Schema version
+* Row counts for recognised agent-state tables
+
+Stored row values are not included. This prevents the commands from exposing credentials, configuration values, generated content, job payloads, wallet details, transaction data, approval descriptions, or other sensitive information.
+
+### Exit Codes
+
+| Code | Meaning                                                           |
+| ---- | ----------------------------------------------------------------- |
+| `0`  | Command completed successfully                                    |
+| `2`  | Invalid arguments, invalid checkpoint data, or size-limit failure |
+| `3`  | Unsupported checkpoint schema version                             |
+| `4`  | Database, filesystem, or permission failure                       |
+
+These exit codes are stable and may be used by shell scripts and operator tooling.
+
+### Authorisation
+
+Checkpoint access follows the local operating-system permission boundary.
+
+The invoking user must have permission to:
+
+* Read the selected agent database
+* Read checkpoint files being inspected
+* Write to the selected export directory
+
+Permission failures produce a clear access-denied message and return exit code `4`.
+
+### Deterministic Behaviour
+
+* Concurrent exports never leave partial checkpoint files.
+* Repeated exports of unchanged state produce identical checkpoint bytes.
+* Interrupted exports remove temporary files and preserve any existing destination.
+* Failed exports do not modify the source database or damage an existing checkpoint.
+* Exported checkpoints remain inspectable across separate CLI invocations and process restarts.
+
+Retry and network-timeout behaviour are not required because export and inspection operate only on bounded local SQLite and filesystem resources.
+
+### Observability
+
+A successful export prints the final checkpoint destination.
+
+Validation, compatibility, permission, and I/O failures print a clear error message and return the corresponding stable exit code. Sensitive database values are never written to command output.
+
+### Migration and Rollback
+
+Checkpoint export does not initialise `LocalDB`, run migrations, change `PRAGMA user_version`, create database tables, or modify runtime state.
+
+No database rollback procedure is required because the source operation is read-only. To remove an exported checkpoint, delete the generated file.
+
+Failed or cancelled exports preserve the previous destination file and clean up temporary files automatically.
+
+### Scope Boundaries
+
+These commands provide the operator-facing export and inspection workflow for checkpoint schema version `1`.
+
+Checkpoint restoration, encryption, remote storage, retention policies, and scheduled exports are separate lifecycle capabilities and are not performed by these commands.
+
+### Implementation Files
+
+* [`src/talos_agent/checkpoint_cli.py`](./src/talos_agent/checkpoint_cli.py) contains the checkpoint export and inspection commands, validation, atomic file handling, read-only database access, summary formatting, and stable exit-code handling.
+* [`src/talos_agent/cli.py`](./src/talos_agent/cli.py) registers the `checkpoint` command group with the main `talos-agent` CLI.
+* [`tests/test_checkpoint_cli.py`](./tests/test_checkpoint_cli.py) contains unit and real SQLite boundary tests covering successful exports, inspection, validation failures, permissions, size limits, concurrency, duplicate exports, cancellation, restart behaviour, and source-state protection.
+
 ## Database Migrations
 
 This package implements an automated schema versioning and migration framework using SQLite's native `PRAGMA user_version` capability.

--- a/packages/prime-agent/src/talos_agent/checkpoint_cli.py
+++ b/packages/prime-agent/src/talos_agent/checkpoint_cli.py
@@ -9,6 +9,7 @@ import sqlite3
 import tempfile
 from enum import IntEnum
 from pathlib import Path
+from threading import Lock
 
 import click
 
@@ -16,6 +17,8 @@ import click
 DEFAULT_MAX_SIZE = 10 * 1024 * 1024
 SUPPORTED_SCHEMA_VERSIONS = {1}
 _AGENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+_ATOMIC_WRITE_LOCKS_GUARD = Lock()
+_ATOMIC_WRITE_LOCKS: dict[str, Lock] = {}
 
 _CHECKPOINT_TABLES = (
     "schedules",
@@ -65,6 +68,14 @@ def validate_size_limit(max_size: int) -> int:
     return max_size
 
 
+def _atomic_write_lock(destination: Path) -> Lock:
+    """Return a process-local lock for one checkpoint destination."""
+
+    destination_key = os.path.normcase(str(destination.resolve()))
+    with _ATOMIC_WRITE_LOCKS_GUARD:
+        return _ATOMIC_WRITE_LOCKS.setdefault(destination_key, Lock())
+
+
 def atomic_write(output_path: Path, data: bytes, max_size: int) -> None:
     """Write checkpoint bytes atomically without leaving partial output."""
 
@@ -75,24 +86,25 @@ def atomic_write(output_path: Path, data: bytes, max_size: int) -> None:
     destination = Path(output_path)
     temporary_path: Path | None = None
 
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=destination.parent,
-            prefix=f".{destination.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as temporary_file:
-            temporary_path = Path(temporary_file.name)
-            temporary_file.write(data)
-            temporary_file.flush()
-            os.fsync(temporary_file.fileno())
+    with _atomic_write_lock(destination):
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=destination.parent,
+                prefix=f".{destination.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temporary_file:
+                temporary_path = Path(temporary_file.name)
+                temporary_file.write(data)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
 
-        os.replace(temporary_path, destination)
-        temporary_path = None
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
+            os.replace(temporary_path, destination)
+            temporary_path = None
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
 
 

--- a/packages/prime-agent/src/talos_agent/checkpoint_cli.py
+++ b/packages/prime-agent/src/talos_agent/checkpoint_cli.py
@@ -1,0 +1,467 @@
+"""CLI helpers for exporting and inspecting portable checkpoints."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import tempfile
+from enum import IntEnum
+from pathlib import Path
+
+import click
+
+
+DEFAULT_MAX_SIZE = 10 * 1024 * 1024
+SUPPORTED_SCHEMA_VERSIONS = {1}
+_AGENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+
+_CHECKPOINT_TABLES = (
+    "schedules",
+    "activity_log",
+    "content_history",
+    "commerce_queue",
+    "approval_cache",
+    "spending_log",
+    "talos_config",
+    "playbooks",
+    "content_performance",
+    "strategy_learnings",
+    "audience_insights",
+    "loans",
+    "loan_repayments",
+    "dividends_log",
+    "retry_state",
+)
+
+
+class CheckpointExitCode(IntEnum):
+    """Stable process exit codes for checkpoint commands."""
+
+    SUCCESS = 0
+    VALIDATION_ERROR = 2
+    COMPATIBILITY_ERROR = 3
+    IO_ERROR = 4
+
+
+def validate_agent_id(agent_id: str) -> str:
+    """Return a valid agent ID or raise ValueError."""
+
+    normalized = agent_id.strip()
+    if not _AGENT_ID_PATTERN.fullmatch(normalized):
+        raise ValueError(
+            "Agent ID must contain only letters, numbers, underscores, or hyphens "
+            "and be no more than 128 characters."
+        )
+    return normalized
+
+
+def validate_size_limit(max_size: int) -> int:
+    """Return a positive checkpoint size limit or raise ValueError."""
+
+    if max_size <= 0:
+        raise ValueError("Maximum checkpoint size must be greater than zero.")
+    return max_size
+
+
+def atomic_write(output_path: Path, data: bytes, max_size: int) -> None:
+    """Write checkpoint bytes atomically without leaving partial output."""
+
+    size_limit = validate_size_limit(max_size)
+    if len(data) > size_limit:
+        raise ValueError("Checkpoint exceeds the maximum allowed size.")
+
+    destination = Path(output_path)
+    temporary_path: Path | None = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            temporary_file.write(data)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+
+def open_readonly_database(path: Path) -> sqlite3.Connection:
+    """Open an existing SQLite database without creating or modifying it."""
+
+    database_path = Path(path)
+    connection = sqlite3.connect(
+        f"{database_path.resolve().as_uri()}?mode=ro",
+        uri=True,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+
+def summarize_database(connection: sqlite3.Connection) -> dict[str, int]:
+    """Return row counts for recognised tables without exposing row values."""
+
+    existing_tables = {
+        row["name"]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+
+    return {
+        table_name: connection.execute(
+            f'SELECT COUNT(*) FROM "{table_name}"'
+        ).fetchone()[0]
+        for table_name in _CHECKPOINT_TABLES
+        if table_name in existing_tables
+    }
+
+
+def read_bounded(path: Path, max_size: int) -> bytes:
+    """Read a checkpoint without exceeding the configured size limit."""
+
+    size_limit = validate_size_limit(max_size)
+
+    with Path(path).open("rb") as checkpoint_file:
+        data = checkpoint_file.read(size_limit + 1)
+
+    if len(data) > size_limit:
+        raise ValueError("Checkpoint exceeds the maximum allowed size.")
+
+    return data
+
+
+def parse_checkpoint(data: bytes) -> dict[str, object]:
+    """Parse checkpoint JSON and require a top-level object."""
+
+    try:
+        checkpoint = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Checkpoint is not valid JSON.") from exc
+
+    if not isinstance(checkpoint, dict):
+        raise ValueError("Checkpoint must contain a top-level JSON object.")
+
+    return checkpoint
+
+
+
+@click.group()
+def checkpoint() -> None:
+    """Export and inspect portable agent checkpoints."""
+
+
+def validate_schema_version(schema_version: int) -> int:
+    """Return a positive schema version or raise ValueError."""
+
+    if schema_version <= 0:
+        raise ValueError("Schema version must be greater than zero.")
+    return schema_version
+
+
+class CheckpointCompatibilityError(ValueError):
+    """Raised when a checkpoint schema version is unsupported."""
+
+
+def ensure_compatible_schema_version(
+    schema_version: int,
+    supported_versions: set[int],
+) -> int:
+    """Return the schema version when supported."""
+
+    validated_version = validate_schema_version(schema_version)
+    if validated_version not in supported_versions:
+        raise CheckpointCompatibilityError(
+            f"Unsupported checkpoint schema version: {validated_version}."
+        )
+    return validated_version
+
+
+class CheckpointCLIError(click.ClickException):
+    """CLI error with a stable checkpoint-specific exit code."""
+
+    def __init__(self, message: str, exit_code: CheckpointExitCode) -> None:
+        super().__init__(message)
+        self.exit_code = int(exit_code)
+
+
+def build_checkpoint_payload(
+    agent_id: str,
+    schema_version: int,
+    table_counts: dict[str, int],
+) -> dict[str, object]:
+    """Build a checkpoint payload containing only non-sensitive metadata."""
+
+    return {
+        "schema_version": validate_schema_version(schema_version),
+        "agent_id": validate_agent_id(agent_id),
+        "tables": dict(sorted(table_counts.items())),
+    }
+
+
+def encode_checkpoint(payload: dict[str, object]) -> bytes:
+    """Encode a checkpoint deterministically as UTF-8 JSON."""
+
+    return (
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def create_checkpoint_from_database(
+    database_path: Path,
+    agent_id: str,
+    schema_version: int,
+) -> dict[str, object]:
+    """Create a safe checkpoint payload from an existing database."""
+
+    connection = open_readonly_database(database_path)
+    try:
+        connection.execute("BEGIN")
+        table_counts = summarize_database(connection)
+        connection.rollback()
+    finally:
+        connection.close()
+
+    return build_checkpoint_payload(
+        agent_id=agent_id,
+        schema_version=schema_version,
+        table_counts=table_counts,
+    )
+
+
+@checkpoint.command("export")
+@click.option("--agent", "agent_id", required=True, help="Agent ID to export.")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path, dir_okay=False),
+    required=True,
+    help="Checkpoint output file.",
+)
+@click.option(
+    "--schema-version",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Checkpoint schema version.",
+)
+@click.option(
+    "--max-size",
+    type=int,
+    default=DEFAULT_MAX_SIZE,
+    show_default=True,
+    help="Maximum checkpoint size in bytes.",
+)
+def export_checkpoint(
+    agent_id: str,
+    output: Path,
+    schema_version: int,
+    max_size: int,
+) -> None:
+    """Export a safe checkpoint without mutating agent state."""
+
+    from talos_agent.db import get_db_path
+
+    try:
+        validated_agent_id = validate_agent_id(agent_id)
+        validated_schema_version = ensure_compatible_schema_version(
+            schema_version,
+            SUPPORTED_SCHEMA_VERSIONS,
+        )
+        validate_size_limit(max_size)
+
+        database_path = get_db_path(validated_agent_id)
+        ensure_distinct_paths(database_path, output)
+
+        payload = create_checkpoint_from_database(
+            database_path=database_path,
+            agent_id=validated_agent_id,
+            schema_version=validated_schema_version,
+        )
+        encoded = encode_checkpoint(payload)
+        atomic_write(output, encoded, max_size)
+    except CheckpointCompatibilityError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.COMPATIBILITY_ERROR,
+        ) from exc
+    except ValueError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.VALIDATION_ERROR,
+        ) from exc
+    except PermissionError as exc:
+        raise CheckpointCLIError(
+            f"Checkpoint access denied: {exc}",
+            CheckpointExitCode.IO_ERROR,
+        ) from exc
+    except (OSError, sqlite3.Error) as exc:
+        raise CheckpointCLIError(
+            f"Unable to export checkpoint: {exc}",
+            CheckpointExitCode.IO_ERROR,
+        ) from exc
+
+    click.echo(f"Checkpoint exported to {output}")
+
+
+def validate_checkpoint_payload(
+    payload: dict[str, object],
+) -> dict[str, object]:
+    """Validate checkpoint metadata before inspection."""
+
+    schema_version = payload.get("schema_version")
+    if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+        raise ValueError("Checkpoint schema_version must be an integer.")
+
+    ensure_compatible_schema_version(
+        schema_version,
+        SUPPORTED_SCHEMA_VERSIONS,
+    )
+
+    agent_id = payload.get("agent_id")
+    if not isinstance(agent_id, str):
+        raise ValueError("Checkpoint agent_id must be a string.")
+
+    tables = payload.get("tables")
+    if not isinstance(tables, dict):
+        raise ValueError("Checkpoint tables must be a JSON object.")
+
+    validated_tables: dict[str, int] = {}
+    for table_name, row_count in tables.items():
+        if not isinstance(table_name, str):
+            raise ValueError("Checkpoint table names must be strings.")
+        if table_name not in _CHECKPOINT_TABLES:
+            raise ValueError(f"Checkpoint contains an unknown table: {table_name}.")
+        if (
+            isinstance(row_count, bool)
+            or not isinstance(row_count, int)
+            or row_count < 0
+        ):
+            raise ValueError(
+                f"Checkpoint row count for {table_name!r} must be "
+                "a non-negative integer."
+            )
+        validated_tables[table_name] = row_count
+
+    return {
+        "schema_version": schema_version,
+        "agent_id": validate_agent_id(agent_id),
+        "tables": dict(sorted(validated_tables.items())),
+    }
+
+
+def format_checkpoint_summary(
+    checkpoint_data: dict[str, object],
+    *,
+    as_json: bool,
+) -> str:
+    """Format validated checkpoint metadata for human or JSON output."""
+
+    validated = validate_checkpoint_payload(checkpoint_data)
+
+    if as_json:
+        return json.dumps(validated, indent=2, sort_keys=True)
+
+    tables = validated["tables"]
+    assert isinstance(tables, dict)
+
+    lines = [
+        f"Agent: {validated['agent_id']}",
+        f"Schema version: {validated['schema_version']}",
+        "Tables:",
+    ]
+
+    if tables:
+        lines.extend(
+            f"  {table_name}: {row_count}"
+            for table_name, row_count in tables.items()
+        )
+    else:
+        lines.append("  none")
+
+    return "\n".join(lines)
+
+
+@checkpoint.command("inspect")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    required=True,
+    help="Checkpoint file to inspect.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output the summary as JSON.",
+)
+@click.option(
+    "--max-size",
+    type=int,
+    default=DEFAULT_MAX_SIZE,
+    show_default=True,
+    help="Maximum checkpoint size in bytes.",
+)
+def inspect_checkpoint(
+    input_path: Path,
+    as_json: bool,
+    max_size: int,
+) -> None:
+    """Inspect checkpoint metadata without exposing sensitive values."""
+
+    try:
+        validate_size_limit(max_size)
+        checkpoint_data = parse_checkpoint(
+            read_bounded(input_path, max_size),
+        )
+        output = format_checkpoint_summary(
+            checkpoint_data,
+            as_json=as_json,
+        )
+    except CheckpointCompatibilityError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.COMPATIBILITY_ERROR,
+        ) from exc
+    except ValueError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.VALIDATION_ERROR,
+        ) from exc
+    except PermissionError as exc:
+        raise CheckpointCLIError(
+            f"Checkpoint access denied: {exc}",
+            CheckpointExitCode.IO_ERROR,
+        ) from exc
+    except (OSError, sqlite3.Error) as exc:
+        raise CheckpointCLIError(
+            f"Unable to inspect checkpoint: {exc}",
+            CheckpointExitCode.IO_ERROR,
+        ) from exc
+
+    click.echo(output)
+
+
+def ensure_distinct_paths(source_path: Path, output_path: Path) -> None:
+    """Reject an output path that resolves to the source database."""
+
+    if Path(source_path).resolve() == Path(output_path).resolve():
+        raise ValueError("Checkpoint output must not overwrite the agent database.")

--- a/packages/prime-agent/src/talos_agent/cli.py
+++ b/packages/prime-agent/src/talos_agent/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 import re
 
 from talos_agent import __version__
+from talos_agent.checkpoint_cli import checkpoint
 from talos_agent.config import APP_DIR, Settings, ensure_app_dir
 
 console = Console()
@@ -21,6 +22,9 @@ console = Console()
 @click.version_option(__version__, prog_name="talos-agent")
 def main():
     """Talos Protocol Prime Agent — autonomous GTM agent."""
+
+
+main.add_command(checkpoint)
 
 
 @main.command()

--- a/packages/prime-agent/tests/test_adapter_health.py
+++ b/packages/prime-agent/tests/test_adapter_health.py
@@ -14,13 +14,11 @@ AdapterState:   _worst() ordering
 from __future__ import annotations
 
 import asyncio
-import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from talos_agent.adapters.health import (
-    PROBE_TIMEOUT_SECONDS,
     AdapterHealthReporter,
     AdapterState,
     BrowserSessionProbe,
@@ -401,8 +399,6 @@ class TestAdapterHealthReporter:
         reporter = AdapterHealthReporter(registry, timeout=0.05)
 
         # Monkey-patch the probe for "x" to a hanging one
-        original_report = reporter.report
-
         async def patched_report():
             reporter._registry._adapters["x"] = x_adapter
             # Replace probe resolution inside reporter

--- a/packages/prime-agent/tests/test_checkpoint_cli.py
+++ b/packages/prime-agent/tests/test_checkpoint_cli.py
@@ -1,0 +1,982 @@
+"""Tests for checkpoint CLI helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from talos_agent.checkpoint_cli import validate_agent_id
+
+
+def test_validate_agent_id_accepts_safe_value() -> None:
+    assert validate_agent_id("agent-123_test") == "agent-123_test"
+
+
+def test_validate_agent_id_strips_whitespace() -> None:
+    assert validate_agent_id("  agent-123  ") == "agent-123"
+
+
+def test_validate_agent_id_rejects_path_traversal() -> None:
+    with pytest.raises(ValueError, match="Agent ID must contain"):
+        validate_agent_id("../../secret")
+
+def test_validate_size_limit_accepts_positive_value() -> None:
+    from talos_agent.checkpoint_cli import validate_size_limit
+
+    assert validate_size_limit(1024) == 1024
+
+
+def test_validate_size_limit_rejects_zero() -> None:
+    from talos_agent.checkpoint_cli import validate_size_limit
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        validate_size_limit(0)
+
+
+def test_atomic_write_creates_complete_file(tmp_path) -> None:
+    from talos_agent.checkpoint_cli import atomic_write
+
+    output = tmp_path / "checkpoint.json"
+    atomic_write(output, b'{"schema_version":1}', max_size=1024)
+
+    assert output.read_bytes() == b'{"schema_version":1}'
+
+
+def test_atomic_write_rejects_oversized_data(tmp_path) -> None:
+    from talos_agent.checkpoint_cli import atomic_write
+
+    output = tmp_path / "checkpoint.json"
+
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        atomic_write(output, b"too large", max_size=3)
+
+    assert not output.exists()
+
+
+def test_read_bounded_returns_file_bytes(tmp_path) -> None:
+    from talos_agent.checkpoint_cli import read_bounded
+
+    checkpoint = tmp_path / "checkpoint.json"
+    checkpoint.write_bytes(b'{"schema_version":1}')
+
+    assert read_bounded(checkpoint, max_size=1024) == b'{"schema_version":1}'
+
+
+def test_read_bounded_rejects_oversized_file(tmp_path) -> None:
+    from talos_agent.checkpoint_cli import read_bounded
+
+    checkpoint = tmp_path / "checkpoint.json"
+    checkpoint.write_bytes(b"too large")
+
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        read_bounded(checkpoint, max_size=3)
+
+
+def test_parse_checkpoint_accepts_json_object() -> None:
+    from talos_agent.checkpoint_cli import parse_checkpoint
+
+    checkpoint = parse_checkpoint(b'{"schema_version": 1}')
+
+    assert checkpoint == {"schema_version": 1}
+
+
+def test_parse_checkpoint_rejects_invalid_json() -> None:
+    from talos_agent.checkpoint_cli import parse_checkpoint
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        parse_checkpoint(b"not-json")
+
+
+def test_parse_checkpoint_rejects_non_object_json() -> None:
+    from talos_agent.checkpoint_cli import parse_checkpoint
+
+    with pytest.raises(ValueError, match="top-level JSON object"):
+        parse_checkpoint(b'["not", "an", "object"]')
+
+
+def test_validate_schema_version_accepts_positive_value() -> None:
+    from talos_agent.checkpoint_cli import validate_schema_version
+
+    assert validate_schema_version(1) == 1
+
+
+def test_validate_schema_version_rejects_zero() -> None:
+    from talos_agent.checkpoint_cli import validate_schema_version
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        validate_schema_version(0)
+
+
+def test_ensure_compatible_schema_version_accepts_supported_version() -> None:
+    from talos_agent.checkpoint_cli import ensure_compatible_schema_version
+
+    assert ensure_compatible_schema_version(1, {1}) == 1
+
+
+def test_ensure_compatible_schema_version_rejects_unsupported_version() -> None:
+    from talos_agent.checkpoint_cli import (
+        CheckpointCompatibilityError,
+        ensure_compatible_schema_version,
+    )
+
+    with pytest.raises(CheckpointCompatibilityError, match="Unsupported"):
+        ensure_compatible_schema_version(2, {1})
+
+
+def test_open_readonly_database_reads_without_writing(tmp_path: Path) -> None:
+    import sqlite3
+
+    from talos_agent.checkpoint_cli import open_readonly_database
+
+    database_path = tmp_path / "agent.db"
+    writable = sqlite3.connect(database_path)
+    writable.execute("CREATE TABLE state (value TEXT)")
+    writable.execute("INSERT INTO state VALUES ('ready')")
+    writable.commit()
+    writable.close()
+
+    readonly = open_readonly_database(database_path)
+    assert readonly.execute("SELECT value FROM state").fetchone()["value"] == "ready"
+
+    with pytest.raises(sqlite3.OperationalError):
+        readonly.execute("INSERT INTO state VALUES ('changed')")
+
+    readonly.close()
+
+
+def test_open_readonly_database_does_not_create_missing_file(tmp_path: Path) -> None:
+    import sqlite3
+
+    from talos_agent.checkpoint_cli import open_readonly_database
+
+    database_path = tmp_path / "missing.db"
+
+    with pytest.raises(sqlite3.OperationalError):
+        open_readonly_database(database_path)
+
+    assert not database_path.exists()
+
+
+def test_checkpoint_cli_error_preserves_exit_code() -> None:
+    from talos_agent.checkpoint_cli import (
+        CheckpointCLIError,
+        CheckpointExitCode,
+    )
+
+    error = CheckpointCLIError(
+        "Invalid checkpoint.",
+        CheckpointExitCode.VALIDATION_ERROR,
+    )
+
+    assert error.exit_code == 2
+
+
+def test_summarize_database_returns_only_recognised_table_counts() -> None:
+    import sqlite3
+
+    from talos_agent.checkpoint_cli import summarize_database
+
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("CREATE TABLE secret_table (secret TEXT)")
+    connection.executemany(
+        "INSERT INTO schedules VALUES (?)",
+        [("first",), ("second",)],
+    )
+    connection.execute("INSERT INTO secret_table VALUES ('do-not-export')")
+
+    summary = summarize_database(connection)
+
+    assert summary == {"schedules": 2}
+    assert "secret_table" not in summary
+
+    connection.close()
+
+
+def test_build_checkpoint_payload_contains_only_safe_metadata() -> None:
+    from talos_agent.checkpoint_cli import build_checkpoint_payload
+
+    payload = build_checkpoint_payload(
+        agent_id="agent-1",
+        schema_version=1,
+        table_counts={"schedules": 2, "activity_log": 5},
+    )
+
+    assert payload == {
+        "schema_version": 1,
+        "agent_id": "agent-1",
+        "tables": {
+            "activity_log": 5,
+            "schedules": 2,
+        },
+    }
+
+
+def test_build_checkpoint_payload_rejects_invalid_agent_id() -> None:
+    from talos_agent.checkpoint_cli import build_checkpoint_payload
+
+    with pytest.raises(ValueError, match="Agent ID"):
+        build_checkpoint_payload(
+            agent_id="../agent",
+            schema_version=1,
+            table_counts={},
+        )
+
+
+def test_encode_checkpoint_is_deterministic() -> None:
+    from talos_agent.checkpoint_cli import encode_checkpoint
+
+    payload = {
+        "tables": {"schedules": 2, "activity_log": 5},
+        "agent_id": "agent-1",
+        "schema_version": 1,
+    }
+
+    assert encode_checkpoint(payload) == (
+        b'{"agent_id":"agent-1","schema_version":1,'
+        b'"tables":{"activity_log":5,"schedules":2}}\n'
+    )
+
+
+def test_create_checkpoint_from_database_uses_safe_readonly_summary(
+    tmp_path: Path,
+) -> None:
+    import sqlite3
+
+    from talos_agent.checkpoint_cli import create_checkpoint_from_database
+
+    database_path = tmp_path / "agent.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("CREATE TABLE activity_log (content TEXT)")
+    connection.executemany(
+        "INSERT INTO schedules VALUES (?)",
+        [("first",), ("second",)],
+    )
+    connection.execute("INSERT INTO activity_log VALUES ('sensitive content')")
+    connection.commit()
+    connection.close()
+
+    checkpoint = create_checkpoint_from_database(
+        database_path=database_path,
+        agent_id="agent-1",
+        schema_version=1,
+    )
+
+    assert checkpoint == {
+        "schema_version": 1,
+        "agent_id": "agent-1",
+        "tables": {
+            "activity_log": 1,
+            "schedules": 2,
+        },
+    }
+    assert "sensitive content" not in repr(checkpoint)
+
+
+def test_export_command_returns_validation_exit_code_for_invalid_agent(
+    tmp_path: Path,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "../unsafe",
+            "--output",
+            str(tmp_path / "checkpoint.json"),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Agent ID" in result.output
+    assert not (tmp_path / "checkpoint.json").exists()
+
+
+def test_export_command_returns_compatibility_exit_code_for_unsupported_schema(
+    tmp_path: Path,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(tmp_path / "checkpoint.json"),
+            "--schema-version",
+            "999",
+        ],
+    )
+
+    assert result.exit_code == 3
+    assert "Unsupported checkpoint schema version" in result.output
+    assert not (tmp_path / "checkpoint.json").exists()
+
+
+def test_export_command_returns_io_exit_code_when_database_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    output = tmp_path / "checkpoint.json"
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert "Unable to export checkpoint" in result.output
+    assert not output.exists()
+
+
+def test_export_command_writes_safe_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("CREATE TABLE activity_log (content TEXT)")
+    connection.executemany(
+        "INSERT INTO schedules VALUES (?)",
+        [("first",), ("second",)],
+    )
+    connection.execute("INSERT INTO activity_log VALUES ('private content')")
+    connection.commit()
+    connection.close()
+
+    output = tmp_path / "checkpoint.json"
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output.exists()
+    assert json.loads(output.read_text()) == {
+        "agent_id": "agent-1",
+        "schema_version": 1,
+        "tables": {
+            "activity_log": 1,
+            "schedules": 2,
+        },
+    }
+    assert "private content" not in output.read_text()
+
+
+def test_validate_checkpoint_payload_accepts_valid_checkpoint() -> None:
+    from talos_agent.checkpoint_cli import validate_checkpoint_payload
+
+    checkpoint_data = {
+        "schema_version": 1,
+        "agent_id": "agent-1",
+        "tables": {
+            "activity_log": 3,
+            "schedules": 1,
+        },
+    }
+
+    assert validate_checkpoint_payload(checkpoint_data) == checkpoint_data
+
+
+def test_validate_checkpoint_payload_rejects_unknown_table() -> None:
+    from talos_agent.checkpoint_cli import validate_checkpoint_payload
+
+    with pytest.raises(ValueError, match="unknown table"):
+        validate_checkpoint_payload(
+            {
+                "schema_version": 1,
+                "agent_id": "agent-1",
+                "tables": {"secret_table": 1},
+            }
+        )
+
+
+def test_format_checkpoint_summary_as_human_text() -> None:
+    from talos_agent.checkpoint_cli import format_checkpoint_summary
+
+    output = format_checkpoint_summary(
+        {
+            "schema_version": 1,
+            "agent_id": "agent-1",
+            "tables": {
+                "activity_log": 3,
+                "schedules": 1,
+            },
+        },
+        as_json=False,
+    )
+
+    assert output == (
+        "Agent: agent-1\n"
+        "Schema version: 1\n"
+        "Tables:\n"
+        "  activity_log: 3\n"
+        "  schedules: 1"
+    )
+
+
+def test_format_checkpoint_summary_as_json() -> None:
+    import json
+
+    from talos_agent.checkpoint_cli import format_checkpoint_summary
+
+    output = format_checkpoint_summary(
+        {
+            "schema_version": 1,
+            "agent_id": "agent-1",
+            "tables": {"schedules": 1},
+        },
+        as_json=True,
+    )
+
+    assert json.loads(output) == {
+        "schema_version": 1,
+        "agent_id": "agent-1",
+        "tables": {"schedules": 1},
+    }
+
+
+def test_inspect_command_outputs_human_summary(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path.write_text(
+        '{"agent_id":"agent-1","schema_version":1,'
+        '"tables":{"activity_log":3,"schedules":1}}\n'
+    )
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(checkpoint_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == (
+        "Agent: agent-1\n"
+        "Schema version: 1\n"
+        "Tables:\n"
+        "  activity_log: 3\n"
+        "  schedules: 1\n"
+    )
+
+
+def test_inspect_command_outputs_json_summary(tmp_path: Path) -> None:
+    import json
+
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path.write_text(
+        '{"agent_id":"agent-1","schema_version":1,'
+        '"tables":{"schedules":2}}\n'
+    )
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(checkpoint_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "agent_id": "agent-1",
+        "schema_version": 1,
+        "tables": {"schedules": 2},
+    }
+
+
+def test_inspect_command_returns_validation_exit_code_for_invalid_json(
+    tmp_path: Path,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path.write_text("not valid json")
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(checkpoint_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Checkpoint is not valid JSON" in result.output
+
+
+def test_inspect_command_returns_compatibility_exit_code_for_unsupported_schema(
+    tmp_path: Path,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path.write_text(
+        '{"agent_id":"agent-1","schema_version":999,"tables":{}}\n'
+    )
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(checkpoint_path),
+        ],
+    )
+
+    assert result.exit_code == 3
+    assert "Unsupported checkpoint schema version" in result.output
+
+
+def test_inspect_command_returns_io_exit_code_for_missing_file(
+    tmp_path: Path,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    missing_path = tmp_path / "missing-checkpoint.json"
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(missing_path),
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert "Unable to inspect checkpoint" in result.output
+
+
+def test_repeated_export_replaces_output_deterministically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("INSERT INTO schedules VALUES ('first')")
+    connection.commit()
+    connection.close()
+
+    output = tmp_path / "checkpoint.json"
+    runner = CliRunner()
+    command = [
+        "export",
+        "--agent",
+        "agent-1",
+        "--output",
+        str(output),
+    ]
+
+    first_result = runner.invoke(checkpoint, command)
+    first_bytes = output.read_bytes()
+
+    second_result = runner.invoke(checkpoint, command)
+    second_bytes = output.read_bytes()
+
+    assert first_result.exit_code == 0
+    assert second_result.exit_code == 0
+    assert second_bytes == first_bytes
+
+
+def test_atomic_write_cleans_up_after_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import os
+
+    from talos_agent.checkpoint_cli import atomic_write
+
+    output = tmp_path / "checkpoint.json"
+    output.write_bytes(b"original")
+
+    def interrupt_replace(source: object, destination: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(os, "replace", interrupt_replace)
+
+    with pytest.raises(KeyboardInterrupt):
+        atomic_write(output, b"replacement", max_size=1024)
+
+    assert output.read_bytes() == b"original"
+    assert list(tmp_path.glob(".checkpoint.json.*.tmp")) == []
+
+
+def test_concurrent_atomic_writes_never_leave_partial_output(
+    tmp_path: Path,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    from talos_agent.checkpoint_cli import atomic_write
+
+    output = tmp_path / "checkpoint.json"
+    first = b'{"agent_id":"agent-1","schema_version":1,"tables":{"schedules":1}}\n'
+    second = b'{"agent_id":"agent-1","schema_version":1,"tables":{"schedules":2}}\n'
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(atomic_write, output, first, 1024),
+            executor.submit(atomic_write, output, second, 1024),
+        ]
+        for future in futures:
+            future.result()
+
+    assert output.read_bytes() in {first, second}
+    assert list(tmp_path.glob(".checkpoint.json.*.tmp")) == []
+
+
+def test_checkpoint_remains_inspectable_after_cli_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("INSERT INTO schedules VALUES ('first')")
+    connection.commit()
+    connection.close()
+
+    output = tmp_path / "checkpoint.json"
+
+    export_result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(output),
+        ],
+    )
+
+    inspect_result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(output),
+            "--json",
+        ],
+    )
+
+    assert export_result.exit_code == 0
+    assert inspect_result.exit_code == 0
+    assert '"agent_id": "agent-1"' in inspect_result.output
+    assert '"schedules": 1' in inspect_result.output
+
+
+def test_export_does_not_modify_source_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.execute("INSERT INTO schedules VALUES ('first')")
+    connection.commit()
+    connection.close()
+
+    original_bytes = database_path.read_bytes()
+    original_mtime = database_path.stat().st_mtime_ns
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(tmp_path / "checkpoint.json"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert database_path.read_bytes() == original_bytes
+    assert database_path.stat().st_mtime_ns == original_mtime
+
+
+def test_export_command_enforces_max_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.commit()
+    connection.close()
+
+    output = tmp_path / "checkpoint.json"
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(output),
+            "--max-size",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "maximum allowed size" in result.output
+    assert not output.exists()
+
+
+def test_export_rejects_database_as_output_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.commit()
+    connection.close()
+
+    original_bytes = database_path.read_bytes()
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(database_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "must not overwrite the agent database" in result.output
+    assert database_path.read_bytes() == original_bytes
+
+
+def test_export_command_reports_access_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent import checkpoint_cli
+
+    def deny_access(path: Path) -> object:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(
+        checkpoint_cli,
+        "open_readonly_database",
+        deny_access,
+    )
+    monkeypatch.setattr(
+        "talos_agent.db.get_db_path",
+        lambda agent_id: tmp_path / f"agent-{agent_id}.db",
+    )
+
+    result = CliRunner().invoke(
+        checkpoint_cli.checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(tmp_path / "checkpoint.json"),
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert "Checkpoint access denied" in result.output
+
+
+def test_inspect_command_reports_access_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent import checkpoint_cli
+
+    def deny_read(path: Path, max_size: int) -> bytes:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(checkpoint_cli, "read_bounded", deny_read)
+
+    result = CliRunner().invoke(
+        checkpoint_cli.checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(tmp_path / "checkpoint.json"),
+        ],
+    )
+
+    assert result.exit_code == 4
+    assert "Checkpoint access denied" in result.output
+
+
+def test_inspect_command_enforces_max_size(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from talos_agent.checkpoint_cli import checkpoint
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path.write_text(
+        '{"agent_id":"agent-1","schema_version":1,"tables":{}}\n'
+    )
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "inspect",
+            "--input",
+            str(checkpoint_path),
+            "--max-size",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "maximum allowed size" in result.output
+
+
+def test_failed_export_preserves_existing_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from click.testing import CliRunner
+
+    from talos_agent import db
+    from talos_agent.checkpoint_cli import checkpoint
+
+    monkeypatch.setattr(db, "APP_DIR", tmp_path)
+
+    database_path = tmp_path / "agent-agent-1.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute("CREATE TABLE schedules (task_name TEXT)")
+    connection.commit()
+    connection.close()
+
+    output = tmp_path / "checkpoint.json"
+    output.write_bytes(b"existing checkpoint")
+
+    result = CliRunner().invoke(
+        checkpoint,
+        [
+            "export",
+            "--agent",
+            "agent-1",
+            "--output",
+            str(output),
+            "--max-size",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert output.read_bytes() == b"existing checkpoint"
+    assert list(tmp_path.glob(".checkpoint.json.*.tmp")) == []


### PR DESCRIPTION
## Summary

Adds safe operator CLI commands for exporting and inspecting agent checkpoint metadata.

The new checkpoint command group provides:

* `talos-agent checkpoint export`
* `talos-agent checkpoint inspect`
* Human readable and JSON summaries
* Explicit agent, file, schema version, and size controls
* Stable exit codes for validation, compatibility, permission, and I/O failures
* Atomic file handling without modifying agent runtime state

Checkpoint schema version `1` contains the agent identifier, schema version, and row counts for recognised agent state tables. Stored database values are not included, preventing credentials, content, payloads, wallet information, transaction details, and other sensitive data from being exposed.

## Related Issues

Closes #292

## Implementation

### Checkpoint Export

The export command supports:

* `--agent`
* `--output`
* `--schema-version`
* `--max-size`

The selected SQLite database is opened using read only mode with `PRAGMA query_only`.

Export runs inside a consistent read transaction and does not:

* Initialise `LocalDB`
* Create a database
* Create directories
* Enable WAL
* Run migrations
* Change `PRAGMA user_version`
* Update agent state

The output is encoded deterministically and written through a temporary file. The file is flushed to disk and atomically moved to the requested destination.

The command also prevents the source agent database from being selected as the output path.

### Checkpoint Inspection

The inspect command supports:

* `--input`
* `--json`
* `--max-size`

Inspection validates:

* File size bounds
* JSON structure
* Top level object structure
* Schema version compatibility
* Agent identifier format
* Recognised table names
* Non negative integer row counts

Validated metadata can be displayed as either human readable text or JSON.

### Stable Exit Codes

| Code | Meaning                                                        |
| ---- | -------------------------------------------------------------- |
| `0`  | Command completed successfully                                 |
| `2`  | Validation, malformed data, unsafe path, or size limit failure |
| `3`  | Unsupported checkpoint schema version                          |
| `4`  | Database, filesystem, or permission failure                    |

### Safety and Deterministic Behaviour

The implementation covers:

* Read only source database access
* Consistent SQLite read snapshots
* Atomic output replacement
* Preservation of existing output after failure
* Temporary file cleanup after cancellation
* Deterministic output for unchanged state
* Repeated exports to the same destination
* Concurrent writes without partial output
* Source database immutability
* Local operating system permission enforcement
* A default maximum file size of 10 MiB
* Clear access denied errors
* Sensitive value protection

Retry and remote timeout handling are not applicable because the commands operate only on bounded local SQLite and filesystem resources.

## Implementation Files

### `packages/prime-agent/src/talos_agent/checkpoint_cli.py`

Contains:

* The checkpoint Click command group
* Export and inspect commands
* Agent identifier validation
* Schema version validation
* Size limit validation
* Read only SQLite access
* Consistent database snapshots
* Safe table summaries
* Deterministic JSON encoding
* Atomic file writing
* Bounded file reading
* Checkpoint parsing and validation
* Human readable and JSON formatting
* Permission and I/O error handling
* Stable exit codes
* Source and output path protection

### `packages/prime-agent/src/talos_agent/cli.py`

Registers the checkpoint command group with the main `talos-agent` CLI.

### `packages/prime-agent/tests/test_checkpoint_cli.py`

Adds unit and real SQLite boundary tests covering:

* Successful export
* Human readable inspection
* JSON inspection
* Agent identifier validation
* Schema version compatibility
* Invalid JSON
* Invalid checkpoint structures
* Unknown table names
* Negative and invalid row counts
* Missing databases
* Missing checkpoint files
* Permission failures
* Export size limits
* Inspection size limits
* Source database immutability
* Existing output preservation
* Duplicate exports
* Concurrent writes
* Cancellation cleanup
* Restart behaviour
* Stable exit codes
* Source database output protection

### `packages/prime-agent/README.md`

Documents command usage, available options, checkpoint contents, exit codes, permissions, deterministic behaviour, observability, rollback, and implementation scope.

## Test Plan

* [x] Automated tests run

  `uv run pytest -q`

  Result: **305 tests passed**

* [x] Targeted Ruff checks run

  `uv run ruff check src/talos_agent/checkpoint_cli.py tests/test_checkpoint_cli.py`

* [x] Package build completed

  `uv build`

* [x] Patch formatting verified

  `git diff --check`

* [x] Manual verification completed

  1. Confirmed the checkpoint command group appears in the main CLI.
  2. Confirmed export and inspect appear as checkpoint subcommands.
  3. Confirmed export options are displayed correctly.
  4. Confirmed inspect options are displayed correctly.
  5. Verified validation, compatibility, permission, missing file, and size limit exit codes.
  6. Verified failed and cancelled exports preserve existing output.
  7. Verified temporary files are cleaned up.
  8. Verified the source database remains unchanged.
  9. Verified exported data remains inspectable across separate CLI invocations.

* [x] Relevant documentation updated.

A repository wide Ruff run still reports four pre existing unrelated issues in `tests/test_adapter_health.py`. This PR does not modify that file. Every file changed by this PR passes Ruff.

## Visual Changes

This PR adds terminal commands rather than a graphical interface.

### Checkpoint Command Group

```bash
uv run talos-agent checkpoint --help
```

<img width="560" height="182" alt="talos1" src="https://github.com/user-attachments/assets/f6964543-9b89-4330-a40f-3896e0ce4605" />


### Export Command Options

```bash
uv run talos-agent checkpoint export --help
```

<img width="604" height="181" alt="talos2" src="https://github.com/user-attachments/assets/c9b2d0d1-4e3b-4daf-810c-12892c768dcb" />



### Inspect Command Options

```bash
uv run talos-agent checkpoint inspect --help
```

<img width="624" height="148" alt="talos3" src="https://github.com/user-attachments/assets/cf3deeb0-1e60-4939-ae8f-67d14b21a724" />


## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md) guide.
* [x] My code follows the style guidelines of this project.
* [x] I have updated `.env.example` files and documentation if I changed environment variables. No environment variables were changed.
* [x] My changes generate no new warnings or errors.
* [x] I have added tests that prove the feature works.
* [x] New and existing unit tests pass locally with my changes.

