### PR TITLE
feat(agent): implement a durable inbox/outbox for exactly-once job effects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,7 @@ If you deploy new contracts, update the contract IDs in `web/.env.local` with th
 - `X_USERNAME`, `X_PASSWORD`, and `X_EMAIL`
 - `BROWSER_HEADLESS`
 - agent timing and approval settings such as `AGENT_CYCLE_INTERVAL`, `POLLING_INTERVAL`, and `APPROVAL_THRESHOLD`
+- opt-in durable job inbox/outbox settings under `TALOS_DURABLE_JOB_EFFECTS_*` and `TALOS_JOB_EFFECT_*`
 
 ### Contracts env
 
@@ -183,6 +184,9 @@ cargo test --target wasm32-unknown-unknown
 - Do not commit secrets, keys, or generated `.env` files
 - For TypeScript and React, run `pnpm lint` and the relevant `pnpm test:*` command before opening a PR
 - For Python, prefer explicit types and validate changes with `uv run pytest`
+- For provider job-effect changes, also run
+  `uv run pytest tests/test_durable_job_effects.py` and follow the
+  [durable job effects runbook](./docs/prime-agent-durable-job-effects.md).
 - For Rust, keep formatting standard with `cargo fmt` and validate with `cargo test`
 
 ## Database Transaction Retry & Serialization Hardening

--- a/docs/prime-agent-durable-job-effects.md
+++ b/docs/prime-agent-durable-job-effects.md
@@ -1,0 +1,199 @@
+# Prime Agent durable job effects
+
+Status: implementation design and operator runbook for issue #226.
+
+## Goal and boundary
+
+The durable job-effect path protects provider-side commerce jobs: the Prime
+Agent receives a job, claims its remote fencing lease, computes a result, and
+submits that result to the Talos Web API. When enabled, the local SQLite
+database becomes the durable source of truth for the job inbox and result
+outbox.
+
+```text
+Web API pending job
+  -> bounded durable inbox
+  -> remote fenced claim
+  -> result prepared atomically with one outbox effect
+  -> leased outbox dispatcher
+  -> POST /api/jobs/{id}/result
+  -> GET /api/jobs/{id}/result reconciliation
+  -> inbox completed + outbox succeeded
+```
+
+This change does not attempt to make arbitrary Python side effects exactly
+once. External exactly-once completion depends on the Web API's durable job
+identity, fencing-token check, completed-state uniqueness, and result
+reconciliation. A receiver without an idempotent or reconcilable contract can
+only provide at-least-once delivery.
+
+The Web API completion update compares the job ID, fencing token, and
+`status='pending'` in the same transaction that records revenue. Concurrent
+completion requests therefore have one winner; a loser receives `409` and the
+agent reconciles the already-completed result with `GET`.
+
+## Data model and invariants
+
+Migration 7 adds:
+
+- `job_inbox`: one row per `(owner_talos_id, job_id)`, including a canonical,
+  size-bounded request payload, its SHA-256 digest, processing state, fencing
+  token, and lease metadata.
+- `job_effect_outbox`: one row per stable effect key. For job completion the
+  key is derived from the Talos owner and job ID. The canonical, size-bounded
+  result and its digest are persisted before network I/O.
+- indexes for bounded status and retry scans.
+
+The following invariants are enforced in SQLite transactions:
+
+1. Re-delivering the same job and payload is idempotent.
+2. Reusing a job ID with a different payload is rejected.
+3. Preparing the same result creates one effect and is idempotent.
+4. Preparing a different result for an existing effect is rejected.
+5. Only one process can hold an outbox dispatch lease at a time.
+6. A stale lease owner cannot complete or reschedule an effect.
+7. Inbox completion and outbox success are committed atomically.
+8. A lost POST response is reconciled with GET before the effect is retried.
+
+SQLite `BEGIN IMMEDIATE`, compare-and-swap updates, durable lease owner IDs,
+fencing tokens, `synchronous=FULL`, and foreign-key enforcement provide
+cross-process correctness and crash-consistent commits. Process-local locks
+are not used for shared state.
+
+## Configuration
+
+The feature is disabled by default.
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `TALOS_DURABLE_JOB_EFFECTS_ENABLED` | `false` | Enables the inbox/outbox path. |
+| `TALOS_JOB_EFFECT_DISPATCH_INTERVAL` | `2` | Seconds between outbox scans. |
+| `TALOS_JOB_EFFECT_LEASE_SECONDS` | `30` | Dispatcher lease duration. |
+| `TALOS_JOB_EFFECT_MAX_ATTEMPTS` | `8` | Attempts before an effect becomes dead-lettered. |
+| `TALOS_JOB_EFFECT_RETRY_BASE_SECONDS` | `2` | Exponential retry base. |
+| `TALOS_JOB_EFFECT_BATCH_SIZE` | `20` | Maximum effects claimed per scan. |
+| `TALOS_JOB_EFFECT_MAX_INBOX_RECORDS` | `100000` | Hard inbox capacity. |
+| `TALOS_JOB_EFFECT_MAX_OUTBOX_RECORDS` | `100000` | Hard outbox capacity. |
+| `TALOS_JOB_EFFECT_MAX_PAYLOAD_BYTES` | `65536` | Maximum canonical job payload size. |
+| `TALOS_JOB_EFFECT_MAX_RESULT_BYTES` | `262144` | Maximum canonical result size. |
+| `TALOS_JOB_EFFECT_DISPATCH_TIMEOUT_SECONDS` | `20` | Timeout for one result delivery attempt. |
+| `TALOS_JOB_EFFECT_DB_TIMEOUT_MS` | `5000` | Maximum SQLite lock wait. |
+| `JOB_LEASE_TTL` | `300` | Remote fenced lease duration, bounded to 600 seconds. |
+| `JOB_HEARTBEAT_INTERVAL` | `60` | Remote lease heartbeat interval. |
+
+Configuration values have additional hard upper bounds in `Settings`.
+
+## State transitions and recovery
+
+Inbox states are `received`, `claimed`, `effect_pending`, `completed`, and
+`conflict`. Outbox states are `pending`, `dispatching`, `succeeded`,
+`retryable`, `indeterminate`, `conflict`, and `dead`.
+
+On restart, `dispatching` rows with expired leases become eligible for
+reconciliation. The dispatcher first asks the Web API for the job result:
+
+- the same completed result marks the effect succeeded without another POST;
+- a different completed result marks a conflict and never overwrites it;
+- a pending remote job allows the same stable effect to be retried;
+- an unavailable remote state leaves the effect indeterminate for a later
+  bounded retry.
+
+Duplicate delivery and duplicate tool calls return the existing durable state.
+After `TALOS_JOB_EFFECT_MAX_ATTEMPTS`, automatic dispatch stops at `dead`.
+
+## Security and observability
+
+- Job IDs, Talos IDs, service names, and serialized JSON have strict type,
+  character, and byte limits.
+- Inbox payloads and outbox results are required for crash recovery and are
+  stored in the local SQLite database. The database file is restricted to its
+  owner (`0600`) on supported platforms; operators must also encrypt the
+  underlying volume when payload confidentiality at rest is required.
+- CLI inspection never prints payloads, results, digests, credentials, or
+  exception messages.
+- Structured events contain only IDs, state, attempt count, and stable error
+  codes. They never contain job payloads, result bodies, API keys, or user
+  content.
+- Replay requests use compare-and-swap attempt checks, an explicit Talos scope,
+  and the owner-only local database permission boundary. The local CLI does not
+  provide an additional remote-authentication layer.
+- Capacity, scan batch, payload, result, lease, retry, and attempt bounds
+  prevent unbounded resource use.
+
+Operational events:
+
+- `job_inbox_transition`
+- `job_effect_transition`
+- `job_effect_reconciled`
+- `job_effect_dispatch_failed`
+- `job_effect_capacity_rejected`
+
+Useful states to alert on are `indeterminate`, `conflict`, and `dead`.
+
+## Replay inspection
+
+Inspection is metadata-only:
+
+```bash
+uv run talos-agent jobs inspect --talos-id "$TALOS_ID" --status indeterminate
+uv run talos-agent jobs inspect --talos-id "$TALOS_ID" --status dead --json
+```
+
+An operator can requeue a `retryable`, `indeterminate`, or `dead` effect after
+checking the receiver:
+
+```bash
+uv run talos-agent jobs retry EFFECT_ID \
+  --talos-id "$TALOS_ID" \
+  --expected-attempt 8
+```
+
+The expected attempt makes duplicate operator delivery idempotent and rejects
+stale decisions.
+
+## Rollout, compatibility, and rollback
+
+1. Back up the agent database.
+2. Deploy with `TALOS_DURABLE_JOB_EFFECTS_ENABLED=false`. Migration 7 is
+   additive and legacy tools continue unchanged.
+3. Enable the feature on one agent and watch transition/error counts.
+4. Verify duplicate fulfillment, restart reconciliation, and dead-letter
+   inspection before widening rollout.
+
+To roll back, set `TALOS_DURABLE_JOB_EFFECTS_ENABLED=false` and restart. The
+legacy in-memory claim and direct-submit path is restored. Do not delete inbox
+or outbox rows until all non-terminal effects have been reconciled. If another
+pending PR adds migration 7 first, rebase this change and renumber its additive
+migration before merge; no data rewrite is otherwise required.
+
+## Known limitations
+
+- The boundary covers provider job-result submission, not arbitrary publishing,
+  payment, browser, or third-party tool effects.
+- Payloads and results remain in the local database as durable recovery data.
+  Use encrypted storage when confidentiality at rest is required.
+- Completed rows are retained as deduplication evidence. There is deliberately
+  no automatic pruning; reaching a configured capacity requires an
+  operator-reviewed archival/migration procedure.
+- An unavailable Web API can leave delivery `indeterminate` until remote state
+  is reachable. The bounded dispatcher never guesses that an effect failed.
+- Migration numbering must be rebased if another pending SQLite migration
+  lands first.
+
+## Local verification
+
+From `packages/prime-agent`:
+
+```bash
+uv run pytest tests/test_durable_job_effects.py
+uv run pytest
+uv run ruff check src tests
+uv build
+```
+
+From the repository root:
+
+```bash
+cargo test --workspace
+pnpm --filter web exec tsc --noEmit
+```

--- a/packages/prime-agent/.env.example
+++ b/packages/prime-agent/.env.example
@@ -27,6 +27,24 @@ X_EMAIL=                          # used if X asks for email verification
 # AGENT_CYCLE_INTERVAL=300         # seconds between GTM cycles (default 30)
 # POLLING_INTERVAL=10              # seconds between API polls (default 10)
 # APPROVAL_THRESHOLD=10            # USD threshold for auto-approval (default 10)
+# JOB_LEASE_TTL=300                # remote provider-job lease (1-600 seconds)
+# JOB_HEARTBEAT_INTERVAL=60        # seconds between lease heartbeats
+
+# ─── Durable provider-job effects (opt-in) ────────────────
+# Persists the job inbox and completion outbox before network delivery.
+# See docs/prime-agent-durable-job-effects.md for rollout and recovery.
+# TALOS_DURABLE_JOB_EFFECTS_ENABLED=false
+# TALOS_JOB_EFFECT_DISPATCH_INTERVAL=2
+# TALOS_JOB_EFFECT_LEASE_SECONDS=30
+# TALOS_JOB_EFFECT_MAX_ATTEMPTS=8
+# TALOS_JOB_EFFECT_RETRY_BASE_SECONDS=2
+# TALOS_JOB_EFFECT_BATCH_SIZE=20
+# TALOS_JOB_EFFECT_MAX_INBOX_RECORDS=100000
+# TALOS_JOB_EFFECT_MAX_OUTBOX_RECORDS=100000
+# TALOS_JOB_EFFECT_MAX_PAYLOAD_BYTES=65536
+# TALOS_JOB_EFFECT_MAX_RESULT_BYTES=262144
+# TALOS_JOB_EFFECT_DISPATCH_TIMEOUT_SECONDS=20
+# TALOS_JOB_EFFECT_DB_TIMEOUT_MS=5000
 
 # ─── Browser (Railway / server) ───────────────────────────
 # Set to true when running on Railway or any headless server.

--- a/packages/prime-agent/README.md
+++ b/packages/prime-agent/README.md
@@ -75,3 +75,14 @@ docker build -t prime-agent .
 docker run --rm prime-agent
 ```
 
+## Durable provider-job effects
+
+The opt-in durable inbox/outbox prevents provider job results from being lost
+or executed twice across crashes. It is disabled by default with
+`TALOS_DURABLE_JOB_EFFECTS_ENABLED=false`.
+
+Before enabling it, read the
+[durable job effects runbook](../../docs/prime-agent-durable-job-effects.md).
+The runbook documents the exact external idempotency boundary, configuration,
+migration, structured operational events, metadata-only replay inspection,
+recovery procedure, known limitations, and rollback steps.

--- a/packages/prime-agent/src/talos_agent/api_client.py
+++ b/packages/prime-agent/src/talos_agent/api_client.py
@@ -289,10 +289,19 @@ class TalosAPIClient:
             return r.json()
         return None
 
-    async def submit_job_result(self, job_id: str, result: dict, fencing_token: int = 0) -> dict | None:
+    async def submit_job_result(
+        self,
+        job_id: str,
+        result: dict,
+        fencing_token: int = 0,
+        *,
+        idempotency_key: str | None = None,
+    ) -> dict | None:
+        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
         r = await self._post(
             f"/api/jobs/{job_id}/result",
             json={"result": result, "fencingToken": fencing_token},
+            headers=headers,
         )
         if r.status_code in (200, 201):
             return r.json()

--- a/packages/prime-agent/src/talos_agent/cli.py
+++ b/packages/prime-agent/src/talos_agent/cli.py
@@ -168,6 +168,115 @@ def encrypt_keys(env_file: str):
     console.print(f"[green]Encrypted {changed} values. Original saved to {backup}[/green]")
 
 
+@main.group()
+def jobs():
+    """Inspect and safely requeue durable job effects."""
+
+
+def _job_store(db_path: str | None, talos_id: str):
+    from pathlib import Path
+
+    from talos_agent.db import LocalDB
+    from talos_agent.job_effects import JobEffectLimits, JobEffectStore
+
+    settings = Settings()
+    limits = JobEffectLimits(
+        max_inbox_records=settings.talos_job_effect_max_inbox_records,
+        max_outbox_records=settings.talos_job_effect_max_outbox_records,
+        max_payload_bytes=settings.talos_job_effect_max_payload_bytes,
+        max_result_bytes=settings.talos_job_effect_max_result_bytes,
+        batch_size=settings.talos_job_effect_batch_size,
+        lease_seconds=settings.talos_job_effect_lease_seconds,
+        max_attempts=settings.talos_job_effect_max_attempts,
+        retry_base_seconds=settings.talos_job_effect_retry_base_seconds,
+        dispatch_timeout_seconds=settings.talos_job_effect_dispatch_timeout_seconds,
+        remote_lease_ttl_seconds=settings.job_lease_ttl,
+        busy_timeout_ms=settings.talos_job_effect_db_timeout_ms,
+    )
+    db = LocalDB(path=Path(db_path)) if db_path else LocalDB()
+    return db, JobEffectStore(db, owner_talos_id=talos_id, limits=limits)
+
+
+@jobs.command(name="inspect")
+@click.option("--talos-id", required=True, help="Talos scope whose effects may be inspected")
+@click.option("--db-path", default=None, type=click.Path(dir_okay=False))
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(
+        [
+            "pending",
+            "dispatching",
+            "succeeded",
+            "retryable",
+            "indeterminate",
+            "conflict",
+            "dead",
+        ],
+        case_sensitive=True,
+    ),
+)
+@click.option("--limit", default=50, type=click.IntRange(1, 200))
+@click.option("--json", "as_json", is_flag=True, help="Emit metadata as JSON")
+def inspect_jobs(
+    talos_id: str,
+    db_path: str | None,
+    status: str | None,
+    limit: int,
+    as_json: bool,
+):
+    """List replay metadata without printing payloads or results."""
+    from talos_agent.job_effects import JobEffectError
+
+    db = None
+    try:
+        db, store = _job_store(db_path, talos_id)
+        rows = store.inspect(status=status, limit=limit)
+        if as_json:
+            console.print_json(json.dumps({"effects": rows, "count": len(rows)}))
+            return
+        if not rows:
+            console.print("[dim]No matching durable job effects.[/dim]")
+            return
+        for row in rows:
+            console.print(
+                f"{row['effect_id']} job={row['job_id']} state={row['state']} "
+                f"attempts={row['attempt_count']} "
+                f"error={row['last_error_code'] or '-'}"
+            )
+    except JobEffectError as exc:
+        raise click.ClickException(f"{exc.code}: {exc}") from exc
+    finally:
+        if db is not None:
+            db.close()
+
+
+@jobs.command(name="retry")
+@click.argument("effect_id")
+@click.option("--talos-id", required=True, help="Talos scope that owns the effect")
+@click.option("--db-path", default=None, type=click.Path(dir_okay=False))
+@click.option("--expected-attempt", required=True, type=click.IntRange(min=0))
+def retry_job_effect(
+    effect_id: str,
+    talos_id: str,
+    db_path: str | None,
+    expected_attempt: int,
+):
+    """Requeue one failed effect with a stale-decision guard."""
+    from talos_agent.job_effects import JobEffectError
+
+    db = None
+    try:
+        db, store = _job_store(db_path, talos_id)
+        result = store.requeue(effect_id, expected_attempt=expected_attempt)
+        console.print_json(json.dumps(result))
+    except JobEffectError as exc:
+        raise click.ClickException(f"{exc.code}: {exc}") from exc
+    finally:
+        if db is not None:
+            db.close()
+
+
 @main.command()
 def status():
     """Show agent status."""

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -90,8 +90,43 @@ class Settings(BaseSettings):
     auto_repay_loans: bool = Field(default=False, description="Enable automatic loan repayment from treasury")
 
     # Job leasing
-    job_lease_ttl: int = Field(default=300, description="Seconds for a claimed job lease TTL")
-    job_heartbeat_interval: int = Field(default=60, description="Seconds between job lease heartbeats")
+    job_lease_ttl: int = Field(
+        default=300,
+        ge=1,
+        le=600,
+        description="Seconds for a claimed job lease TTL",
+    )
+    job_heartbeat_interval: int = Field(
+        default=60,
+        ge=1,
+        le=300,
+        description="Seconds between job lease heartbeats",
+    )
+
+    # Durable provider-job inbox/outbox (opt-in)
+    talos_durable_job_effects_enabled: bool = Field(
+        default=False,
+        description="Persist provider jobs and completion effects before external delivery",
+    )
+    talos_job_effect_dispatch_interval: int = Field(default=2, ge=1, le=300)
+    talos_job_effect_lease_seconds: int = Field(default=30, ge=5, le=900)
+    talos_job_effect_max_attempts: int = Field(default=8, ge=1, le=100)
+    talos_job_effect_retry_base_seconds: int = Field(default=2, ge=1, le=300)
+    talos_job_effect_batch_size: int = Field(default=20, ge=1, le=200)
+    talos_job_effect_max_inbox_records: int = Field(
+        default=100_000, ge=100, le=1_000_000
+    )
+    talos_job_effect_max_outbox_records: int = Field(
+        default=100_000, ge=100, le=1_000_000
+    )
+    talos_job_effect_max_payload_bytes: int = Field(
+        default=65_536, ge=1_024, le=1_048_576
+    )
+    talos_job_effect_max_result_bytes: int = Field(
+        default=262_144, ge=1_024, le=2_097_152
+    )
+    talos_job_effect_dispatch_timeout_seconds: int = Field(default=20, ge=1, le=120)
+    talos_job_effect_db_timeout_ms: int = Field(default=5_000, ge=1, le=30_000)
 
     # Dividend distribution
     dividend_distribution_interval: int = Field(default=3600, description="Seconds between dividend distribution checks")

--- a/packages/prime-agent/src/talos_agent/db.py
+++ b/packages/prime-agent/src/talos_agent/db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -211,6 +212,61 @@ CREATE TABLE IF NOT EXISTS retry_state (
 );
         """,
     ),
+    (
+        7,
+        """
+CREATE TABLE IF NOT EXISTS job_inbox (
+    owner_talos_id         TEXT NOT NULL,
+    job_id                 TEXT NOT NULL,
+    requester_talos_id     TEXT,
+    service_type           TEXT NOT NULL,
+    payload_json           TEXT NOT NULL,
+    payload_digest         TEXT NOT NULL,
+    state                  TEXT NOT NULL DEFAULT 'received'
+                           CHECK (state IN (
+                               'received', 'claimed', 'effect_pending',
+                               'completed', 'conflict'
+                           )),
+    fencing_token          INTEGER,
+    remote_lease_expires_at TEXT,
+    completed_at           TEXT,
+    created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (owner_talos_id, job_id)
+);
+
+CREATE TABLE IF NOT EXISTS job_effect_outbox (
+    effect_id          TEXT PRIMARY KEY,
+    owner_talos_id     TEXT NOT NULL,
+    job_id             TEXT NOT NULL,
+    effect_type        TEXT NOT NULL,
+    deduplication_key  TEXT NOT NULL,
+    result_json        TEXT NOT NULL,
+    result_digest      TEXT NOT NULL,
+    fencing_token      INTEGER NOT NULL,
+    state              TEXT NOT NULL DEFAULT 'pending'
+                       CHECK (state IN (
+                           'pending', 'dispatching', 'succeeded', 'retryable',
+                           'indeterminate', 'conflict', 'dead'
+                       )),
+    attempt_count      INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at    TEXT NOT NULL,
+    lease_owner        TEXT,
+    lease_until        TEXT,
+    last_error_code    TEXT,
+    created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (owner_talos_id, deduplication_key),
+    FOREIGN KEY (owner_talos_id, job_id)
+        REFERENCES job_inbox(owner_talos_id, job_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_inbox_state
+    ON job_inbox(owner_talos_id, state, created_at);
+CREATE INDEX IF NOT EXISTS idx_job_effect_outbox_due
+    ON job_effect_outbox(owner_talos_id, state, next_attempt_at, lease_until);
+        """,
+    ),
 ]
 
 
@@ -219,6 +275,11 @@ class LocalDB:
         self._path = path
         path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(path))
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            # Some platforms/filesystems do not implement POSIX modes.
+            pass
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._run_migrations()

--- a/packages/prime-agent/src/talos_agent/job_effects.py
+++ b/packages/prime-agent/src/talos_agent/job_effects.py
@@ -1,0 +1,1042 @@
+"""Durable inbox/outbox for provider job completion effects.
+
+The Web API owns the externally visible job state.  This module persists the
+local intent before network I/O and reconciles the remote completed state after
+ambiguous failures.  Correctness is based on SQLite transactions and remote
+fencing, never on process-local locks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from talos_agent.observability import log
+
+if TYPE_CHECKING:
+    from talos_agent.api_client import TalosAPIClient
+    from talos_agent.db import LocalDB
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+class JobEffectError(Exception):
+    """Base class for safe, operator-facing durable job errors."""
+
+    code = "job_effect_error"
+
+
+class JobValidationError(JobEffectError):
+    code = "validation_error"
+
+
+class JobAuthorizationError(JobEffectError):
+    code = "authorization_error"
+
+
+class JobConflictError(JobEffectError):
+    code = "conflict"
+
+
+class JobBusyError(JobEffectError):
+    code = "busy"
+
+
+class JobCapacityError(JobEffectError):
+    code = "capacity"
+
+
+class JobStateError(JobEffectError):
+    code = "invalid_state"
+
+
+class InboxState(str, Enum):
+    RECEIVED = "received"
+    CLAIMED = "claimed"
+    EFFECT_PENDING = "effect_pending"
+    COMPLETED = "completed"
+    CONFLICT = "conflict"
+
+
+class EffectState(str, Enum):
+    PENDING = "pending"
+    DISPATCHING = "dispatching"
+    SUCCEEDED = "succeeded"
+    RETRYABLE = "retryable"
+    INDETERMINATE = "indeterminate"
+    CONFLICT = "conflict"
+    DEAD = "dead"
+
+
+@dataclass(frozen=True)
+class JobEffectLimits:
+    max_inbox_records: int = 100_000
+    max_outbox_records: int = 100_000
+    max_payload_bytes: int = 65_536
+    max_result_bytes: int = 262_144
+    batch_size: int = 20
+    lease_seconds: int = 30
+    max_attempts: int = 8
+    retry_base_seconds: int = 2
+    dispatch_timeout_seconds: int = 20
+    remote_lease_ttl_seconds: int = 300
+    busy_timeout_ms: int = 5_000
+
+
+@dataclass(frozen=True)
+class InboxRecord:
+    job_id: str
+    state: InboxState
+    payload_digest: str
+    fencing_token: int | None
+
+
+@dataclass(frozen=True)
+class EffectRecord:
+    effect_id: str
+    job_id: str
+    state: EffectState
+    result: dict[str, Any]
+    result_digest: str
+    fencing_token: int
+    attempt_count: int
+    lease_owner: str
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _validate_identifier(value: object, label: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER_RE.fullmatch(value):
+        raise JobValidationError(f"{label} must be a valid bounded identifier")
+    return value
+
+
+def _canonical_json(value: object, *, max_bytes: int, label: str) -> tuple[str, str]:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise JobValidationError(f"{label} must be JSON-compatible") from exc
+    raw = encoded.encode("utf-8")
+    if len(raw) > max_bytes:
+        raise JobValidationError(f"{label} exceeds the configured byte limit")
+    return encoded, hashlib.sha256(raw).hexdigest()
+
+
+def _validate_text(value: object, label: str, *, max_bytes: int) -> str:
+    if not isinstance(value, str):
+        raise JobValidationError(f"{label} must be a string")
+    if len(value.encode("utf-8")) > max_bytes:
+        raise JobValidationError(f"{label} exceeds the configured byte limit")
+    if any(ord(char) < 32 for char in value):
+        raise JobValidationError(f"{label} contains invalid control characters")
+    return value
+
+
+def _decode_object(encoded: str, label: str) -> dict[str, Any]:
+    value = json.loads(encoded)
+    if not isinstance(value, dict):
+        raise JobStateError(f"stored {label} is not an object")
+    return value
+
+
+class JobEffectStore:
+    """Transactional durable job state scoped to one Talos identity."""
+
+    def __init__(
+        self,
+        db: LocalDB,
+        *,
+        owner_talos_id: str,
+        limits: JobEffectLimits | None = None,
+    ):
+        self._db = db
+        self.owner_talos_id = _validate_identifier(owner_talos_id, "Talos ID")
+        self.limits = limits or JobEffectLimits()
+        numeric_bounds = {
+            "max_inbox_records": (self.limits.max_inbox_records, 1, 1_000_000),
+            "max_outbox_records": (self.limits.max_outbox_records, 1, 1_000_000),
+            "max_payload_bytes": (self.limits.max_payload_bytes, 1, 1_048_576),
+            "max_result_bytes": (self.limits.max_result_bytes, 1, 2_097_152),
+            "batch_size": (self.limits.batch_size, 1, 200),
+            "lease_seconds": (self.limits.lease_seconds, 1, 900),
+            "max_attempts": (self.limits.max_attempts, 1, 100),
+            "retry_base_seconds": (self.limits.retry_base_seconds, 1, 300),
+            "dispatch_timeout_seconds": (
+                self.limits.dispatch_timeout_seconds,
+                1,
+                120,
+            ),
+            "remote_lease_ttl_seconds": (
+                self.limits.remote_lease_ttl_seconds,
+                1,
+                3_600,
+            ),
+            "busy_timeout_ms": (self.limits.busy_timeout_ms, 1, 30_000),
+        }
+        for label, (value, minimum, maximum) in numeric_bounds.items():
+            if (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < minimum
+                or value > maximum
+            ):
+                raise JobValidationError(f"{label} is outside the supported range")
+        self._conn.execute(f"PRAGMA busy_timeout = {self.limits.busy_timeout_ms}")
+        self._conn.execute("PRAGMA synchronous = FULL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        return self._db._conn
+
+    def _begin(self) -> None:
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as exc:
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                raise JobBusyError("durable job store is busy; retry later") from exc
+            raise
+
+    def _capacity(self, table: str, limit: int) -> None:
+        count = self._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        if count >= limit:
+            log.warning(
+                "job_effect_capacity_rejected",
+                table=table,
+                limit=limit,
+                talos_id=self.owner_talos_id,
+            )
+            raise JobCapacityError(f"{table} reached its configured record limit")
+
+    def ingest(self, job: dict[str, Any]) -> InboxRecord:
+        job_id = _validate_identifier(job.get("id"), "job ID")
+        owner = _validate_identifier(job.get("talosId"), "job Talos ID")
+        if owner != self.owner_talos_id:
+            raise JobAuthorizationError("job does not belong to this Talos")
+        service_type = _validate_text(
+            job.get("serviceName") or "",
+            "service name",
+            max_bytes=200,
+        )
+        payload_json, payload_digest = _canonical_json(
+            job.get("payload"),
+            max_bytes=self.limits.max_payload_bytes,
+            label="job payload",
+        )
+        requester = job.get("requesterTalosId")
+        if requester is not None:
+            requester = _validate_identifier(requester, "requester Talos ID")
+
+        self._begin()
+        try:
+            row = self._conn.execute(
+                """
+                SELECT state, payload_digest, fencing_token,
+                       requester_talos_id, service_type
+                FROM job_inbox
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (self.owner_talos_id, job_id),
+            ).fetchone()
+            if row:
+                if (
+                    row["payload_digest"] != payload_digest
+                    or row["requester_talos_id"] != requester
+                    or row["service_type"] != service_type
+                ):
+                    raise JobConflictError("job ID was reused with different immutable data")
+                self._conn.commit()
+                return InboxRecord(
+                    job_id=job_id,
+                    state=InboxState(row["state"]),
+                    payload_digest=payload_digest,
+                    fencing_token=row["fencing_token"],
+                )
+
+            self._capacity("job_inbox", self.limits.max_inbox_records)
+            self._conn.execute(
+                """
+                INSERT INTO job_inbox (
+                    owner_talos_id, job_id, requester_talos_id, service_type,
+                    payload_json, payload_digest, state, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.owner_talos_id,
+                    job_id,
+                    requester,
+                    service_type,
+                    payload_json,
+                    payload_digest,
+                    InboxState.RECEIVED.value,
+                    _iso(_utcnow()),
+                ),
+            )
+            # Preserve the established queue for backward-compatible status and
+            # contributor tooling.  Both inserts commit atomically.
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO commerce_queue
+                    (job_id, talos_id, service_type, payload)
+                VALUES (?, ?, ?, ?)
+                """,
+                (job_id, owner, service_type, payload_json),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+        log.info(
+            "job_inbox_transition",
+            talos_id=self.owner_talos_id,
+            job_id=job_id,
+            state=InboxState.RECEIVED.value,
+        )
+        return InboxRecord(job_id, InboxState.RECEIVED, payload_digest, None)
+
+    def mark_claimed(
+        self,
+        job_id: str,
+        *,
+        fencing_token: int,
+        lease_expires_at: str | None,
+    ) -> InboxRecord:
+        job_id = _validate_identifier(job_id, "job ID")
+        if not isinstance(fencing_token, int) or isinstance(fencing_token, bool):
+            raise JobValidationError("fencing token must be an integer")
+        if fencing_token < 1 or fencing_token > 9_223_372_036_854_775_807:
+            raise JobValidationError("fencing token is outside the supported range")
+        if lease_expires_at is not None:
+            if not isinstance(lease_expires_at, str) or len(lease_expires_at) > 64:
+                raise JobValidationError("lease expiry is invalid")
+            try:
+                datetime.fromisoformat(lease_expires_at.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise JobValidationError("lease expiry is invalid") from exc
+
+        self._begin()
+        try:
+            row = self._conn.execute(
+                """
+                SELECT state, payload_digest, fencing_token
+                FROM job_inbox
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (self.owner_talos_id, job_id),
+            ).fetchone()
+            if not row:
+                raise JobStateError("job must be ingested before it can be claimed")
+            if row["state"] in (InboxState.COMPLETED.value, InboxState.CONFLICT.value):
+                raise JobStateError("terminal job cannot be claimed")
+            previous = row["fencing_token"]
+            if previous is not None and fencing_token < previous:
+                raise JobConflictError("stale fencing token was rejected")
+            self._conn.execute(
+                """
+                UPDATE job_inbox
+                SET state = ?, fencing_token = ?, remote_lease_expires_at = ?,
+                    updated_at = ?
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (
+                    InboxState.CLAIMED.value,
+                    fencing_token,
+                    lease_expires_at,
+                    _iso(_utcnow()),
+                    self.owner_talos_id,
+                    job_id,
+                ),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+        log.info(
+            "job_inbox_transition",
+            talos_id=self.owner_talos_id,
+            job_id=job_id,
+            state=InboxState.CLAIMED.value,
+        )
+        return InboxRecord(job_id, InboxState.CLAIMED, row["payload_digest"], fencing_token)
+
+    def prepare_effect(self, job_id: str, result: dict[str, Any]) -> str:
+        job_id = _validate_identifier(job_id, "job ID")
+        if not isinstance(result, dict):
+            raise JobValidationError("job result must be an object")
+        result_json, result_digest = _canonical_json(
+            result,
+            max_bytes=self.limits.max_result_bytes,
+            label="job result",
+        )
+        effect_id = hashlib.sha256(
+            f"{self.owner_talos_id}:job_result:{job_id}".encode()
+        ).hexdigest()
+        deduplication_key = f"job-result:{job_id}"
+
+        self._begin()
+        try:
+            inbox = self._conn.execute(
+                """
+                SELECT state, fencing_token
+                FROM job_inbox
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (self.owner_talos_id, job_id),
+            ).fetchone()
+            if not inbox or inbox["fencing_token"] is None:
+                raise JobStateError("job must have a durable claim before fulfillment")
+            existing = self._conn.execute(
+                """
+                SELECT result_digest, state, fencing_token
+                FROM job_effect_outbox
+                WHERE effect_id = ? AND owner_talos_id = ?
+                """,
+                (effect_id, self.owner_talos_id),
+            ).fetchone()
+            if existing:
+                if existing["result_digest"] != result_digest:
+                    raise JobConflictError("job effect was reused with a different result")
+                if inbox["fencing_token"] > existing["fencing_token"] and existing[
+                    "state"
+                ] != EffectState.SUCCEEDED.value:
+                    self._conn.execute(
+                        """
+                        UPDATE job_effect_outbox
+                        SET fencing_token = ?, updated_at = ?
+                        WHERE effect_id = ? AND owner_talos_id = ?
+                        """,
+                        (
+                            inbox["fencing_token"],
+                            _iso(_utcnow()),
+                            effect_id,
+                            self.owner_talos_id,
+                        ),
+                    )
+                self._conn.commit()
+                return effect_id
+
+            self._capacity("job_effect_outbox", self.limits.max_outbox_records)
+            now = _iso(_utcnow())
+            self._conn.execute(
+                """
+                INSERT INTO job_effect_outbox (
+                    effect_id, owner_talos_id, job_id, effect_type,
+                    deduplication_key, result_json, result_digest,
+                    fencing_token, state, next_attempt_at, updated_at
+                ) VALUES (?, ?, ?, 'submit_job_result', ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    effect_id,
+                    self.owner_talos_id,
+                    job_id,
+                    deduplication_key,
+                    result_json,
+                    result_digest,
+                    inbox["fencing_token"],
+                    EffectState.PENDING.value,
+                    now,
+                    now,
+                ),
+            )
+            self._conn.execute(
+                """
+                UPDATE job_inbox
+                SET state = ?, updated_at = ?
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (
+                    InboxState.EFFECT_PENDING.value,
+                    now,
+                    self.owner_talos_id,
+                    job_id,
+                ),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+        log.info(
+            "job_effect_transition",
+            talos_id=self.owner_talos_id,
+            job_id=job_id,
+            effect_id=effect_id,
+            state=EffectState.PENDING.value,
+            attempt_count=0,
+        )
+        return effect_id
+
+    def claim_due(self, worker_id: str, limit: int | None = None) -> list[EffectRecord]:
+        worker_id = _validate_identifier(worker_id, "worker ID")
+        limit = min(limit or self.limits.batch_size, self.limits.batch_size)
+        if limit < 1:
+            raise JobValidationError("claim limit must be positive")
+        now = _utcnow()
+        lease_until = _iso(now + timedelta(seconds=self.limits.lease_seconds))
+
+        self._begin()
+        try:
+            rows = self._conn.execute(
+                """
+                SELECT effect_id
+                FROM job_effect_outbox
+                WHERE owner_talos_id = ?
+                  AND state IN (?, ?, ?, ?)
+                  AND next_attempt_at <= ?
+                  AND (lease_until IS NULL OR lease_until <= ?)
+                ORDER BY created_at, effect_id
+                LIMIT ?
+                """,
+                (
+                    self.owner_talos_id,
+                    EffectState.PENDING.value,
+                    EffectState.RETRYABLE.value,
+                    EffectState.INDETERMINATE.value,
+                    EffectState.DISPATCHING.value,
+                    _iso(now),
+                    _iso(now),
+                    limit,
+                ),
+            ).fetchall()
+            claimed: list[EffectRecord] = []
+            for selected in rows:
+                updated = self._conn.execute(
+                    """
+                    UPDATE job_effect_outbox
+                    SET state = ?, lease_owner = ?, lease_until = ?,
+                        attempt_count = attempt_count + 1, updated_at = ?
+                    WHERE effect_id = ? AND owner_talos_id = ?
+                      AND (lease_until IS NULL OR lease_until <= ?)
+                    RETURNING effect_id, job_id, state, result_json,
+                              result_digest, fencing_token, attempt_count,
+                              lease_owner
+                    """,
+                    (
+                        EffectState.DISPATCHING.value,
+                        worker_id,
+                        lease_until,
+                        _iso(now),
+                        selected["effect_id"],
+                        self.owner_talos_id,
+                        _iso(now),
+                    ),
+                ).fetchone()
+                if updated:
+                    claimed.append(
+                        EffectRecord(
+                            effect_id=updated["effect_id"],
+                            job_id=updated["job_id"],
+                            state=EffectState(updated["state"]),
+                            result=_decode_object(updated["result_json"], "job result"),
+                            result_digest=updated["result_digest"],
+                            fencing_token=updated["fencing_token"],
+                            attempt_count=updated["attempt_count"],
+                            lease_owner=updated["lease_owner"],
+                        )
+                    )
+            self._conn.commit()
+            return claimed
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def mark_succeeded(self, effect: EffectRecord, *, reconciled: bool) -> None:
+        now = _iso(_utcnow())
+        self._begin()
+        try:
+            updated = self._conn.execute(
+                """
+                UPDATE job_effect_outbox
+                SET state = ?, lease_owner = NULL, lease_until = NULL,
+                    last_error_code = NULL, updated_at = ?
+                WHERE effect_id = ? AND owner_talos_id = ?
+                  AND state = ? AND lease_owner = ?
+                """,
+                (
+                    EffectState.SUCCEEDED.value,
+                    now,
+                    effect.effect_id,
+                    self.owner_talos_id,
+                    EffectState.DISPATCHING.value,
+                    effect.lease_owner,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise JobConflictError("dispatch lease was lost before completion")
+            self._conn.execute(
+                """
+                UPDATE job_inbox
+                SET state = ?, completed_at = ?, updated_at = ?
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (
+                    InboxState.COMPLETED.value,
+                    now,
+                    now,
+                    self.owner_talos_id,
+                    effect.job_id,
+                ),
+            )
+            self._conn.execute(
+                """
+                INSERT INTO activity_log (type, content, channel)
+                VALUES ('commerce', ?, 'x402')
+                """,
+                (f"Fulfilled job {effect.job_id}",),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        log.info(
+            "job_effect_reconciled" if reconciled else "job_effect_transition",
+            talos_id=self.owner_talos_id,
+            job_id=effect.job_id,
+            effect_id=effect.effect_id,
+            state=EffectState.SUCCEEDED.value,
+            attempt_count=effect.attempt_count,
+        )
+
+    def mark_failure(
+        self,
+        effect: EffectRecord,
+        *,
+        error_code: str,
+        indeterminate: bool,
+    ) -> EffectState:
+        if not _ERROR_CODE_RE.fullmatch(error_code):
+            raise JobValidationError("error code is invalid")
+        if effect.attempt_count >= self.limits.max_attempts:
+            state = EffectState.DEAD
+        elif indeterminate:
+            state = EffectState.INDETERMINATE
+        else:
+            state = EffectState.RETRYABLE
+        delay = min(
+            self.limits.retry_base_seconds * (2 ** max(effect.attempt_count - 1, 0)),
+            300,
+        )
+        next_attempt = _iso(_utcnow() + timedelta(seconds=delay))
+        self._begin()
+        try:
+            updated = self._conn.execute(
+                """
+                UPDATE job_effect_outbox
+                SET state = ?, next_attempt_at = ?, lease_owner = NULL,
+                    lease_until = NULL, last_error_code = ?, updated_at = ?
+                WHERE effect_id = ? AND owner_talos_id = ?
+                  AND state = ? AND lease_owner = ?
+                """,
+                (
+                    state.value,
+                    next_attempt,
+                    error_code,
+                    _iso(_utcnow()),
+                    effect.effect_id,
+                    self.owner_talos_id,
+                    EffectState.DISPATCHING.value,
+                    effect.lease_owner,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise JobConflictError("dispatch lease was lost before failure handling")
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        log.warning(
+            "job_effect_dispatch_failed",
+            talos_id=self.owner_talos_id,
+            job_id=effect.job_id,
+            effect_id=effect.effect_id,
+            state=state.value,
+            attempt_count=effect.attempt_count,
+            error_code=error_code,
+        )
+        return state
+
+    def mark_conflict(self, effect: EffectRecord) -> None:
+        self._begin()
+        try:
+            updated = self._conn.execute(
+                """
+                UPDATE job_effect_outbox
+                SET state = ?, lease_owner = NULL, lease_until = NULL,
+                    last_error_code = 'remote_result_conflict', updated_at = ?
+                WHERE effect_id = ? AND owner_talos_id = ?
+                  AND state = ? AND lease_owner = ?
+                """,
+                (
+                    EffectState.CONFLICT.value,
+                    _iso(_utcnow()),
+                    effect.effect_id,
+                    self.owner_talos_id,
+                    EffectState.DISPATCHING.value,
+                    effect.lease_owner,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise JobConflictError("dispatch lease was lost before conflict handling")
+            self._conn.execute(
+                """
+                UPDATE job_inbox
+                SET state = ?, updated_at = ?
+                WHERE owner_talos_id = ? AND job_id = ?
+                """,
+                (
+                    InboxState.CONFLICT.value,
+                    _iso(_utcnow()),
+                    self.owner_talos_id,
+                    effect.job_id,
+                ),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        log.error(
+            "job_effect_transition",
+            talos_id=self.owner_talos_id,
+            job_id=effect.job_id,
+            effect_id=effect.effect_id,
+            state=EffectState.CONFLICT.value,
+            attempt_count=effect.attempt_count,
+            error_code="remote_result_conflict",
+        )
+
+    def claimed_jobs(self) -> dict[str, int]:
+        rows = self._conn.execute(
+            """
+            SELECT inbox.job_id, inbox.fencing_token
+            FROM job_inbox AS inbox
+            LEFT JOIN job_effect_outbox AS effect
+              ON effect.owner_talos_id = inbox.owner_talos_id
+             AND effect.job_id = inbox.job_id
+            WHERE inbox.owner_talos_id = ?
+              AND (
+                  inbox.state = ?
+                  OR (
+                      inbox.state = ?
+                      AND effect.state IN (?, ?, ?, ?)
+                  )
+              )
+              AND inbox.fencing_token IS NOT NULL
+            """,
+            (
+                self.owner_talos_id,
+                InboxState.CLAIMED.value,
+                InboxState.EFFECT_PENDING.value,
+                EffectState.PENDING.value,
+                EffectState.DISPATCHING.value,
+                EffectState.RETRYABLE.value,
+                EffectState.INDETERMINATE.value,
+            ),
+        ).fetchall()
+        return {row["job_id"]: row["fencing_token"] for row in rows}
+
+    def pending_jobs(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        if limit < 1 or limit > 200:
+            raise JobValidationError("pending-job limit must be between 1 and 200")
+        rows = self._conn.execute(
+            """
+            SELECT job_id, service_type, requester_talos_id, payload_json,
+                   state, remote_lease_expires_at
+            FROM job_inbox
+            WHERE owner_talos_id = ?
+              AND state IN (?, ?)
+            ORDER BY created_at, job_id
+            LIMIT ?
+            """,
+            (
+                self.owner_talos_id,
+                InboxState.RECEIVED.value,
+                InboxState.CLAIMED.value,
+                limit,
+            ),
+        ).fetchall()
+        return [
+            {
+                "job_id": row["job_id"],
+                "service": row["service_type"],
+                "requester": row["requester_talos_id"],
+                "payload": json.loads(row["payload_json"]),
+                "state": row["state"],
+                "lease_expires_at": row["remote_lease_expires_at"],
+            }
+            for row in rows
+        ]
+
+    def effect_status(self, effect_id: str) -> dict[str, Any]:
+        effect_id = _validate_identifier(effect_id, "effect ID")
+        row = self._conn.execute(
+            """
+            SELECT effect_id, job_id, state, attempt_count, next_attempt_at,
+                   last_error_code
+            FROM job_effect_outbox
+            WHERE effect_id = ? AND owner_talos_id = ?
+            """,
+            (effect_id, self.owner_talos_id),
+        ).fetchone()
+        if not row:
+            raise JobStateError("effect was not found for this Talos")
+        return dict(row)
+
+    def inspect(
+        self, *, status: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        if limit < 1 or limit > 200:
+            raise JobValidationError("inspection limit must be between 1 and 200")
+        params: list[object] = [self.owner_talos_id]
+        where = "owner_talos_id = ?"
+        if status is not None:
+            try:
+                normalized = EffectState(status).value
+            except ValueError as exc:
+                raise JobValidationError("unknown effect status") from exc
+            where += " AND state = ?"
+            params.append(normalized)
+        params.append(limit)
+        rows = self._conn.execute(
+            f"""
+            SELECT effect_id, job_id, effect_type, state, attempt_count,
+                   next_attempt_at, lease_until, last_error_code, created_at,
+                   updated_at
+            FROM job_effect_outbox
+            WHERE {where}
+            ORDER BY created_at DESC, effect_id
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def requeue(self, effect_id: str, *, expected_attempt: int) -> dict[str, Any]:
+        effect_id = _validate_identifier(effect_id, "effect ID")
+        if expected_attempt < 0:
+            raise JobValidationError("expected attempt cannot be negative")
+        self._begin()
+        try:
+            row = self._conn.execute(
+                """
+                SELECT state, attempt_count, job_id
+                FROM job_effect_outbox
+                WHERE effect_id = ? AND owner_talos_id = ?
+                """,
+                (effect_id, self.owner_talos_id),
+            ).fetchone()
+            if not row:
+                raise JobStateError("effect was not found for this Talos")
+            if row["attempt_count"] != expected_attempt:
+                raise JobConflictError("stale expected attempt was rejected")
+            if row["state"] == EffectState.PENDING.value:
+                self._conn.commit()
+                return {
+                    "effect_id": effect_id,
+                    "job_id": row["job_id"],
+                    "state": row["state"],
+                    "attempt_count": row["attempt_count"],
+                }
+            if row["state"] not in {
+                EffectState.RETRYABLE.value,
+                EffectState.INDETERMINATE.value,
+                EffectState.DEAD.value,
+            }:
+                raise JobStateError("only retryable, indeterminate, or dead effects can be requeued")
+            self._conn.execute(
+                """
+                UPDATE job_effect_outbox
+                SET state = ?, next_attempt_at = ?, lease_owner = NULL,
+                    lease_until = NULL, last_error_code = NULL, updated_at = ?
+                WHERE effect_id = ? AND owner_talos_id = ?
+                  AND attempt_count = ?
+                """,
+                (
+                    EffectState.PENDING.value,
+                    _iso(_utcnow()),
+                    _iso(_utcnow()),
+                    effect_id,
+                    self.owner_talos_id,
+                    expected_attempt,
+                ),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        log.info(
+            "job_effect_transition",
+            talos_id=self.owner_talos_id,
+            job_id=row["job_id"],
+            effect_id=effect_id,
+            state=EffectState.PENDING.value,
+            attempt_count=expected_attempt,
+            operator_action="requeue",
+        )
+        return {
+            "effect_id": effect_id,
+            "job_id": row["job_id"],
+            "state": EffectState.PENDING.value,
+            "attempt_count": expected_attempt,
+        }
+
+
+class JobEffectDispatcher:
+    """Bounded async dispatcher with remote reconciliation."""
+
+    def __init__(
+        self,
+        store: JobEffectStore,
+        api: TalosAPIClient,
+        *,
+        worker_id: str | None = None,
+    ):
+        self.store = store
+        self.api = api
+        self.worker_id = worker_id or f"worker:{uuid.uuid4()}"
+
+    async def _reconcile(self, effect: EffectRecord) -> EffectState | None:
+        remote = await self.api.get_job_result(effect.job_id)
+        if not isinstance(remote, dict) or remote.get("status") != "completed":
+            return None
+        remote_result = remote.get("result")
+        if not isinstance(remote_result, dict):
+            self.store.mark_conflict(effect)
+            return EffectState.CONFLICT
+        try:
+            _, digest = _canonical_json(
+                remote_result,
+                max_bytes=self.store.limits.max_result_bytes,
+                label="remote job result",
+            )
+        except JobValidationError:
+            self.store.mark_conflict(effect)
+            return EffectState.CONFLICT
+        if digest == effect.result_digest:
+            self.store.mark_succeeded(effect, reconciled=True)
+            return EffectState.SUCCEEDED
+        else:
+            self.store.mark_conflict(effect)
+            return EffectState.CONFLICT
+
+    async def _refresh_remote_claim(self, effect: EffectRecord) -> bool:
+        claimed = await self.api.claim_job(
+            effect.job_id,
+            ttl_seconds=self.store.limits.remote_lease_ttl_seconds,
+        )
+        if not claimed or claimed.get("fencingToken") is None:
+            return False
+        self.store.mark_claimed(
+            effect.job_id,
+            fencing_token=claimed["fencingToken"],
+            lease_expires_at=claimed.get("leaseExpiresAt"),
+        )
+        # Idempotently updates the existing effect to the newer fencing token.
+        self.store.prepare_effect(effect.job_id, effect.result)
+        return True
+
+    async def _dispatch(self, effect: EffectRecord) -> EffectState:
+        try:
+            reconciled = await self._reconcile(effect)
+            if reconciled is not None:
+                return reconciled
+        except JobEffectError:
+            raise
+        except Exception:
+            # Reconciliation being unavailable is ambiguous, but the remote POST
+            # remains safe because completion is fenced and reconcilable.
+            pass
+
+        try:
+            response = await asyncio.wait_for(
+                self.api.submit_job_result(
+                    effect.job_id,
+                    effect.result,
+                    fencing_token=effect.fencing_token,
+                    idempotency_key=effect.effect_id,
+                ),
+                timeout=self.store.limits.dispatch_timeout_seconds,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            try:
+                reconciled = await self._reconcile(effect)
+                if reconciled is not None:
+                    return reconciled
+            except Exception:
+                pass
+            return self.store.mark_failure(
+                effect,
+                error_code="dispatch_timeout",
+                indeterminate=True,
+            )
+        except Exception:
+            try:
+                reconciled = await self._reconcile(effect)
+                if reconciled is not None:
+                    return reconciled
+            except Exception:
+                pass
+            return self.store.mark_failure(
+                effect,
+                error_code="transport_error",
+                indeterminate=True,
+            )
+
+        if response:
+            self.store.mark_succeeded(effect, reconciled=False)
+            return EffectState.SUCCEEDED
+        try:
+            reconciled = await self._reconcile(effect)
+            if reconciled is not None:
+                return reconciled
+        except Exception:
+            return self.store.mark_failure(
+                effect,
+                error_code="reconciliation_unavailable",
+                indeterminate=True,
+            )
+        try:
+            refreshed = await self._refresh_remote_claim(effect)
+        except Exception:
+            refreshed = False
+        return self.store.mark_failure(
+            effect,
+            error_code=(
+                "remote_claim_refreshed"
+                if refreshed
+                else "remote_rejected_or_pending"
+            ),
+            indeterminate=False,
+        )
+
+    async def dispatch_once(self) -> dict[str, int]:
+        effects = self.store.claim_due(self.worker_id)
+        counts = {state.value: 0 for state in EffectState}
+        for effect in effects:
+            state = await self._dispatch(effect)
+            counts[state.value] += 1
+        counts["claimed"] = len(effects)
+        return counts

--- a/packages/prime-agent/src/talos_agent/scheduler.py
+++ b/packages/prime-agent/src/talos_agent/scheduler.py
@@ -406,13 +406,49 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
     from talos_agent.payments.stellar_kit import StellarKit
     from talos_agent.tools.registry import build_all_tools
 
+    job_effect_store = None
+    job_effect_dispatcher = None
+    if settings.talos_durable_job_effects_enabled:
+        from talos_agent.job_effects import (
+            JobEffectDispatcher,
+            JobEffectLimits,
+            JobEffectStore,
+        )
+
+        limits = JobEffectLimits(
+            max_inbox_records=settings.talos_job_effect_max_inbox_records,
+            max_outbox_records=settings.talos_job_effect_max_outbox_records,
+            max_payload_bytes=settings.talos_job_effect_max_payload_bytes,
+            max_result_bytes=settings.talos_job_effect_max_result_bytes,
+            batch_size=settings.talos_job_effect_batch_size,
+            lease_seconds=settings.talos_job_effect_lease_seconds,
+            max_attempts=settings.talos_job_effect_max_attempts,
+            retry_base_seconds=settings.talos_job_effect_retry_base_seconds,
+            dispatch_timeout_seconds=settings.talos_job_effect_dispatch_timeout_seconds,
+            remote_lease_ttl_seconds=settings.job_lease_ttl,
+            busy_timeout_ms=settings.talos_job_effect_db_timeout_ms,
+        )
+        job_effect_store = JobEffectStore(
+            db,
+            owner_talos_id=settings.talos_id,
+            limits=limits,
+        )
+        job_effect_dispatcher = JobEffectDispatcher(job_effect_store, api)
+
     # Start browser session
     console.print("[bold]Starting browser session...[/bold]")
     browser = await BrowserSession.start(model_api_key=settings.llm_api_key)
     console.print("[green]Browser ready.[/green]")
 
     # Build tools
-    tools = build_all_tools(api=api, db=db, browser=browser, settings=settings)
+    tools = build_all_tools(
+        api=api,
+        db=db,
+        browser=browser,
+        settings=settings,
+        job_effect_store=job_effect_store,
+        job_effect_dispatcher=job_effect_dispatcher,
+    )
     console.print(f"[green]Registered {len(tools)} tools.[/green]")
 
     # Initialize StellarKit for balance checks
@@ -455,7 +491,14 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                         pass
                 
                 browser = await BrowserSession.start(model_api_key=settings.llm_api_key)
-                tools = build_all_tools(api=api, db=db, browser=browser, settings=settings)
+                tools = build_all_tools(
+                    api=api,
+                    db=db,
+                    browser=browser,
+                    settings=settings,
+                    job_effect_store=job_effect_store,
+                    job_effect_dispatcher=job_effect_dispatcher,
+                )
                 
                 console.print(f"[bold green]Browser reconnection event logged successfully on attempt {browser_restart_attempts}.[/bold green]")
                 return True
@@ -564,9 +607,26 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
 
                 jobs = await api.get_pending_jobs()
                 for job in jobs:
-                    db.add_commerce_job(
-                        job["id"], job["talosId"], job.get("serviceName", ""), job.get("payload")
-                    )
+                    if job_effect_store is not None:
+                        try:
+                            job_effect_store.ingest(job)
+                        except Exception as exc:
+                            from talos_agent.job_effects import JobEffectError
+
+                            if isinstance(exc, JobEffectError):
+                                log.warning(
+                                    "job_inbox_rejected",
+                                    error_code=exc.code,
+                                )
+                                continue
+                            raise
+                    else:
+                        db.add_commerce_job(
+                            job["id"],
+                            job["talosId"],
+                            job.get("serviceName", ""),
+                            job.get("payload"),
+                        )
 
                 backoff.success()
             except Exception as e:
@@ -602,7 +662,11 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
         backoff = DurableBackoff(task_name="job_heartbeat", db=db, base_delay=settings.job_heartbeat_interval)
         while not shutdown_event.is_set():
             try:
-                claimed = get_claimed_jobs_copy()
+                claimed = (
+                    job_effect_store.claimed_jobs()
+                    if job_effect_store is not None
+                    else get_claimed_jobs_copy()
+                )
                 for job_id, fencing_token in claimed.items():
                     result = await api.heartbeat_job(job_id, fencing_token)
                     if not result:
@@ -612,6 +676,40 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                 logger.debug(f"Job heartbeat error: {e}")
                 backoff.failure()
 
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=backoff.next_delay())
+                break
+            except asyncio.TimeoutError:
+                pass
+
+    async def job_effect_dispatch_task():
+        """Recover and dispatch durable provider-job effects."""
+        if job_effect_dispatcher is None:
+            return
+        backoff = DurableBackoff(
+            task_name="job_effect_dispatch",
+            db=db,
+            base_delay=settings.talos_job_effect_dispatch_interval,
+        )
+        while not shutdown_event.is_set():
+            try:
+                result = await job_effect_dispatcher.dispatch_once()
+                if result["claimed"]:
+                    log.info(
+                        "job_effect_dispatch_batch",
+                        claimed=result["claimed"],
+                        succeeded=result["succeeded"],
+                        retryable=result["retryable"],
+                        indeterminate=result["indeterminate"],
+                        conflict=result["conflict"],
+                        dead=result["dead"],
+                    )
+                backoff.success()
+            except Exception:
+                # Error details can contain driver or remote payload fragments.
+                # Emit only a stable code and let the next bounded scan retry.
+                log.error("job_effect_dispatch_batch_failed", error_code="batch_failure")
+                backoff.failure()
             try:
                 await asyncio.wait_for(shutdown_event.wait(), timeout=backoff.next_delay())
                 break
@@ -796,6 +894,10 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
         asyncio.create_task(dividend_distribution_task(), name="dividend_distribution"),
         asyncio.create_task(loan_repayment_task(), name="loan_repayment"),
     ]
+    if job_effect_dispatcher is not None:
+        tasks.append(
+            asyncio.create_task(job_effect_dispatch_task(), name="job_effect_dispatch")
+        )
 
     try:
         await shutdown_event.wait()

--- a/packages/prime-agent/src/talos_agent/tools/commerce.py
+++ b/packages/prime-agent/src/talos_agent/tools/commerce.py
@@ -7,6 +7,7 @@ import json
 from typing import TYPE_CHECKING
 
 from talos_agent.db import normalize_playbook_name
+from talos_agent.observability import log
 from talos_agent.payments import USDC_TESTNET_ISSUER
 from talos_agent.payments.x402_signer import X402Signer
 from talos_agent.tools.registry import tool
@@ -15,12 +16,15 @@ if TYPE_CHECKING:
     from talos_agent.api_client import TalosAPIClient
     from talos_agent.config import Settings
     from talos_agent.db import LocalDB
+    from talos_agent.job_effects import JobEffectDispatcher, JobEffectStore
 
 # Injected by registry.build_all_tools
 _api: TalosAPIClient = None  # type: ignore[assignment]
 _db: LocalDB = None  # type: ignore[assignment]
 _settings: Settings = None  # type: ignore[assignment]
 _signer: X402Signer | None = None
+_job_effect_store: JobEffectStore | None = None
+_job_effect_dispatcher: JobEffectDispatcher | None = None
 
 ALL_CATEGORIES = [
     "Sales", "Marketing", "Analytics", "Development", "Research",
@@ -283,6 +287,26 @@ async def remove_claimed_job(job_id: str) -> None:
     "Check for incoming x402 service requests that Other Taloses have purchased from us. Returns pending jobs available to fulfill.",
 )
 async def get_pending_jobs() -> dict:
+    if _job_effect_store is not None:
+        try:
+            jobs = await _api.get_pending_jobs()
+        except Exception:
+            jobs = []
+        for job in jobs:
+            try:
+                _job_effect_store.ingest(job)
+            except Exception as exc:
+                from talos_agent.job_effects import JobEffectError
+
+                if isinstance(exc, JobEffectError):
+                    log.warning("job_inbox_rejected", error_code=exc.code)
+                    continue
+                raise
+        durable_jobs = _job_effect_store.pending_jobs()
+        if not durable_jobs:
+            return {"status": "no_pending_jobs", "count": 0}
+        return {"jobs": durable_jobs, "count": len(durable_jobs)}
+
     jobs = await _api.get_pending_jobs()
     if not jobs:
         return {"status": "no_pending_jobs", "count": 0}
@@ -307,11 +331,29 @@ async def get_pending_jobs() -> dict:
     "Call this before working on a job, then call fulfill_job with the result.",
 )
 async def claim_job(job_id: str, ttl_seconds: int = 300) -> dict:
+    if _job_effect_store is not None:
+        if (
+            not isinstance(ttl_seconds, int)
+            or isinstance(ttl_seconds, bool)
+            or ttl_seconds < 1
+            or ttl_seconds > 600
+        ):
+            return {"error": "validation_error"}
+        # A direct claim may race ahead of polling. Refreshing the durable inbox
+        # first preserves the invariant that remote leases always have a local
+        # owner and payload record.
+        await get_pending_jobs()
     result = await _api.claim_job(job_id, ttl_seconds=ttl_seconds)
     if not result:
         return {"error": f"Failed to claim job {job_id} — it may be leased by another worker"}
     fencing_token = result.get("fencingToken")
-    if fencing_token is not None:
+    if fencing_token is not None and _job_effect_store is not None:
+        _job_effect_store.mark_claimed(
+            job_id,
+            fencing_token=fencing_token,
+            lease_expires_at=result.get("leaseExpiresAt"),
+        )
+    elif fencing_token is not None:
         await set_claimed_job(job_id, fencing_token)
     return {
         "status": "claimed",
@@ -332,6 +374,36 @@ async def fulfill_job(job_id: str, result: str = "{}") -> dict:
         result_dict = json.loads(result)
     except json.JSONDecodeError:
         result_dict = {"text": result}
+
+    if _job_effect_store is not None and _job_effect_dispatcher is not None:
+        try:
+            effect_id = _job_effect_store.prepare_effect(job_id, result_dict)
+            await _job_effect_dispatcher.dispatch_once()
+            effect = _job_effect_store.effect_status(effect_id)
+        except Exception as exc:
+            from talos_agent.job_effects import JobEffectError
+
+            if isinstance(exc, JobEffectError):
+                return {"error": exc.code, "job_id": job_id}
+            raise
+        if effect["state"] == "succeeded":
+            return {
+                "status": "fulfilled",
+                "job_id": job_id,
+                "effect_id": effect_id,
+            }
+        if effect["state"] == "conflict":
+            return {
+                "error": "remote_result_conflict",
+                "job_id": job_id,
+                "effect_id": effect_id,
+            }
+        return {
+            "status": "queued",
+            "job_id": job_id,
+            "effect_id": effect_id,
+            "effect_state": effect["state"],
+        }
 
     fencing_token = _claimed_jobs.get(job_id, 0)
     response = await _api.submit_job_result(job_id, result_dict, fencing_token=fencing_token)

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -133,6 +133,9 @@ def build_all_tools(
     db: Any,
     browser: Any,
     settings: Settings,
+    *,
+    job_effect_store: Any | None = None,
+    job_effect_dispatcher: Any | None = None,
 ) -> ToolRegistry:
     """Import all tool modules to trigger @tool registrations, then return registry."""
     # Import modules so decorators execute
@@ -165,6 +168,8 @@ def build_all_tools(
     _commerce_mod._api = api
     _commerce_mod._db = db
     _commerce_mod._settings = settings
+    _commerce_mod._job_effect_store = job_effect_store
+    _commerce_mod._job_effect_dispatcher = job_effect_dispatcher
     _stellar_mod._settings = settings
     _stellar_mod._api = api
     _learning_mod._db = db

--- a/packages/prime-agent/tests/test_durable_job_effects.py
+++ b/packages/prime-agent/tests/test_durable_job_effects.py
@@ -1,0 +1,696 @@
+"""Security and recovery tests for the durable provider-job effect boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+import talos_agent.db as db_module
+from talos_agent.api_client import TalosAPIClient
+from talos_agent.cli import main
+from talos_agent.config import Settings
+from talos_agent.db import LocalDB, _MIGRATIONS
+from talos_agent.job_effects import (
+    JobAuthorizationError,
+    JobBusyError,
+    JobCapacityError,
+    JobConflictError,
+    JobEffectDispatcher,
+    JobEffectLimits,
+    JobEffectStore,
+    JobStateError,
+    JobValidationError,
+)
+
+OWNER = "talos-provider"
+
+
+def _job(
+    job_id: str = "job-1",
+    *,
+    payload: object | None = None,
+    owner: str = OWNER,
+) -> dict:
+    return {
+        "id": job_id,
+        "talosId": owner,
+        "requesterTalosId": "talos-requester",
+        "serviceName": "research",
+        "payload": {"query": "safe"} if payload is None else payload,
+    }
+
+
+def _store(
+    db: LocalDB,
+    *,
+    limits: JobEffectLimits | None = None,
+    owner: str = OWNER,
+) -> JobEffectStore:
+    return JobEffectStore(db, owner_talos_id=owner, limits=limits)
+
+
+def _prepare(
+    store: JobEffectStore,
+    *,
+    job_id: str = "job-1",
+    result: dict | None = None,
+) -> str:
+    store.ingest(_job(job_id))
+    store.mark_claimed(
+        job_id,
+        fencing_token=7,
+        lease_expires_at="2026-07-25T12:00:00+00:00",
+    )
+    return store.prepare_effect(job_id, result or {"answer": "done"})
+
+
+def test_migration_7_creates_durable_job_tables(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "migration.db")
+    tables = {
+        row[0]
+        for row in db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    version = db._conn.execute("PRAGMA user_version").fetchone()[0]
+
+    assert {"job_inbox", "job_effect_outbox"}.issubset(tables)
+    assert version == _MIGRATIONS[-1][0] == 7
+    db.close()
+
+
+def test_store_enables_crash_safe_sqlite_settings(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "sqlite-settings.db")
+    _store(db)
+    assert db._conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+    assert db._conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    db.close()
+
+
+def test_migration_7_upgrades_v6_without_losing_existing_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = tmp_path / "upgrade-v6.db"
+    original = list(db_module._MIGRATIONS)
+    monkeypatch.setattr(db_module, "_MIGRATIONS", original[:-1])
+    old = LocalDB(path=path)
+    old.add_activity("existing", "keep-me", "test")
+    old.close()
+
+    monkeypatch.setattr(db_module, "_MIGRATIONS", original)
+    upgraded = LocalDB(path=path)
+
+    assert upgraded._conn.execute("PRAGMA user_version").fetchone()[0] == 7
+    assert (
+        upgraded._conn.execute(
+            "SELECT content FROM activity_log WHERE type = 'existing'"
+        ).fetchone()["content"]
+        == "keep-me"
+    )
+    assert (
+        upgraded._conn.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'job_effect_outbox'"
+        ).fetchone()
+        is not None
+    )
+    upgraded.close()
+
+
+def test_rollout_is_disabled_by_default_and_configuration_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = Settings(
+        _env_file=None,
+        talos_api_key="test",
+        groq_api_key="test",
+    )
+    assert settings.talos_durable_job_effects_enabled is False
+
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, talos_job_effect_batch_size=201)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, talos_job_effect_max_result_bytes=2_097_153)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, job_lease_ttl=601)
+    monkeypatch.setenv("TALOS_DURABLE_JOB_EFFECTS_ENABLED", "true")
+    monkeypatch.setenv("TALOS_JOB_EFFECT_BATCH_SIZE", "7")
+    enabled = Settings(_env_file=None)
+    assert enabled.talos_durable_job_effects_enabled is True
+    assert enabled.talos_job_effect_batch_size == 7
+
+
+def test_duplicate_inbox_delivery_is_idempotent_and_conflicts_are_rejected(
+    tmp_path: Path,
+):
+    db = LocalDB(path=tmp_path / "inbox.db")
+    store = _store(db)
+
+    first = store.ingest(_job())
+    duplicate = store.ingest(_job())
+
+    assert duplicate == first
+    assert (
+        db._conn.execute("SELECT COUNT(*) FROM job_inbox").fetchone()[0] == 1
+    )
+    assert (
+        db._conn.execute("SELECT COUNT(*) FROM commerce_queue").fetchone()[0]
+        == 1
+    )
+    with pytest.raises(JobConflictError):
+        store.ingest(_job(payload={"query": "different"}))
+    changed_service = _job()
+    changed_service["serviceName"] = "different-service"
+    with pytest.raises(JobConflictError):
+        store.ingest(changed_service)
+    db.close()
+
+
+def test_authorization_identifiers_and_payload_limits_are_enforced(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "validation.db")
+    store = _store(
+        db,
+        limits=JobEffectLimits(max_payload_bytes=20, max_result_bytes=20),
+    )
+
+    with pytest.raises(JobAuthorizationError):
+        store.ingest(_job(owner="other-talos"))
+    with pytest.raises(JobValidationError):
+        store.ingest(_job("../escape"))
+    with pytest.raises(JobValidationError):
+        store.ingest(_job(payload={"content": "x" * 50}))
+    unsafe_service = _job()
+    unsafe_service["serviceName"] = "unsafe\nservice"
+    with pytest.raises(JobValidationError):
+        store.ingest(unsafe_service)
+
+    store.ingest(_job(payload={}))
+    store.mark_claimed(
+        "job-1",
+        fencing_token=1,
+        lease_expires_at="2026-07-25T12:00:00+00:00",
+    )
+    with pytest.raises(JobValidationError):
+        store.prepare_effect("job-1", {"result": "x" * 50})
+    assert (
+        db._conn.execute("SELECT COUNT(*) FROM job_effect_outbox").fetchone()[0]
+        == 0
+    )
+    db.close()
+
+
+def test_inbox_capacity_is_bounded(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "capacity.db")
+    store = _store(db, limits=JobEffectLimits(max_inbox_records=1))
+
+    store.ingest(_job("job-1"))
+    with pytest.raises(JobCapacityError):
+        store.ingest(_job("job-2"))
+    db.close()
+
+
+def test_stale_fencing_token_and_unclaimed_fulfillment_are_rejected(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "fencing.db")
+    store = _store(db)
+    store.ingest(_job())
+
+    with pytest.raises(JobStateError):
+        store.prepare_effect("job-1", {"answer": "no-claim"})
+
+    store.mark_claimed(
+        "job-1",
+        fencing_token=9,
+        lease_expires_at="2026-07-25T12:00:00+00:00",
+    )
+    with pytest.raises(JobConflictError):
+        store.mark_claimed(
+            "job-1",
+            fencing_token=8,
+            lease_expires_at="2026-07-25T12:00:00+00:00",
+        )
+    db.close()
+
+
+def test_effect_preparation_is_atomic_idempotent_and_rejects_result_reuse(
+    tmp_path: Path,
+):
+    db = LocalDB(path=tmp_path / "effect.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+
+    assert store.prepare_effect("job-1", {"answer": "done"}) == effect_id
+    assert (
+        db._conn.execute("SELECT COUNT(*) FROM job_effect_outbox").fetchone()[0]
+        == 1
+    )
+    inbox = db._conn.execute(
+        "SELECT state FROM job_inbox WHERE job_id = 'job-1'"
+    ).fetchone()
+    assert inbox["state"] == "effect_pending"
+    with pytest.raises(JobConflictError):
+        store.prepare_effect("job-1", {"answer": "changed"})
+    db.close()
+
+
+def test_outbox_capacity_failure_rolls_back_inbox_transition(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "outbox-capacity.db")
+    store = _store(db, limits=JobEffectLimits(max_outbox_records=1))
+    _prepare(store, job_id="job-1")
+    store.ingest(_job("job-2"))
+    store.mark_claimed(
+        "job-2",
+        fencing_token=2,
+        lease_expires_at="2026-07-25T12:00:00+00:00",
+    )
+
+    with pytest.raises(JobCapacityError):
+        store.prepare_effect("job-2", {"answer": "second"})
+
+    assert (
+        db._conn.execute(
+            "SELECT state FROM job_inbox WHERE job_id = 'job-2'"
+        ).fetchone()["state"]
+        == "claimed"
+    )
+    assert (
+        db._conn.execute("SELECT COUNT(*) FROM job_effect_outbox").fetchone()[0]
+        == 1
+    )
+    db.close()
+
+
+def test_cross_instance_dispatch_lease_allows_one_owner(tmp_path: Path):
+    path = tmp_path / "lease.db"
+    db_one = LocalDB(path=path)
+    db_two = LocalDB(path=path)
+    first = _store(db_one)
+    second = _store(db_two)
+    _prepare(first)
+
+    claimed_one = first.claim_due("worker-one")
+    claimed_two = second.claim_due("worker-two")
+
+    assert len(claimed_one) == 1
+    assert claimed_two == []
+    db_one.close()
+    db_two.close()
+
+
+def test_sqlite_lock_wait_is_bounded(tmp_path: Path):
+    path = tmp_path / "locked.db"
+    holder_db = LocalDB(path=path)
+    contender_db = LocalDB(path=path)
+    contender = _store(
+        contender_db,
+        limits=JobEffectLimits(busy_timeout_ms=10),
+    )
+    holder_db._conn.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(JobBusyError):
+            contender.ingest(_job())
+    finally:
+        holder_db._conn.rollback()
+        holder_db.close()
+        contender_db.close()
+
+
+def test_concurrent_duplicate_delivery_across_connections_is_deterministic(
+    tmp_path: Path,
+):
+    path = tmp_path / "concurrent.db"
+    LocalDB(path=path).close()
+
+    def ingest_once() -> str:
+        db = LocalDB(path=path)
+        try:
+            return _store(db).ingest(_job()).payload_digest
+        finally:
+            db.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        digests = list(pool.map(lambda _: ingest_once(), range(2)))
+
+    db = LocalDB(path=path)
+    assert len(set(digests)) == 1
+    assert db._conn.execute("SELECT COUNT(*) FROM job_inbox").fetchone()[0] == 1
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_successful_dispatch_atomically_completes_inbox_and_outbox(
+    tmp_path: Path,
+):
+    db = LocalDB(path=tmp_path / "success.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(return_value={"status": "pending"})
+    api.submit_job_result = AsyncMock(return_value={"status": "completed"})
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["succeeded"] == 1
+    assert store.effect_status(effect_id)["state"] == "succeeded"
+    assert (
+        db._conn.execute(
+            "SELECT state FROM job_inbox WHERE job_id = 'job-1'"
+        ).fetchone()["state"]
+        == "completed"
+    )
+    api.submit_job_result.assert_awaited_once_with(
+        "job-1",
+        {"answer": "done"},
+        fencing_token=7,
+        idempotency_key=effect_id,
+    )
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_lost_response_is_reconciled_without_duplicate_visible_effect(
+    tmp_path: Path,
+):
+    db = LocalDB(path=tmp_path / "lost-response.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(
+        side_effect=[
+            {"status": "pending"},
+            {"status": "completed", "result": {"answer": "done"}},
+        ]
+    )
+    api.submit_job_result = AsyncMock(side_effect=TimeoutError)
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["succeeded"] == 1
+    assert store.effect_status(effect_id)["state"] == "succeeded"
+    assert api.submit_job_result.await_count == 1
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_restart_recovers_expired_dispatch_lease_by_remote_reconciliation(
+    tmp_path: Path,
+):
+    path = tmp_path / "restart.db"
+    first_db = LocalDB(path=path)
+    first_store = _store(first_db)
+    effect_id = _prepare(first_store)
+    assert first_store.claim_due("crashed-worker")
+    first_db._conn.execute(
+        """
+        UPDATE job_effect_outbox
+        SET lease_until = ?
+        WHERE effect_id = ?
+        """,
+        (
+            (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+            effect_id,
+        ),
+    )
+    first_db._conn.commit()
+    first_db.close()
+
+    restarted_db = LocalDB(path=path)
+    restarted_store = _store(restarted_db)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(
+        return_value={"status": "completed", "result": {"answer": "done"}}
+    )
+    api.submit_job_result = AsyncMock()
+
+    counts = await JobEffectDispatcher(
+        restarted_store, api, worker_id="restart-worker"
+    ).dispatch_once()
+
+    assert counts["succeeded"] == 1
+    assert restarted_store.effect_status(effect_id)["attempt_count"] == 2
+    api.submit_job_result.assert_not_awaited()
+    restarted_db.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_result_conflict_is_terminal_and_not_overwritten(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "conflict.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(
+        return_value={"status": "completed", "result": {"answer": "other"}}
+    )
+    api.submit_job_result = AsyncMock()
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["conflict"] == 1
+    assert store.effect_status(effect_id)["state"] == "conflict"
+    api.submit_job_result.assert_not_awaited()
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_malformed_completed_remote_result_is_a_safe_conflict(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "malformed-remote.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(
+        return_value={"status": "completed", "result": "unexpected"}
+    )
+    api.submit_job_result = AsyncMock()
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["conflict"] == 1
+    assert store.effect_status(effect_id)["state"] == "conflict"
+    api.submit_job_result.assert_not_awaited()
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_retryable_failure_becomes_dead_at_attempt_bound(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "dead.db")
+    store = _store(
+        db,
+        limits=JobEffectLimits(max_attempts=1, retry_base_seconds=1),
+    )
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(return_value={"status": "pending"})
+    api.submit_job_result = AsyncMock(return_value=None)
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["dead"] == 1
+    status = store.effect_status(effect_id)
+    assert status["state"] == "dead"
+    assert status["last_error_code"] == "remote_rejected_or_pending"
+    assert store.claimed_jobs() == {}
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_remote_lease_is_refreshed_for_next_attempt(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "refresh-claim.db")
+    store = _store(db, limits=JobEffectLimits(retry_base_seconds=1))
+    effect_id = _prepare(store)
+    api = MagicMock()
+    api.get_job_result = AsyncMock(return_value={"status": "pending"})
+    api.submit_job_result = AsyncMock(return_value=None)
+    api.claim_job = AsyncMock(
+        return_value={
+            "fencingToken": 8,
+            "leaseExpiresAt": "2026-07-25T12:05:00+00:00",
+        }
+    )
+
+    counts = await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    assert counts["retryable"] == 1
+    assert store.effect_status(effect_id)["last_error_code"] == "remote_claim_refreshed"
+    token = db._conn.execute(
+        "SELECT fencing_token FROM job_effect_outbox WHERE effect_id = ?",
+        (effect_id,),
+    ).fetchone()["fencing_token"]
+    assert token == 8
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_failure_logs_are_structured_and_redacted(tmp_path: Path):
+    secret = "user-payload-secret"
+    db = LocalDB(path=tmp_path / "redaction.db")
+    store = _store(db)
+    _prepare(store, result={"answer": secret})
+    api = MagicMock()
+    api.get_job_result = AsyncMock(return_value={"status": "pending"})
+    api.submit_job_result = AsyncMock(side_effect=RuntimeError(secret))
+    fake_log = MagicMock()
+
+    with patch("talos_agent.job_effects.log", fake_log):
+        await JobEffectDispatcher(store, api, worker_id="worker-one").dispatch_once()
+
+    rendered = repr(fake_log.mock_calls)
+    assert secret not in rendered
+    assert "transport_error" in rendered
+    db.close()
+
+
+def test_inspection_and_cli_never_return_payload_or_result(tmp_path: Path):
+    secret = "private-user-content"
+    path = tmp_path / "inspect.db"
+    db = LocalDB(path=path)
+    store = _store(db)
+    effect_id = _prepare(
+        store,
+        result={"answer": secret},
+    )
+    metadata = store.inspect()
+    assert secret not in json.dumps(metadata)
+    assert "result_json" not in metadata[0]
+    db.close()
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "jobs",
+            "inspect",
+            "--db-path",
+            str(path),
+            "--talos-id",
+            OWNER,
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert effect_id in result.output
+    assert secret not in result.output
+    assert "result_json" not in result.output
+
+
+def test_operator_requeue_is_idempotent_and_rejects_stale_decisions(tmp_path: Path):
+    db = LocalDB(path=tmp_path / "requeue.db")
+    store = _store(db)
+    effect_id = _prepare(store)
+    effect = store.claim_due("worker-one")[0]
+    store.mark_failure(effect, error_code="transport_error", indeterminate=True)
+
+    first = store.requeue(effect_id, expected_attempt=1)
+    duplicate = store.requeue(effect_id, expected_attempt=1)
+    assert first == duplicate
+    assert store.claimed_jobs() == {"job-1": 7}
+    with pytest.raises(JobConflictError):
+        store.requeue(effect_id, expected_attempt=0)
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_real_commerce_tool_boundary_survives_duplicate_fulfillment(
+    tmp_path: Path,
+):
+    from talos_agent.tools.commerce import claim_job, fulfill_job, get_pending_jobs
+
+    db = LocalDB(path=tmp_path / "boundary.db")
+    store = _store(db)
+    api = MagicMock()
+    api.get_pending_jobs = AsyncMock(return_value=[_job()])
+    api.claim_job = AsyncMock(
+        return_value={
+            "fencingToken": 3,
+            "leaseExpiresAt": "2026-07-25T12:00:00+00:00",
+        }
+    )
+    api.get_job_result = AsyncMock(return_value={"status": "pending"})
+    api.submit_job_result = AsyncMock(return_value={"status": "completed"})
+    dispatcher = JobEffectDispatcher(store, api, worker_id="boundary-worker")
+
+    with (
+        patch("talos_agent.tools.commerce._api", api),
+        patch("talos_agent.tools.commerce._db", db),
+        patch("talos_agent.tools.commerce._job_effect_store", store),
+        patch(
+            "talos_agent.tools.commerce._job_effect_dispatcher",
+            dispatcher,
+        ),
+    ):
+        pending = await get_pending_jobs()
+        invalid_claim = await claim_job("job-1", ttl_seconds=601)
+        claimed = await claim_job("job-1")
+        first = await fulfill_job("job-1", '{"answer":"done"}')
+        duplicate = await fulfill_job("job-1", '{"answer":"done"}')
+
+    assert pending["count"] == 1
+    assert invalid_claim == {"error": "validation_error"}
+    assert claimed["fencing_token"] == 3
+    api.claim_job.assert_awaited_once()
+    assert first["status"] == "fulfilled"
+    assert duplicate["status"] == "fulfilled"
+    assert api.submit_job_result.await_count == 1
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_fulfillment_path_remains_backward_compatible(tmp_path: Path):
+    from talos_agent.tools.commerce import fulfill_job
+
+    db = LocalDB(path=tmp_path / "legacy.db")
+    api = MagicMock()
+    api.submit_job_result = AsyncMock(return_value={"status": "completed"})
+
+    with (
+        patch("talos_agent.tools.commerce._api", api),
+        patch("talos_agent.tools.commerce._db", db),
+        patch("talos_agent.tools.commerce._job_effect_store", None),
+        patch("talos_agent.tools.commerce._job_effect_dispatcher", None),
+        patch("talos_agent.tools.commerce._claimed_jobs", {"job-1": 4}),
+    ):
+        result = await fulfill_job("job-1", '{"answer":"legacy"}')
+
+    assert result == {"status": "fulfilled", "job_id": "job-1"}
+    api.submit_job_result.assert_awaited_once_with(
+        "job-1", {"answer": "legacy"}, fencing_token=4
+    )
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_api_client_forwards_stable_idempotency_key():
+    client = object.__new__(TalosAPIClient)
+    client._post = AsyncMock(
+        return_value=MagicMock(
+            status_code=200,
+            json=lambda: {"status": "completed"},
+        )
+    )
+
+    result = await client.submit_job_result(
+        "job-1",
+        {"answer": "done"},
+        fencing_token=2,
+        idempotency_key="effect-1",
+    )
+
+    assert result == {"status": "completed"}
+    client._post.assert_awaited_once_with(
+        "/api/jobs/job-1/result",
+        json={"result": {"answer": "done"}, "fencingToken": 2},
+        headers={"Idempotency-Key": "effect-1"},
+    )
+
+
+def test_database_file_is_owner_only_where_supported(tmp_path: Path):
+    path = tmp_path / "permissions.db"
+    db = LocalDB(path=path)
+    mode = os.stat(path).st_mode & 0o777
+    db.close()
+    assert mode & 0o077 == 0

--- a/web/src/app/api/jobs/[id]/result/route.ts
+++ b/web/src/app/api/jobs/[id]/result/route.ts
@@ -87,6 +87,7 @@ export async function POST(
             and(
               eq(tlsCommerceJobs.id, id),
               eq(tlsCommerceJobs.fencingToken, effectiveFencingToken),
+              eq(tlsCommerceJobs.status, "pending"),
             ),
           )
           .returning();

--- a/web/tests/async-jobs-revenue.unit.test.ts
+++ b/web/tests/async-jobs-revenue.unit.test.ts
@@ -43,13 +43,19 @@ vi.mock("@stellar/stellar-sdk", () => {
   };
 });
 
-const mockSelectChain = (result: any) => {
-  const chain: any = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    then: vi.fn().mockImplementation((callback) => callback(result)),
+const mockSelectChain = (result: unknown[]) => {
+  const chain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+    then: vi.fn(),
   };
+  chain.from.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.limit.mockReturnValue(chain);
+  chain.then.mockImplementation(
+    (callback: (rows: unknown[]) => unknown) => callback(result),
+  );
   return chain;
 };
 
@@ -258,6 +264,50 @@ describe("Async Jobs Revenue Recording Unit Tests", () => {
       expect(response.status).toBe(409);
       // Verify that the transaction was never entered
       expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it("does NOT record revenue when a concurrent completion loses the pending-state CAS", async () => {
+      // Both workers may read "pending" before either transaction commits.
+      // The UPDATE includes status='pending', so the loser returns no row.
+      mockDb.select
+        .mockReturnValueOnce(mockSelectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(mockSelectChain([mockJob]));
+
+      const mockTxUpdate = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+      const mockTxInsert = vi.fn();
+
+      mockDb.transaction.mockImplementation(async (callback) => {
+        const mockTx = {
+          update: mockTxUpdate,
+          insert: mockTxInsert,
+          select: vi.fn(),
+        };
+        return callback(mockTx);
+      });
+
+      const request = new NextRequest("http://localhost:3000/api/jobs/job_1/result", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer mock_token",
+        },
+        body: JSON.stringify({
+          result: { data: "concurrent-result" },
+        }),
+      });
+
+      const response = await completeJobPOST(request, {
+        params: Promise.resolve({ id: "job_1" }),
+      });
+
+      expect(response.status).toBe(409);
+      expect(mockTxUpdate).toHaveBeenCalledTimes(1);
+      expect(mockTxInsert).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #226

## Summary

Implement a durable Prime Agent inbox/outbox for crash-safe job processing and exactly-once publication of provider result effects.

The feature is backward compatible and disabled by default. When enabled, job receipt, claims, prepared effects, dispatch leases, retries, terminal state, and replay metadata are persisted in SQLite instead of relying on process-local memory.

## Architecture

- Add versioned `job_inbox` and `job_effect_outbox` tables with an additive migration.
- Atomically persist API deliveries in the durable inbox while preserving the existing commerce queue.
- Derive stable SHA-256 effect IDs/deduplication keys from the owner, job, and effect type.
- Use `BEGIN IMMEDIATE`, compare-and-set transitions, fencing tokens, and database-backed dispatch leases for cross-process correctness.
- Reconcile remote job state before submission and after ambiguous failures such as timeouts or lost responses.
- Atomically mark the outbox effect succeeded, complete the inbox record, and write activity metadata.
- Add bounded retries, deterministic exponential backoff, terminal dead/conflict states, and operator requeue guarded by the expected attempt.
- Add metadata-only `talos-agent jobs inspect` and `talos-agent jobs retry` commands.
- Add structured transition/failure logs containing stable codes and identifiers, never job payloads, results, credentials, or raw exception text.
- Require `status = pending` in the web result compare-and-set update, preventing concurrent completions from both creating revenue effects.

## Rollout and compatibility

- Disabled by default with `TALOS_DURABLE_JOB_EFFECTS_ENABLED=false`.
- Existing in-memory behavior remains unchanged while disabled.
- Resource limits, batch sizes, retry bounds, lease durations, payload/result sizes, SQLite lock waits, and dispatch timeouts are configurable and validated.
- Rollback is performed by disabling the feature and restarting the agent; additive tables remain available for recovery.
- Migration compatibility and rollback procedures are documented in `docs/prime-agent-durable-job-effects.md`.

## Focused failure-path evidence

| Scenario | Evidence |
| --- | --- |
| Concurrent duplicate delivery | Cross-connection test proves one durable inbox row and a stable digest. |
| Concurrent dispatch | Two store instances contend for a DB lease; only one claims the effect. |
| Atomic rollback | Outbox-capacity failure leaves the inbox transition uncommitted. |
| Restart recovery | An expired dispatch lease is reclaimed by a newly constructed store/dispatcher. |
| Lost response | A timeout is reconciled through the remote result endpoint without a second externally visible effect. |
| Duplicate fulfillment | The real commerce-tool boundary submits one external result for duplicate fulfillment calls. |
| Stale fencing/version | Stale claim tokens and changed immutable job data are rejected deterministically. |
| Retry exhaustion | Retryable failures transition to `dead` after the configured attempt bound. |
| Redaction | Structured logs and CLI inspection are asserted not to contain payload/result secrets. |
| Authorization and limits | Owner scoping, identifiers, control characters, payload/result sizes, capacities, timeouts, and numeric bounds are explicitly tested. |

## Test plan

- [x] Prime Agent full suite
  - `cd packages/prime-agent && env UV_CACHE_DIR=/tmp/talos-uv-cache-226 PYTHONPATH=src /tmp/talos-uv-bin/uv run --extra dev pytest -q`
  - **284 passed in 1.71s**
- [x] Focused durable-effects suite
  - `cd packages/prime-agent && env UV_CACHE_DIR=/tmp/talos-uv-cache-226 PYTHONPATH=src /tmp/talos-uv-bin/uv run --extra dev pytest -q tests/test_durable_job_effects.py`
  - **27 passed**
- [x] Changed-file Python lint
  - `cd packages/prime-agent && env UV_CACHE_DIR=/tmp/talos-uv-cache-226 PYTHONPATH=src /tmp/talos-uv-bin/uv run --extra dev ruff check src/talos_agent/job_effects.py src/talos_agent/db.py src/talos_agent/config.py src/talos_agent/api_client.py src/talos_agent/tools/commerce.py src/talos_agent/tools/registry.py src/talos_agent/scheduler.py src/talos_agent/cli.py tests/test_durable_job_effects.py`
  - **All checks passed**
- [x] Prime Agent compilation and package build
  - `python -m compileall -q src`: **passed**
  - `uv build --out-dir /tmp/talos-agent-dist-226-verified`: **sdist and wheel built**
- [x] Web unit tests
  - `env CI=true pnpm --filter web test:unit`
  - **6 files passed, 58 tests passed**
- [x] Web type check and changed-file lint
  - `cd web && ./node_modules/.bin/tsc --noEmit`: **passed**
  - `cd web && ./node_modules/.bin/eslint 'src/app/api/jobs/[id]/result/route.ts' tests/async-jobs-revenue.unit.test.ts`: **passed**
- [x] Contract tests
  - `cargo test --workspace`
  - **67 passed** (governance 5, name service 20, registry 38, TTL manager 4)
- [x] `git diff --check`: **passed**
- [x] Documentation updated for configuration, signals, migration, recovery, rollback, local verification, and limitations.

## Existing repository baseline

Repository-wide checks still surface failures in untouched code: four Ruff findings in `tests/test_adapter_health.py`, existing contract formatting differences, existing broad web lint debt, and the existing Next.js `/_not-found` prerender error (`bi?.getItem is not a function`). Every focused check for files and boundaries changed by this PR passes.

## Known limitations

- The exactly-once guarantee covers publication of the provider job-result effect. Arbitrary side effects performed while computing a result still require their own idempotency keys.
- SQLite coordinates processes sharing one local database file; it is not a distributed database across hosts.
- Inbox payloads and prepared results must be persisted for recovery. The database is restricted to mode `0600` where supported; operators requiring at-rest confidentiality should use encrypted storage.
- This branch introduces migration version 7. If another pending migration using version 7 lands first, this migration must be renumbered during rebase.