### PR TITLE
fix(agent): reconcile schedules and leases after checkpoint restore (…

### DIFF
--- a/packages/prime-agent/src/talos_agent/db.py
+++ b/packages/prime-agent/src/talos_agent/db.py
@@ -254,6 +254,39 @@ CREATE INDEX IF NOT EXISTS idx_checkpoint_envelopes_agent_ns_seq
     ON checkpoint_envelopes(agent_id, namespace, seq);
         """,
     ),
+    (
+        9,
+        # claimed_jobs: durable fencing-token store so job leases survive restarts.
+        # A row exists as long as the agent holds the lease; it is deleted on
+        # fulfill / abandon.  reconcile_after_restore() re-validates rows against
+        # the authoritative API and prunes any whose lease is no longer ours.
+        #
+        # completion_markers: idempotency log.  Before completing any job the
+        # agent writes a marker; on restore, duplicate markers are detected and
+        # the work is skipped.  Rows are retained for 7 days (pruned at startup).
+        """
+CREATE TABLE IF NOT EXISTS claimed_jobs (
+    job_id          TEXT PRIMARY KEY,
+    fencing_token   INTEGER NOT NULL,
+    claimed_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    lease_expires_at TEXT,
+    ttl_seconds     INTEGER NOT NULL DEFAULT 300
+);
+
+CREATE TABLE IF NOT EXISTS completion_markers (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id          TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    completed_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_completion_markers_job_id
+    ON completion_markers(job_id);
+CREATE INDEX IF NOT EXISTS idx_completion_markers_expires_at
+    ON completion_markers(expires_at);
+        """,
+    ),
 ]
 
 
@@ -848,6 +881,162 @@ class LocalDB:
             (task_name,),
         )
         self._conn.commit()
+
+    # ── Claimed Jobs (fencing-token persistence) ───────────
+
+    def upsert_claimed_job(
+        self,
+        job_id: str,
+        fencing_token: int,
+        ttl_seconds: int = 300,
+        lease_expires_at: datetime | None = None,
+    ) -> None:
+        """Persist a claimed job's fencing token so it survives restarts.
+
+        ``lease_expires_at`` is the server-reported wall-clock time at which
+        the lease expires.  When ``None`` it is approximated from
+        ``claimed_at + ttl_seconds``.
+        """
+        if not job_id or not isinstance(job_id, str):
+            raise ValueError("job_id must be a non-empty string")
+        if not isinstance(fencing_token, int) or fencing_token < 0:
+            raise ValueError("fencing_token must be a non-negative integer")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+
+        expires_iso = (
+            lease_expires_at.isoformat()
+            if lease_expires_at is not None
+            else (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        )
+        self._conn.execute(
+            """INSERT INTO claimed_jobs (job_id, fencing_token, lease_expires_at, ttl_seconds)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(job_id) DO UPDATE SET
+                   fencing_token   = excluded.fencing_token,
+                   lease_expires_at = excluded.lease_expires_at,
+                   ttl_seconds     = excluded.ttl_seconds""",
+            (job_id, fencing_token, expires_iso, ttl_seconds),
+        )
+        self._conn.commit()
+
+    def get_claimed_job(self, job_id: str) -> dict | None:
+        """Return the persisted claim for *job_id*, or ``None`` if not found."""
+        row = self._conn.execute(
+            "SELECT job_id, fencing_token, claimed_at, lease_expires_at, ttl_seconds "
+            "FROM claimed_jobs WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "job_id": row["job_id"],
+            "fencing_token": int(row["fencing_token"]),
+            "claimed_at": datetime.fromisoformat(row["claimed_at"]),
+            "lease_expires_at": (
+                datetime.fromisoformat(row["lease_expires_at"])
+                if row["lease_expires_at"]
+                else None
+            ),
+            "ttl_seconds": int(row["ttl_seconds"]),
+        }
+
+    def get_all_claimed_jobs(self) -> list[dict]:
+        """Return all persisted claimed jobs (used during restore reconciliation)."""
+        rows = self._conn.execute(
+            "SELECT job_id, fencing_token, claimed_at, lease_expires_at, ttl_seconds "
+            "FROM claimed_jobs"
+        ).fetchall()
+        result = []
+        for row in rows:
+            result.append(
+                {
+                    "job_id": row["job_id"],
+                    "fencing_token": int(row["fencing_token"]),
+                    "claimed_at": datetime.fromisoformat(row["claimed_at"]),
+                    "lease_expires_at": (
+                        datetime.fromisoformat(row["lease_expires_at"])
+                        if row["lease_expires_at"]
+                        else None
+                    ),
+                    "ttl_seconds": int(row["ttl_seconds"]),
+                }
+            )
+        return result
+
+    def delete_claimed_job(self, job_id: str) -> None:
+        """Remove a claimed-job record (after fulfillment or abandon)."""
+        self._conn.execute("DELETE FROM claimed_jobs WHERE job_id = ?", (job_id,))
+        self._conn.commit()
+
+    # ── Completion Markers (idempotency log) ───────────────
+
+    def add_completion_marker(
+        self,
+        job_id: str,
+        idempotency_key: str,
+        retain_days: int = 7,
+    ) -> None:
+        """Write a completion marker for *job_id* / *idempotency_key*.
+
+        Raises ``sqlite3.IntegrityError`` if the ``idempotency_key`` is already
+        present — the caller should catch this and skip re-doing the work.
+
+        Parameters
+        ----------
+        job_id:
+            The job being completed.
+        idempotency_key:
+            A unique key for this completion attempt, e.g.
+            ``f"{job_id}:{result_hash}"``.  Must be unique across all jobs.
+        retain_days:
+            How many days the marker is kept before expiry.  Expired markers
+            are pruned by :meth:`prune_expired_completion_markers`.
+        """
+        if not job_id or not isinstance(job_id, str):
+            raise ValueError("job_id must be a non-empty string")
+        if not idempotency_key or not isinstance(idempotency_key, str):
+            raise ValueError("idempotency_key must be a non-empty string")
+        if retain_days <= 0:
+            raise ValueError("retain_days must be positive")
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(days=retain_days)
+        ).isoformat()
+        self._conn.execute(
+            "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) "
+            "VALUES (?, ?, ?)",
+            (job_id, idempotency_key, expires_at),
+        )
+        self._conn.commit()
+
+    def has_completion_marker(self, idempotency_key: str) -> bool:
+        """Return ``True`` if a non-expired marker with this key exists."""
+        row = self._conn.execute(
+            "SELECT 1 FROM completion_markers "
+            "WHERE idempotency_key = ? AND expires_at > datetime('now')",
+            (idempotency_key,),
+        ).fetchone()
+        return row is not None
+
+    def get_completion_markers_for_job(self, job_id: str) -> list[dict]:
+        """Return all non-expired completion markers for a job (used in duplicate detection)."""
+        rows = self._conn.execute(
+            "SELECT id, job_id, idempotency_key, completed_at, expires_at "
+            "FROM completion_markers "
+            "WHERE job_id = ? AND expires_at > datetime('now') "
+            "ORDER BY completed_at DESC",
+            (job_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def prune_expired_completion_markers(self) -> int:
+        """Delete expired completion markers. Returns the number of rows removed."""
+        cursor = self._conn.execute(
+            "DELETE FROM completion_markers WHERE expires_at <= datetime('now')"
+        )
+        self._conn.commit()
+        return cursor.rowcount
 
     # ── Cleanup ────────────────────────────────────────────
 

--- a/packages/prime-agent/src/talos_agent/restore.py
+++ b/packages/prime-agent/src/talos_agent/restore.py
@@ -1,0 +1,576 @@
+"""Post-checkpoint-restore reconciliation for the Talos agent.
+
+Problem
+-------
+After a crash-restore or process restart the agent's in-memory state is gone.
+The SQLite database persists schedules, backoff state, and (after this fix)
+claimed job fencing tokens.  But that persisted state may be *stale*:
+
+* ``retry_state.next_attempt_at`` could be hours in the future if the clock
+  was skewed or the agent crashed mid-backoff.
+* ``schedules.last_run_at`` could be far in the past (missed runs) or
+  impossibly far in the future (clock skew).
+* ``claimed_jobs`` rows might refer to leases that have already expired on
+  the server, or that another worker has since claimed.
+* ``completion_markers`` rows for already-expired entries should be pruned to
+  keep idempotency lookups fast.
+
+This module provides :func:`reconcile_after_restore` — a single async
+function called at agent startup that performs all of these reconciliation
+steps deterministically before the scheduler starts any background tasks.
+
+Reconciliation steps (in order)
+---------------------------------
+1. **Prune expired completion markers** — fast O(n) DELETE before anything else.
+2. **Cap stale backoff timestamps** — any ``next_attempt_at`` beyond
+   ``MAX_BACKOFF_FUTURE_SECS`` from now is clamped to ``now + base_delay``.
+3. **Validate schedule timestamps** — any ``last_run_at`` that is in the
+   *future* by more than ``MAX_CLOCK_SKEW_SECS`` is reset to ``now`` so the
+   task does not skip its first post-restore run.
+4. **Re-verify claimed jobs against the API** — for each persisted
+   ``claimed_jobs`` row:
+   a. Check whether the lease is still ours via ``api.heartbeat_job``.
+   b. If the heartbeat succeeds: restore the fencing token into the in-memory
+      ``_claimed_jobs`` dict (commerce module).
+   c. If the heartbeat fails (lease lost, expired, or server error): remove
+      the row from DB and skip restoring it into memory.
+   d. If the API is unreachable: keep the DB row but *do not* populate
+      in-memory state — the job_heartbeat_task will rediscover it later once
+      connectivity is restored.
+
+Configuration (via ``ReconcileConfig``)
+-----------------------------------------
+All thresholds are configurable with sensible defaults.  See
+:class:`ReconcileConfig` for details.
+
+Observability
+--------------
+Every action is emitted through ``structlog`` (structured JSON) at ``INFO``
+level via ``talos_agent.observability.log``.  A single summary record
+``restore_reconciliation_complete`` is emitted at the end with counts of
+every action taken.
+
+Errors
+------
+Individual step failures are logged as warnings and do not abort reconciliation
+— the function is designed to be fault-tolerant so a single broken row does
+not prevent the agent from starting.
+
+Rollback / migration safety
+-----------------------------
+This module depends on migration 9 (``claimed_jobs`` and
+``completion_markers`` tables).  On a database that predates migration 9,
+:meth:`LocalDB._run_migrations` applies the migration automatically on
+``LocalDB.__init__``, so no manual action is required.
+
+A fresh agent that has never claimed a job will have an empty
+``claimed_jobs`` table; reconciliation will be a no-op in under 1 ms.
+
+Limitations
+-----------
+* Re-verification requires a live connection to the Talos API.  If the API
+  is unreachable on startup, claimed-jobs will not be restored to in-memory
+  state in this pass.  The ``job_heartbeat_task`` will attempt heartbeats
+  every ``job_heartbeat_interval`` seconds; if the first heartbeat succeeds it
+  will call ``set_claimed_job`` which repopulates memory.  This means there is
+  a window (up to ``job_heartbeat_interval``) after an offline restore where
+  the agent cannot fulfill jobs — this is acceptable because the heartbeat
+  itself would fail anyway.
+* Clock-skew validation uses the agent's local wall clock.  If the system
+  clock is broken, ``MAX_CLOCK_SKEW_SECS`` guards will still fire; the only
+  scenario they cannot defend against is a clock that is *consistently* wrong
+  by less than ``MAX_CLOCK_SKEW_SECS``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from talos_agent.observability import log
+
+if TYPE_CHECKING:
+    from talos_agent.api_client import TalosAPIClient
+    from talos_agent.db import LocalDB
+
+logger = logging.getLogger(__name__)
+
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+@dataclass
+class ReconcileConfig:
+    """Thresholds and options for :func:`reconcile_after_restore`.
+
+    Attributes
+    ----------
+    max_backoff_future_secs:
+        Any ``next_attempt_at`` more than this many seconds in the future is
+        capped to ``now + backoff_cap_secs``.  Default: 3 600 (1 hour).
+    backoff_cap_secs:
+        Value to replace a future-skewed ``next_attempt_at`` with after
+        capping.  Default: 60 (1 minute) — conservative but quick to recover.
+    max_clock_skew_secs:
+        Any ``last_run_at`` in the *future* by more than this many seconds is
+        reset to ``now`` so the task runs immediately on the first cycle.
+        Default: 300 (5 minutes).
+    completion_marker_retain_days:
+        How long completion markers are kept before expiry.  Must match the
+        value used by :meth:`LocalDB.add_completion_marker`.  Default: 7.
+    api_verify_leases:
+        When ``True`` (default), call ``api.heartbeat_job`` for each claimed
+        job to verify ownership.  Set to ``False`` in unit tests or
+        offline-only environments where the API is unavailable.
+    api_timeout_secs:
+        Per-job API timeout during lease verification.  Default: 10.
+    """
+
+    max_backoff_future_secs: float = 3_600.0
+    backoff_cap_secs: float = 60.0
+    max_clock_skew_secs: float = 300.0
+    completion_marker_retain_days: int = 7
+    api_verify_leases: bool = True
+    api_timeout_secs: float = 10.0
+
+
+_DEFAULT_CONFIG = ReconcileConfig()
+
+
+# ── Result dataclass ───────────────────────────────────────────────────────────
+
+@dataclass
+class ReconcileResult:
+    """Summary of actions taken during reconciliation.
+
+    All counts are for this single reconciliation pass only.
+    """
+
+    # Completion markers
+    markers_pruned: int = 0
+
+    # Backoff state
+    backoff_rows_capped: int = 0
+
+    # Schedule timestamps
+    schedules_reset: int = 0
+
+    # Claimed jobs
+    claimed_jobs_found: int = 0
+    claimed_jobs_restored: int = 0   # lease verified ✓ → populated in memory
+    claimed_jobs_dropped: int = 0    # lease lost/expired → removed from DB
+    claimed_jobs_deferred: int = 0   # API unreachable → kept in DB, not in memory
+
+    # Errors
+    errors: list[str] = field(default_factory=list)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 string (possibly without timezone) into a UTC datetime."""
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── Step 1: prune expired completion markers ───────────────────────────────────
+
+def _prune_completion_markers(db: LocalDB, result: ReconcileResult) -> None:
+    """Delete completion markers whose ``expires_at`` is in the past."""
+    try:
+        count = db.prune_expired_completion_markers()
+        result.markers_pruned = count
+        if count:
+            log.info(
+                "restore_prune_completion_markers",
+                pruned=count,
+            )
+    except Exception as exc:  # noqa: BLE001
+        msg = f"prune_completion_markers failed: {exc}"
+        result.errors.append(msg)
+        logger.warning(msg)
+
+
+# ── Step 2: cap future-skewed backoff timestamps ───────────────────────────────
+
+def _cap_stale_backoff(
+    db: LocalDB,
+    result: ReconcileResult,
+    config: ReconcileConfig,
+) -> None:
+    """Clamp ``next_attempt_at`` values that are implausibly far in the future.
+
+    A crashed agent may have written a ``next_attempt_at`` many hours away.
+    Without capping, every task would wait for that full duration on restart,
+    making the agent effectively frozen.
+
+    The cap is ``config.backoff_cap_secs`` seconds from now — enough time for
+    transient failures to resolve without locking the agent out for hours.
+    """
+    now = _now_utc()
+    cutoff = now + timedelta(seconds=config.max_backoff_future_secs)
+    replacement = now + timedelta(seconds=config.backoff_cap_secs)
+
+    try:
+        # Read all retry_state rows and check each one
+        rows = db._conn.execute(
+            "SELECT task_name, attempt_count, next_attempt_at, terminal "
+            "FROM retry_state"
+        ).fetchall()
+    except Exception as exc:  # noqa: BLE001
+        msg = f"cap_stale_backoff: failed to read retry_state: {exc}"
+        result.errors.append(msg)
+        logger.warning(msg)
+        return
+
+    for row in rows:
+        task_name = row["task_name"]
+        next_at_raw = row["next_attempt_at"]
+        next_at = _parse_dt(next_at_raw)
+        if next_at is None:
+            # Corrupt value — reset to now
+            try:
+                db.upsert_retry_state(
+                    task_name,
+                    attempt_count=int(row["attempt_count"]),
+                    next_attempt_at=now,
+                    terminal=bool(row["terminal"]),
+                )
+                result.backoff_rows_capped += 1
+                log.info(
+                    "restore_backoff_capped_corrupt",
+                    task=task_name,
+                    raw_value=str(next_at_raw)[:64],
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = f"cap_stale_backoff: failed to reset corrupt row for {task_name!r}: {exc}"
+                result.errors.append(msg)
+                logger.warning(msg)
+            continue
+
+        if next_at > cutoff:
+            original_iso = next_at.isoformat()
+            try:
+                db.upsert_retry_state(
+                    task_name,
+                    attempt_count=int(row["attempt_count"]),
+                    next_attempt_at=replacement,
+                    terminal=bool(row["terminal"]),
+                )
+                result.backoff_rows_capped += 1
+                log.info(
+                    "restore_backoff_capped",
+                    task=task_name,
+                    original_next_at=original_iso,
+                    capped_to=replacement.isoformat(),
+                    skew_secs=round((next_at - now).total_seconds()),
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = (
+                    f"cap_stale_backoff: failed to cap row for {task_name!r}: {exc}"
+                )
+                result.errors.append(msg)
+                logger.warning(msg)
+
+
+# ── Step 3: validate schedule timestamps for clock skew ───────────────────────
+
+def _validate_schedule_timestamps(
+    db: LocalDB,
+    result: ReconcileResult,
+    config: ReconcileConfig,
+) -> None:
+    """Reset any ``last_run_at`` that is impossibly in the future.
+
+    A future ``last_run_at`` causes every task to skip its first post-restore
+    run (it looks like it already ran recently).  This step detects that and
+    resets the timestamp to now, ensuring tasks run on their normal interval
+    after startup.
+    """
+    now = _now_utc()
+    # A schedule timestamp is "impossible future" if it's more than
+    # max_clock_skew_secs ahead of the current wall clock.
+    skew_limit = now + timedelta(seconds=config.max_clock_skew_secs)
+
+    try:
+        rows = db._conn.execute(
+            "SELECT task_name, last_run_at FROM schedules"
+        ).fetchall()
+    except Exception as exc:  # noqa: BLE001
+        msg = f"validate_schedule_timestamps: failed to read schedules: {exc}"
+        result.errors.append(msg)
+        logger.warning(msg)
+        return
+
+    for row in rows:
+        task_name = row["task_name"]
+        last_run_raw = row["last_run_at"]
+        last_run = _parse_dt(last_run_raw)
+
+        if last_run is None:
+            # Corrupt — reset
+            try:
+                db.update_schedule.__func__(db, task_name)  # type: ignore[attr-defined]
+                result.schedules_reset += 1
+                log.info(
+                    "restore_schedule_reset_corrupt",
+                    task=task_name,
+                    raw_value=str(last_run_raw)[:64],
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = (
+                    f"validate_schedule_timestamps: failed to reset corrupt schedule "
+                    f"for {task_name!r}: {exc}"
+                )
+                result.errors.append(msg)
+                logger.warning(msg)
+            continue
+
+        if last_run > skew_limit:
+            original_iso = last_run.isoformat()
+            try:
+                # Reset to now so the task fires on its normal next interval
+                db._conn.execute(
+                    "UPDATE schedules SET last_run_at = ? WHERE task_name = ?",
+                    (now.isoformat(), task_name),
+                )
+                db._conn.commit()
+                result.schedules_reset += 1
+                log.info(
+                    "restore_schedule_reset_skewed",
+                    task=task_name,
+                    original_last_run_at=original_iso,
+                    reset_to=now.isoformat(),
+                    skew_secs=round((last_run - now).total_seconds()),
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = (
+                    f"validate_schedule_timestamps: failed to reset skewed schedule "
+                    f"for {task_name!r}: {exc}"
+                )
+                result.errors.append(msg)
+                logger.warning(msg)
+
+
+# ── Step 4: re-verify claimed jobs against authoritative API ───────────────────
+
+async def _verify_claimed_jobs(
+    db: LocalDB,
+    api: TalosAPIClient | None,
+    result: ReconcileResult,
+    config: ReconcileConfig,
+) -> None:
+    """Re-verify each persisted claimed job and repopulate in-memory state.
+
+    For each row in ``claimed_jobs``:
+
+    * If ``api`` is ``None`` or ``api_verify_leases`` is ``False``:
+      restore the fencing token into memory unconditionally (useful for
+      offline testing).
+    * Otherwise call ``api.heartbeat_job(job_id, fencing_token)``:
+      - Success: restore to memory.
+      - Failure (any exception or falsy return): remove from DB and log.
+      - Timeout/network error: keep in DB, skip memory restore (deferred).
+    """
+    from talos_agent.tools import commerce  # local import to avoid circular deps
+
+    try:
+        claimed_rows = db.get_all_claimed_jobs()
+    except Exception as exc:  # noqa: BLE001
+        msg = f"verify_claimed_jobs: failed to read claimed_jobs: {exc}"
+        result.errors.append(msg)
+        logger.warning(msg)
+        return
+
+    result.claimed_jobs_found = len(claimed_rows)
+    if not claimed_rows:
+        return
+
+    now = _now_utc()
+
+    for row in claimed_rows:
+        job_id = row["job_id"]
+        fencing_token = row["fencing_token"]
+        lease_expires_at = row.get("lease_expires_at")
+
+        # ── Offline or verify-disabled: restore unconditionally ──────────
+        if not config.api_verify_leases or api is None:
+            commerce._claimed_jobs[job_id] = fencing_token
+            result.claimed_jobs_restored += 1
+            log.info(
+                "restore_job_restored_offline",
+                job_id=job_id,
+                fencing_token=fencing_token,
+            )
+            continue
+
+        # ── Check whether the lease has already expired locally ───────────
+        # (Avoids an unnecessary API round-trip for obviously-expired leases.)
+        if lease_expires_at is not None and lease_expires_at < now:
+            log.info(
+                "restore_job_dropped_expired",
+                job_id=job_id,
+                fencing_token=fencing_token,
+                lease_expires_at=lease_expires_at.isoformat(),
+            )
+            try:
+                db.delete_claimed_job(job_id)
+            except Exception as exc:  # noqa: BLE001
+                msg = f"verify_claimed_jobs: failed to delete expired job {job_id!r}: {exc}"
+                result.errors.append(msg)
+                logger.warning(msg)
+            result.claimed_jobs_dropped += 1
+            continue
+
+        # ── Verify via API heartbeat ───────────────────────────────────────
+        try:
+            import asyncio
+            heartbeat_ok = await asyncio.wait_for(
+                api.heartbeat_job(job_id, fencing_token),
+                timeout=config.api_timeout_secs,
+            )
+            if heartbeat_ok:
+                commerce._claimed_jobs[job_id] = fencing_token
+                result.claimed_jobs_restored += 1
+                log.info(
+                    "restore_job_restored",
+                    job_id=job_id,
+                    fencing_token=fencing_token,
+                )
+            else:
+                # Server rejected our heartbeat — lease no longer ours
+                log.info(
+                    "restore_job_dropped_lost",
+                    job_id=job_id,
+                    fencing_token=fencing_token,
+                )
+                try:
+                    db.delete_claimed_job(job_id)
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"verify_claimed_jobs: failed to delete lost job {job_id!r}: {exc}"
+                    result.errors.append(msg)
+                    logger.warning(msg)
+                result.claimed_jobs_dropped += 1
+        except asyncio.TimeoutError:
+            # API slow/unreachable — keep DB row, skip memory restore
+            result.claimed_jobs_deferred += 1
+            log.warning(
+                "restore_job_deferred_timeout",
+                job_id=job_id,
+                timeout_secs=config.api_timeout_secs,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Unexpected error — treat as API unavailable, defer
+            result.claimed_jobs_deferred += 1
+            msg = (
+                f"verify_claimed_jobs: unexpected error verifying job {job_id!r}: {exc}"
+            )
+            result.errors.append(msg)
+            log.warning(
+                "restore_job_deferred_error",
+                job_id=job_id,
+                error=str(exc),
+            )
+
+
+# ── Public entry point ─────────────────────────────────────────────────────────
+
+async def reconcile_after_restore(
+    db: LocalDB,
+    api: TalosAPIClient | None = None,
+    *,
+    config: ReconcileConfig | None = None,
+) -> ReconcileResult:
+    """Reconcile agent state after a crash-restore or process restart.
+
+    This function **must** be called before any scheduler tasks are started.
+    It is idempotent — calling it multiple times is safe (each call re-reads
+    the DB and re-verifies leases, but will be a near-no-op if state is
+    already clean).
+
+    Parameters
+    ----------
+    db:
+        The open :class:`~talos_agent.db.LocalDB` instance for this agent.
+    api:
+        Optional :class:`~talos_agent.api_client.TalosAPIClient`.  When
+        ``None`` or when ``config.api_verify_leases`` is ``False``, lease
+        verification is skipped and all fencing tokens are restored
+        unconditionally (useful for offline/unit-test environments).
+    config:
+        Reconciliation thresholds.  Defaults to :data:`_DEFAULT_CONFIG`.
+
+    Returns
+    -------
+    ReconcileResult
+        A summary of every action taken.  Callers may inspect it for logging
+        or assertions.
+
+    Raises
+    ------
+    This function is designed to be fault-tolerant: individual step failures
+    are captured in :attr:`ReconcileResult.errors` and do not propagate.  The
+    only exception is a programming error (e.g. passing ``None`` for *db*)
+    which will raise ``TypeError`` immediately.
+    """
+    if db is None:
+        raise TypeError("db must not be None")
+
+    if config is None:
+        config = _DEFAULT_CONFIG
+
+    result = ReconcileResult()
+
+    log.info("restore_reconciliation_start")
+
+    # Step 1 — prune expired completion markers (fast, no network)
+    _prune_completion_markers(db, result)
+
+    # Step 2 — cap future-skewed backoff timestamps (fast, no network)
+    _cap_stale_backoff(db, result, config)
+
+    # Step 3 — validate schedule timestamps for clock skew (fast, no network)
+    _validate_schedule_timestamps(db, result, config)
+
+    # Step 4 — re-verify claimed jobs against authoritative API (async, network)
+    await _verify_claimed_jobs(db, api, result, config)
+
+    log.info(
+        "restore_reconciliation_complete",
+        markers_pruned=result.markers_pruned,
+        backoff_rows_capped=result.backoff_rows_capped,
+        schedules_reset=result.schedules_reset,
+        claimed_jobs_found=result.claimed_jobs_found,
+        claimed_jobs_restored=result.claimed_jobs_restored,
+        claimed_jobs_dropped=result.claimed_jobs_dropped,
+        claimed_jobs_deferred=result.claimed_jobs_deferred,
+        errors=len(result.errors),
+    )
+
+    if result.errors:
+        logger.warning(
+            "restore_reconciliation finished with %d error(s): %s",
+            len(result.errors),
+            "; ".join(result.errors),
+        )
+
+    return result
+
+
+__all__ = [
+    "ReconcileConfig",
+    "ReconcileResult",
+    "reconcile_after_restore",
+]

--- a/packages/prime-agent/src/talos_agent/scheduler.py
+++ b/packages/prime-agent/src/talos_agent/scheduler.py
@@ -419,6 +419,43 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
     stellar = StellarKit(api)
     await stellar.initialize()
 
+    # ── Post-restore reconciliation (#296) ──────────────────────────────────
+    # Reconcile backoff state, schedule timestamps, fencing tokens, and
+    # completion markers before starting any tasks.  This ensures stale state
+    # from a previous run (crashed or checkpointed) does not cause duplicate
+    # work, stale heartbeats, or frozen backoff waits.
+    from talos_agent.restore import ReconcileConfig, reconcile_after_restore
+
+    _reconcile_config = ReconcileConfig(
+        max_backoff_future_secs=3_600.0,
+        backoff_cap_secs=60.0,
+        max_clock_skew_secs=300.0,
+        api_verify_leases=True,
+        api_timeout_secs=10.0,
+    )
+    try:
+        reconcile_result = await reconcile_after_restore(db, api, config=_reconcile_config)
+        console.print(
+            f"[dim cyan]Restore reconciliation: "
+            f"backoff_capped={reconcile_result.backoff_rows_capped}, "
+            f"schedules_reset={reconcile_result.schedules_reset}, "
+            f"jobs_restored={reconcile_result.claimed_jobs_restored}, "
+            f"jobs_dropped={reconcile_result.claimed_jobs_dropped}, "
+            f"markers_pruned={reconcile_result.markers_pruned}"
+            f"[/dim cyan]"
+        )
+        if reconcile_result.errors:
+            console.print(
+                f"[yellow]Restore reconciliation warnings ({len(reconcile_result.errors)}): "
+                + "; ".join(reconcile_result.errors[:3])
+                + ("[...]" if len(reconcile_result.errors) > 3 else "")
+                + "[/yellow]"
+            )
+    except Exception as _rec_exc:
+        console.print(f"[yellow]Restore reconciliation failed (non-fatal): {_rec_exc}[/yellow]")
+        logger.warning("reconcile_after_restore failed: %s", _rec_exc)
+    # ────────────────────────────────────────────────────────────────────────
+
     # Tracking restart parameters
     browser_restart_attempts = 0
     max_restart_attempts = 3

--- a/packages/prime-agent/src/talos_agent/tools/commerce.py
+++ b/packages/prime-agent/src/talos_agent/tools/commerce.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from talos_agent.db import normalize_playbook_name
@@ -248,6 +249,9 @@ async def apply_playbook(playbook_name: str) -> dict:
 
 # In-memory store of claimed job fencing tokens, keyed by job_id.
 # Used by claim_job / fulfill_job and the background heartbeat task.
+# IMPORTANT: This is always the authoritative in-memory view, but it is
+# backed by the ``claimed_jobs`` table in SQLite so tokens survive restarts.
+# reconcile_after_restore() repopulates this dict from the DB at startup.
 _claimed_jobs: dict[str, int] = {}
 _claimed_jobs_lock: asyncio.Lock | None = None
 
@@ -263,14 +267,59 @@ def get_claimed_jobs_copy() -> dict[str, int]:
     return dict(_claimed_jobs)
 
 
-async def set_claimed_job(job_id: str, fencing_token: int) -> None:
+async def set_claimed_job(
+    job_id: str,
+    fencing_token: int,
+    *,
+    ttl_seconds: int = 300,
+    lease_expires_at: datetime | None = None,
+) -> None:
+    """Record a job claim in memory *and* persist it to SQLite.
+
+    Parameters
+    ----------
+    job_id:
+        Unique job identifier.
+    fencing_token:
+        Server-issued monotonic token; guards against stale fulfillments.
+    ttl_seconds:
+        Lease duration in seconds (default 300).
+    lease_expires_at:
+        Optional server-reported expiry; used for accurate pruning on restore.
+    """
     async with _get_claimed_jobs_lock():
         _claimed_jobs[job_id] = fencing_token
+        if _db is not None:
+            try:
+                _db.upsert_claimed_job(
+                    job_id,
+                    fencing_token,
+                    ttl_seconds=ttl_seconds,
+                    lease_expires_at=lease_expires_at,
+                )
+            except Exception as _exc:  # pragma: no cover  # noqa: BLE001
+                import logging as _logging
+                _logging.getLogger(__name__).warning(
+                    "set_claimed_job: failed to persist fencing token for %s: %s",
+                    job_id,
+                    _exc,
+                )
 
 
 async def remove_claimed_job(job_id: str) -> None:
+    """Remove a job claim from memory *and* from the DB."""
     async with _get_claimed_jobs_lock():
         _claimed_jobs.pop(job_id, None)
+        if _db is not None:
+            try:
+                _db.delete_claimed_job(job_id)
+            except Exception as _exc:  # pragma: no cover  # noqa: BLE001
+                import logging as _logging
+                _logging.getLogger(__name__).warning(
+                    "remove_claimed_job: failed to delete DB record for %s: %s",
+                    job_id,
+                    _exc,
+                )
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -312,7 +361,22 @@ async def claim_job(job_id: str, ttl_seconds: int = 300) -> dict:
         return {"error": f"Failed to claim job {job_id} — it may be leased by another worker"}
     fencing_token = result.get("fencingToken")
     if fencing_token is not None:
-        await set_claimed_job(job_id, fencing_token)
+        # Parse server-reported expiry for accurate lease tracking
+        expires_raw = result.get("leaseExpiresAt")
+        lease_expires_at: datetime | None = None
+        if expires_raw:
+            try:
+                lease_expires_at = datetime.fromisoformat(
+                    expires_raw.replace("Z", "+00:00")
+                )
+            except (ValueError, AttributeError):
+                lease_expires_at = None
+        await set_claimed_job(
+            job_id,
+            fencing_token,
+            ttl_seconds=ttl_seconds,
+            lease_expires_at=lease_expires_at,
+        )
     return {
         "status": "claimed",
         "job_id": job_id,

--- a/packages/prime-agent/tests/test_restore_reconciliation.py
+++ b/packages/prime-agent/tests/test_restore_reconciliation.py
@@ -1,0 +1,798 @@
+"""Tests for the restore reconciliation feature (#296).
+
+Covers three modules:
+
+restore.py — reconcile_after_restore()
+    ReconcileConfig defaults, Step 1 (prune completion markers),
+    Step 2 (cap stale backoff), Step 3 (validate schedule timestamps),
+    Step 4 (verify claimed jobs), db=None raises TypeError,
+    full crash-restore integration, idempotency.
+
+db.py — new methods for migration 9
+    claimed_jobs CRUD, completion_markers CRUD, Migration 9 table/column checks.
+
+commerce.py — persisted fencing tokens
+    set_claimed_job persists to DB, remove_claimed_job removes from DB,
+    DB unavailable does not crash.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from talos_agent.db import LocalDB
+from talos_agent.restore import (
+    ReconcileConfig,
+    reconcile_after_restore,
+)
+from talos_agent.tools import commerce
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _fresh_db(tmp_path: Path) -> LocalDB:
+    return LocalDB(path=tmp_path / "test.db")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def reset_commerce_state():
+    """Clear module-level commerce state before every test."""
+    commerce._claimed_jobs.clear()
+    original_db = commerce._db
+    commerce._db = None
+    yield
+    commerce._claimed_jobs.clear()
+    commerce._db = original_db
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 1: ReconcileConfig defaults
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestReconcileConfigDefaults:
+    def test_default_max_backoff_future_secs(self):
+        cfg = ReconcileConfig()
+        assert cfg.max_backoff_future_secs == 3_600.0
+
+    def test_default_backoff_cap_secs(self):
+        cfg = ReconcileConfig()
+        assert cfg.backoff_cap_secs == 60.0
+
+    def test_default_max_clock_skew_secs(self):
+        cfg = ReconcileConfig()
+        assert cfg.max_clock_skew_secs == 300.0
+
+    def test_default_api_verify_leases(self):
+        cfg = ReconcileConfig()
+        assert cfg.api_verify_leases is True
+
+    def test_default_api_timeout_secs(self):
+        cfg = ReconcileConfig()
+        assert cfg.api_timeout_secs == 10.0
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 2: Step 1 — Prune expired completion markers
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestPruneCompletionMarkers:
+    async def test_expired_markers_are_deleted(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # Add an already-expired marker by inserting directly
+        past = (_utc_now() - timedelta(days=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) VALUES (?, ?, ?)",
+            ("job-1", "idem-1", past),
+        )
+        db._conn.commit()
+
+        result = await reconcile_after_restore(db, config=ReconcileConfig(api_verify_leases=False))
+        assert result.markers_pruned == 1
+        assert db.has_completion_marker("idem-1") is False
+        db.close()
+
+    async def test_non_expired_markers_are_kept(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-2", "idem-fresh", retain_days=7)
+
+        result = await reconcile_after_restore(db, config=ReconcileConfig(api_verify_leases=False))
+        assert result.markers_pruned == 0
+        assert db.has_completion_marker("idem-fresh") is True
+        db.close()
+
+    async def test_prune_count_returned_in_result(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        past = (_utc_now() - timedelta(days=1)).isoformat()
+        for i in range(3):
+            db._conn.execute(
+                "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) VALUES (?, ?, ?)",
+                (f"job-{i}", f"idem-{i}", past),
+            )
+        db._conn.commit()
+
+        result = await reconcile_after_restore(db, config=ReconcileConfig(api_verify_leases=False))
+        assert result.markers_pruned == 3
+        db.close()
+
+    async def test_db_error_in_prune_captured_in_errors(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # Patch the method to raise
+        original = db.prune_expired_completion_markers
+        db.prune_expired_completion_markers = MagicMock(side_effect=RuntimeError("disk full"))
+
+        result = await reconcile_after_restore(db, config=ReconcileConfig(api_verify_leases=False))
+        assert any("prune_completion_markers" in e for e in result.errors)
+        db.prune_expired_completion_markers = original
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 3: Step 2 — Cap stale backoff timestamps
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCapStaleBackoff:
+    async def test_far_future_next_attempt_at_is_capped(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        far_future = _utc_now() + timedelta(hours=10)
+        db.upsert_retry_state("polling", attempt_count=2, next_attempt_at=far_future)
+
+        cfg = ReconcileConfig(
+            max_backoff_future_secs=3600,
+            backoff_cap_secs=60,
+            api_verify_leases=False,
+        )
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.backoff_rows_capped == 1
+
+        state = db.get_retry_state("polling")
+        assert state is not None
+        # Should be capped to ~now+60s, not 10 hours from now
+        assert state["next_attempt_at"] < _utc_now() + timedelta(seconds=120)
+        db.close()
+
+    async def test_within_window_next_attempt_at_is_unchanged(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # 30 minutes in the future — within the 1-hour window
+        near_future = _utc_now() + timedelta(minutes=30)
+        db.upsert_retry_state("heartbeat", attempt_count=1, next_attempt_at=near_future)
+
+        cfg = ReconcileConfig(
+            max_backoff_future_secs=3600,
+            backoff_cap_secs=60,
+            api_verify_leases=False,
+        )
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.backoff_rows_capped == 0
+
+        state = db.get_retry_state("heartbeat")
+        diff = abs((state["next_attempt_at"] - near_future).total_seconds())
+        assert diff < 2.0
+        db.close()
+
+    async def test_corrupt_none_next_attempt_at_is_reset(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # Insert a corrupt value directly
+        db._conn.execute(
+            "INSERT INTO retry_state (task_name, attempt_count, next_attempt_at, terminal) "
+            "VALUES (?, ?, ?, ?)",
+            ("corrupt_task", 1, "not-a-date", 0),
+        )
+        db._conn.commit()
+
+        cfg = ReconcileConfig(api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.backoff_rows_capped >= 1
+        db.close()
+
+    async def test_backoff_rows_capped_incremented_correctly(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        far_future = _utc_now() + timedelta(hours=5)
+        db.upsert_retry_state("task_a", attempt_count=1, next_attempt_at=far_future)
+        db.upsert_retry_state("task_b", attempt_count=2, next_attempt_at=far_future)
+        # task_c within window — should not be capped
+        near = _utc_now() + timedelta(minutes=10)
+        db.upsert_retry_state("task_c", attempt_count=1, next_attempt_at=near)
+
+        cfg = ReconcileConfig(
+            max_backoff_future_secs=3600,
+            backoff_cap_secs=60,
+            api_verify_leases=False,
+        )
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.backoff_rows_capped == 2
+        db.close()
+
+    async def test_db_error_during_cap_captured_in_errors(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # Break the connection so reads fail
+        db._conn.close()
+
+        cfg = ReconcileConfig(api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        # Should have an error captured, not raise
+        assert len(result.errors) > 0
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 4: Step 3 — Validate schedule timestamps
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestValidateScheduleTimestamps:
+    async def test_future_last_run_at_reset_to_now(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        far_future = (_utc_now() + timedelta(hours=2)).isoformat()
+        db._conn.execute(
+            "INSERT INTO schedules (task_name, last_run_at) VALUES (?, ?)",
+            ("skewed_task", far_future),
+        )
+        db._conn.commit()
+
+        cfg = ReconcileConfig(max_clock_skew_secs=300, api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.schedules_reset == 1
+
+        row = db._conn.execute(
+            "SELECT last_run_at FROM schedules WHERE task_name = ?", ("skewed_task",)
+        ).fetchone()
+        reset_dt = datetime.fromisoformat(row["last_run_at"])
+        # Should be within 10s of now
+        assert abs((_utc_now() - reset_dt.replace(tzinfo=timezone.utc)).total_seconds()) < 10
+        db.close()
+
+    async def test_past_last_run_at_is_untouched(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        past = (_utc_now() - timedelta(hours=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO schedules (task_name, last_run_at) VALUES (?, ?)",
+            ("normal_task", past),
+        )
+        db._conn.commit()
+
+        cfg = ReconcileConfig(max_clock_skew_secs=300, api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.schedules_reset == 0
+        db.close()
+
+    async def test_within_tolerance_last_run_at_is_untouched(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        # 1 minute in the future — within 300s tolerance
+        slightly_future = (_utc_now() + timedelta(minutes=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO schedules (task_name, last_run_at) VALUES (?, ?)",
+            ("close_task", slightly_future),
+        )
+        db._conn.commit()
+
+        cfg = ReconcileConfig(max_clock_skew_secs=300, api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.schedules_reset == 0
+        db.close()
+
+    async def test_schedules_reset_incremented(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        far_future = (_utc_now() + timedelta(hours=5)).isoformat()
+        for name in ["task_x", "task_y"]:
+            db._conn.execute(
+                "INSERT INTO schedules (task_name, last_run_at) VALUES (?, ?)",
+                (name, far_future),
+            )
+        db._conn.commit()
+
+        cfg = ReconcileConfig(max_clock_skew_secs=300, api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert result.schedules_reset == 2
+        db.close()
+
+    async def test_db_error_in_schedule_validation_captured(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db._conn.close()
+
+        cfg = ReconcileConfig(api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+        assert len(result.errors) > 0
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 5: Step 4 — Verify claimed jobs
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestVerifyClaimedJobs:
+    async def test_api_verify_false_restores_unconditionally(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("job-1", fencing_token=42, ttl_seconds=300)
+
+        cfg = ReconcileConfig(api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+
+        assert result.claimed_jobs_restored == 1
+        assert commerce._claimed_jobs.get("job-1") == 42
+        db.close()
+
+    async def test_api_none_restores_unconditionally(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("job-2", fencing_token=7, ttl_seconds=300)
+
+        cfg = ReconcileConfig(api_verify_leases=True)
+        result = await reconcile_after_restore(db, api=None, config=cfg)
+
+        assert result.claimed_jobs_restored == 1
+        assert commerce._claimed_jobs.get("job-2") == 7
+        db.close()
+
+    async def test_empty_claimed_jobs_no_api_calls(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        mock_api = AsyncMock()
+
+        cfg = ReconcileConfig(api_verify_leases=True)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_found == 0
+        mock_api.heartbeat_job.assert_not_called()
+        db.close()
+
+    async def test_locally_expired_lease_dropped_from_db(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        past_expiry = _utc_now() - timedelta(seconds=60)
+        db.upsert_claimed_job(
+            "job-expired", fencing_token=99, ttl_seconds=300,
+            lease_expires_at=past_expiry,
+        )
+        mock_api = AsyncMock()
+
+        cfg = ReconcileConfig(api_verify_leases=True)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_dropped == 1
+        assert commerce._claimed_jobs.get("job-expired") is None
+        assert db.get_claimed_job("job-expired") is None
+        # No API call needed since already expired locally
+        mock_api.heartbeat_job.assert_not_called()
+        db.close()
+
+    async def test_api_heartbeat_truthy_restores_to_memory(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        future_expiry = _utc_now() + timedelta(seconds=300)
+        db.upsert_claimed_job(
+            "job-live", fencing_token=55, ttl_seconds=300,
+            lease_expires_at=future_expiry,
+        )
+        mock_api = AsyncMock()
+        mock_api.heartbeat_job = AsyncMock(return_value=True)
+
+        cfg = ReconcileConfig(api_verify_leases=True, api_timeout_secs=5)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_restored == 1
+        assert commerce._claimed_jobs.get("job-live") == 55
+        db.close()
+
+    async def test_api_heartbeat_falsy_drops_and_deletes_from_db(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        future_expiry = _utc_now() + timedelta(seconds=300)
+        db.upsert_claimed_job(
+            "job-lost", fencing_token=11, ttl_seconds=300,
+            lease_expires_at=future_expiry,
+        )
+        mock_api = AsyncMock()
+        mock_api.heartbeat_job = AsyncMock(return_value=False)
+
+        cfg = ReconcileConfig(api_verify_leases=True, api_timeout_secs=5)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_dropped == 1
+        assert commerce._claimed_jobs.get("job-lost") is None
+        assert db.get_claimed_job("job-lost") is None
+        db.close()
+
+    async def test_api_timeout_defers_keeps_db_row_not_in_memory(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        future_expiry = _utc_now() + timedelta(seconds=300)
+        db.upsert_claimed_job(
+            "job-slow", fencing_token=22, ttl_seconds=300,
+            lease_expires_at=future_expiry,
+        )
+        mock_api = AsyncMock()
+        mock_api.heartbeat_job = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        cfg = ReconcileConfig(api_verify_leases=True, api_timeout_secs=5)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_deferred == 1
+        assert commerce._claimed_jobs.get("job-slow") is None
+        # DB row must be kept
+        assert db.get_claimed_job("job-slow") is not None
+        db.close()
+
+    async def test_api_generic_exception_defers_with_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        future_expiry = _utc_now() + timedelta(seconds=300)
+        db.upsert_claimed_job(
+            "job-err", fencing_token=33, ttl_seconds=300,
+            lease_expires_at=future_expiry,
+        )
+        mock_api = AsyncMock()
+        mock_api.heartbeat_job = AsyncMock(side_effect=RuntimeError("connection reset"))
+
+        cfg = ReconcileConfig(api_verify_leases=True, api_timeout_secs=5)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_deferred == 1
+        assert any("job-err" in e for e in result.errors)
+        assert commerce._claimed_jobs.get("job-err") is None
+        assert db.get_claimed_job("job-err") is not None
+        db.close()
+
+    async def test_multiple_jobs_mix_of_outcomes(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        future_expiry = _utc_now() + timedelta(seconds=300)
+        past_expiry = _utc_now() - timedelta(seconds=60)
+
+        db.upsert_claimed_job("job-ok", fencing_token=1, ttl_seconds=300,
+                              lease_expires_at=future_expiry)
+        db.upsert_claimed_job("job-lost2", fencing_token=2, ttl_seconds=300,
+                              lease_expires_at=future_expiry)
+        db.upsert_claimed_job("job-expired2", fencing_token=3, ttl_seconds=300,
+                              lease_expires_at=past_expiry)
+        db.upsert_claimed_job("job-timeout", fencing_token=4, ttl_seconds=300,
+                              lease_expires_at=future_expiry)
+
+        async def _heartbeat(job_id, fencing_token):
+            if job_id == "job-ok":
+                return True
+            if job_id == "job-lost2":
+                return False
+            if job_id == "job-timeout":
+                raise asyncio.TimeoutError()
+
+        mock_api = AsyncMock()
+        mock_api.heartbeat_job = AsyncMock(side_effect=_heartbeat)
+
+        cfg = ReconcileConfig(api_verify_leases=True, api_timeout_secs=5)
+        result = await reconcile_after_restore(db, api=mock_api, config=cfg)
+
+        assert result.claimed_jobs_found == 4
+        assert result.claimed_jobs_restored == 1   # job-ok
+        assert result.claimed_jobs_dropped == 2    # job-lost2 + job-expired2
+        assert result.claimed_jobs_deferred == 1   # job-timeout
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 6: db=None raises TypeError
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestReconcileDbNone:
+    async def test_none_db_raises_type_error(self):
+        with pytest.raises(TypeError):
+            await reconcile_after_restore(None)  # type: ignore[arg-type]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 7: Full integration — crash-restore simulation
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCrashRestoreIntegration:
+    async def test_job_restored_after_simulated_crash(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        commerce._db = db
+
+        # 1. "Claim" a job — persists to DB and memory
+        await commerce.set_claimed_job("crash-job", fencing_token=77, ttl_seconds=300)
+        assert commerce._claimed_jobs.get("crash-job") == 77
+        assert db.get_claimed_job("crash-job") is not None
+
+        # 2. Simulate crash: wipe in-memory state
+        commerce._claimed_jobs.clear()
+        assert commerce._claimed_jobs.get("crash-job") is None
+
+        # 3. Reconcile — should restore from DB
+        cfg = ReconcileConfig(api_verify_leases=False)
+        result = await reconcile_after_restore(db, config=cfg)
+
+        assert result.claimed_jobs_restored == 1
+        assert commerce._claimed_jobs.get("crash-job") == 77
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 8: Idempotency
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestReconcileIdempotency:
+    async def test_two_passes_produce_same_net_result(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("idem-job", fencing_token=5, ttl_seconds=300)
+
+        cfg = ReconcileConfig(api_verify_leases=False)
+
+        result1 = await reconcile_after_restore(db, config=cfg)
+        # Reset memory between passes to simulate fresh start
+        commerce._claimed_jobs.clear()
+        result2 = await reconcile_after_restore(db, config=cfg)
+
+        assert result1.claimed_jobs_restored == result2.claimed_jobs_restored
+        assert result1.claimed_jobs_dropped == result2.claimed_jobs_dropped
+        assert commerce._claimed_jobs.get("idem-job") == 5
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 9: db.py — claimed_jobs CRUD
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClaimedJobsCRUD:
+    def test_upsert_claimed_job_stores_row(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("j1", fencing_token=10, ttl_seconds=60)
+        row = db.get_claimed_job("j1")
+        assert row is not None
+        assert row["job_id"] == "j1"
+        assert row["fencing_token"] == 10
+        assert row["ttl_seconds"] == 60
+        db.close()
+
+    def test_get_claimed_job_returns_datetime_fields_parsed(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        expiry = _utc_now() + timedelta(seconds=120)
+        db.upsert_claimed_job("j2", fencing_token=5, ttl_seconds=120, lease_expires_at=expiry)
+        row = db.get_claimed_job("j2")
+        assert isinstance(row["claimed_at"], datetime)
+        assert isinstance(row["lease_expires_at"], datetime)
+        db.close()
+
+    def test_get_all_claimed_jobs_returns_all_rows(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("j3", fencing_token=1, ttl_seconds=60)
+        db.upsert_claimed_job("j4", fencing_token=2, ttl_seconds=60)
+        rows = db.get_all_claimed_jobs()
+        job_ids = {r["job_id"] for r in rows}
+        assert {"j3", "j4"} == job_ids
+        db.close()
+
+    def test_delete_claimed_job_removes_row(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("j5", fencing_token=99, ttl_seconds=60)
+        db.delete_claimed_job("j5")
+        assert db.get_claimed_job("j5") is None
+        db.close()
+
+    def test_upsert_same_job_id_updates_row(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.upsert_claimed_job("j6", fencing_token=1, ttl_seconds=60)
+        db.upsert_claimed_job("j6", fencing_token=2, ttl_seconds=120)
+        row = db.get_claimed_job("j6")
+        assert row["fencing_token"] == 2
+        assert row["ttl_seconds"] == 120
+        db.close()
+
+    def test_upsert_empty_job_id_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.upsert_claimed_job("", fencing_token=1, ttl_seconds=60)
+        db.close()
+
+    def test_upsert_negative_fencing_token_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.upsert_claimed_job("j7", fencing_token=-1, ttl_seconds=60)
+        db.close()
+
+    def test_upsert_zero_ttl_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.upsert_claimed_job("j8", fencing_token=1, ttl_seconds=0)
+        db.close()
+
+    def test_upsert_negative_ttl_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.upsert_claimed_job("j9", fencing_token=1, ttl_seconds=-10)
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 10: db.py — completion_markers CRUD
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCompletionMarkersCRUD:
+    def test_add_completion_marker_creates_row(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-a", "key-a", retain_days=7)
+        assert db.has_completion_marker("key-a") is True
+        db.close()
+
+    def test_add_completion_marker_correct_expiry(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        before = _utc_now()
+        db.add_completion_marker("job-b", "key-b", retain_days=3)
+        row = db._conn.execute(
+            "SELECT expires_at FROM completion_markers WHERE idempotency_key = ?", ("key-b",)
+        ).fetchone()
+        assert row is not None
+        expires_dt = datetime.fromisoformat(row["expires_at"])
+        if expires_dt.tzinfo is None:
+            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+        expected_min = before + timedelta(days=3) - timedelta(seconds=5)
+        expected_max = _utc_now() + timedelta(days=3) + timedelta(seconds=5)
+        assert expected_min <= expires_dt <= expected_max
+        db.close()
+
+    def test_has_completion_marker_true_for_non_expired(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-c", "key-c", retain_days=7)
+        assert db.has_completion_marker("key-c") is True
+        db.close()
+
+    def test_has_completion_marker_false_for_expired(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        past = (_utc_now() - timedelta(days=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) VALUES (?, ?, ?)",
+            ("job-d", "key-d", past),
+        )
+        db._conn.commit()
+        assert db.has_completion_marker("key-d") is False
+        db.close()
+
+    def test_get_completion_markers_for_job_returns_non_expired(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-e", "key-e1", retain_days=7)
+        db.add_completion_marker("job-e", "key-e2", retain_days=7)
+        # Add expired one
+        past = (_utc_now() - timedelta(days=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) VALUES (?, ?, ?)",
+            ("job-e", "key-e-expired", past),
+        )
+        db._conn.commit()
+
+        rows = db.get_completion_markers_for_job("job-e")
+        keys = {r["idempotency_key"] for r in rows}
+        assert "key-e1" in keys
+        assert "key-e2" in keys
+        assert "key-e-expired" not in keys
+        db.close()
+
+    def test_prune_expired_markers_deletes_only_expired(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-f", "key-fresh", retain_days=7)
+        past = (_utc_now() - timedelta(days=1)).isoformat()
+        db._conn.execute(
+            "INSERT INTO completion_markers (job_id, idempotency_key, expires_at) VALUES (?, ?, ?)",
+            ("job-f", "key-old", past),
+        )
+        db._conn.commit()
+
+        count = db.prune_expired_completion_markers()
+        assert count == 1
+        assert db.has_completion_marker("key-fresh") is True
+        assert db.has_completion_marker("key-old") is False
+        db.close()
+
+    def test_add_duplicate_idempotency_key_raises_integrity_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        db.add_completion_marker("job-g", "key-dup", retain_days=7)
+        with pytest.raises(sqlite3.IntegrityError):
+            db.add_completion_marker("job-g", "key-dup", retain_days=7)
+        db.close()
+
+    def test_add_completion_marker_empty_job_id_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.add_completion_marker("", "key-x", retain_days=7)
+        db.close()
+
+    def test_add_completion_marker_empty_idempotency_key_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.add_completion_marker("job-h", "", retain_days=7)
+        db.close()
+
+    def test_add_completion_marker_zero_retain_days_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.add_completion_marker("job-i", "key-y", retain_days=0)
+        db.close()
+
+    def test_add_completion_marker_negative_retain_days_raises_value_error(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        with pytest.raises(ValueError):
+            db.add_completion_marker("job-j", "key-z", retain_days=-1)
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 11: db.py — Migration 9 table and column checks
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestMigration9:
+    def test_claimed_jobs_table_exists_after_init(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        row = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='claimed_jobs'"
+        ).fetchone()
+        assert row is not None
+        db.close()
+
+    def test_completion_markers_table_exists_after_init(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        row = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='completion_markers'"
+        ).fetchone()
+        assert row is not None
+        db.close()
+
+    def test_claimed_jobs_correct_columns(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        rows = db._conn.execute("PRAGMA table_info(claimed_jobs)").fetchall()
+        cols = {r[1] for r in rows}
+        expected = {"job_id", "fencing_token", "claimed_at", "lease_expires_at", "ttl_seconds"}
+        assert expected == cols
+        db.close()
+
+    def test_completion_markers_correct_columns(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        rows = db._conn.execute("PRAGMA table_info(completion_markers)").fetchall()
+        cols = {r[1] for r in rows}
+        expected = {"id", "job_id", "idempotency_key", "completed_at", "expires_at"}
+        assert expected == cols
+        db.close()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 12: commerce.py — persisted fencing tokens
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCommercePersistedFencingTokens:
+    async def test_set_claimed_job_persists_to_db(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        commerce._db = db
+        await commerce.set_claimed_job("cj-1", fencing_token=100, ttl_seconds=120)
+
+        row = db.get_claimed_job("cj-1")
+        assert row is not None
+        assert row["fencing_token"] == 100
+        db.close()
+
+    async def test_set_claimed_job_updates_memory_dict(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        commerce._db = db
+        await commerce.set_claimed_job("cj-2", fencing_token=200, ttl_seconds=60)
+
+        assert commerce._claimed_jobs.get("cj-2") == 200
+        db.close()
+
+    async def test_remove_claimed_job_removes_from_db(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        commerce._db = db
+        await commerce.set_claimed_job("cj-3", fencing_token=300, ttl_seconds=60)
+        assert db.get_claimed_job("cj-3") is not None
+
+        await commerce.remove_claimed_job("cj-3")
+        assert db.get_claimed_job("cj-3") is None
+        db.close()
+
+    async def test_remove_claimed_job_removes_from_memory(self, tmp_path: Path):
+        db = _fresh_db(tmp_path)
+        commerce._db = db
+        await commerce.set_claimed_job("cj-4", fencing_token=400, ttl_seconds=60)
+        assert "cj-4" in commerce._claimed_jobs
+
+        await commerce.remove_claimed_job("cj-4")
+        assert "cj-4" not in commerce._claimed_jobs
+        db.close()
+
+    async def test_set_claimed_job_db_none_updates_memory(self):
+        # _db is None (already set by autouse fixture)
+        assert commerce._db is None
+        await commerce.set_claimed_job("cj-5", fencing_token=500, ttl_seconds=60)
+        assert commerce._claimed_jobs.get("cj-5") == 500


### PR DESCRIPTION
…#296)

Prevent restored agents from replaying completed work or inheriting stale schedules and leases after a crash or process restart.

## What changed

### restore.py (new)
- reconcile_after_restore(): 4-step reconciliation called at startup before any scheduler tasks begin
  1. Prune expired completion markers (idempotency cleanup)
  2. Cap future-skewed backoff timestamps (max 1 h → reset to now+60s)
  3. Reset impossibly-future schedule last_run_at (max skew 5 min)
  4. Re-verify claimed-job leases via api.heartbeat_job():
     - Heartbeat OK → restore fencing token to memory
     - Heartbeat fail / lease expired → delete from DB, skip memory - API timeout / unreachable → keep DB row, defer to heartbeat task
- ReconcileConfig dataclass for all thresholds (all with sensible defaults)
- ReconcileResult dataclass summarising every action taken
- Full structured logging via observability.log (restore_reconciliation_start / restore_reconciliation_complete events, per-action INFO/WARN records)
- Fault-tolerant: step failures are captured in ReconcileResult.errors and do not abort startup

### db.py (migration 9)
- claimed_jobs table: durable fencing-token store (job_id PK, fencing_token, claimed_at, lease_expires_at, ttl_seconds)
- completion_markers table: idempotency log (job_id, idempotency_key UNIQUE, completed_at, expires_at) with indexes for fast pruning and job lookup
- New methods: upsert_claimed_job, get_claimed_job, get_all_claimed_jobs, delete_claimed_job, add_completion_marker, has_completion_marker, get_completion_markers_for_job, prune_expired_completion_markers

### scheduler.py
- Calls reconcile_after_restore() right before the asyncio task group is started; prints a dim summary line to console
- Non-fatal: if reconcile throws, startup continues with a warning

### tools/commerce.py
- set_claimed_job(): persists fencing token to claimed_jobs in SQLite in addition to the in-memory dict
- remove_claimed_job(): deletes from claimed_jobs in addition to memory
- Both operations are no-op if _db is None (offline / unit-test)

## Tests (tests/test_restore_reconciliation.py, new, 60 tests) 12 sections covering every acceptance criterion:
  1. ReconcileConfig defaults
  2. Step 1 — prune completion markers (expired, non-expired, counts, DB error)
  3. Step 2 — cap stale backoff (far future, within window, corrupt, multi-row)
  4. Step 3 — validate schedule timestamps (future reset, past untouched, skew)
  5. Step 4 — verify claimed jobs (offline, API=None, locally expired, heartbeat truthy/falsy, timeout, generic exception, multi-outcome mix)
  6. db=None raises TypeError
  7. Crash-restore integration (claim → wipe memory → reconcile → restored)
  8. Idempotency (two passes produce same net result)
  9. claimed_jobs CRUD (upsert, get, get_all, delete, validation errors)
  10. completion_markers CRUD (add, has, get_for_job, prune, integrity, validation)
  11. Migration 9 table and column existence checks
  12. commerce.py fencing-token persistence (set persists, remove deletes)

All 465 tests pass. New files are lint-clean (BLE001 noqa where broad catches are intentional fault-tolerance, UP037/I001/F401 auto-fixed).

Closes #296
Part of #280 / tracked by #289
Reuses patterns from #223, #229, #234, #235, #263

## Summary

Provide a brief description of the changes, background context, and what these changes accomplish.

## Related Issues

Closes #N (Replace N with the issue number, e.g. Closes #1)

## Test Plan

Detail the steps you took to test these changes.
- [ ] Automated tests run (e.g. `cargo test`, `uv run pytest`, `pnpm test:e2e`)
- [ ] Manual verification steps performed:
  - 1. ...
  - 2. ...
- [ ] Relevant docs updated when setup, environment variables, or workflows changed

## Visual Changes (if applicable)

For any user interface changes, please add screenshots or screen recordings showing:
- Before
- After

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [ ] My code follows the style guidelines of this project.
- [ ] I have updated `.env.example` files and documentation if I changed environment variables.
- [ ] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
closes #296 