### PR TITLE
chore(agent): clean policy engine lint

### DIFF
--- a/packages/prime-agent/src/talos_agent/policy/middleware.py
+++ b/packages/prime-agent/src/talos_agent/policy/middleware.py
@@ -8,7 +8,6 @@ engine and the agent loop.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any, Callable
 

--- a/packages/prime-agent/src/talos_agent/policy/simulator.py
+++ b/packages/prime-agent/src/talos_agent/policy/simulator.py
@@ -8,13 +8,12 @@ and can also be used for operator-facing "test this policy" workflows.
 
 from __future__ import annotations
 
-import copy
 import json
 import logging
 from typing import Any
 
 from talos_agent.policy.engine import PolicyEngine
-from talos_agent.policy.schema import ActionSpec, PolicyDecision, PolicyResult
+from talos_agent.policy.schema import ActionSpec, PolicyResult
 
 logger = logging.getLogger(__name__)
 

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -60,7 +60,6 @@ class ToolRegistry:
         if self._middleware is not None:
             try:
                 from talos_agent.policy.middleware import (
-                    _BYPASS_ACTIONS,
                     _GATED_ACTIONS,
                 )
                 if name in _GATED_ACTIONS:

--- a/packages/prime-agent/tests/test_policy_engine.py
+++ b/packages/prime-agent/tests/test_policy_engine.py
@@ -6,10 +6,7 @@ Covers: schema, engine evaluation, loader, middleware, and simulator.
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
-from decimal import Decimal
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -404,30 +401,12 @@ class TestPolicyLoader:
             assert len(p.rules) > 0, f"Policy {p.name} has no rules"
 
     def test_loader_merge_by_name(self):
-        """Later sources override earlier ones by name."""
+        """Default policy loading de-duplicates policies by name."""
         loader = PolicyLoader(db=None)
-        # Create a file override that replaces budget-guard
-        custom = [
-            Policy(
-                name="budget-guard",
-                priority=200,
-                description="Custom budget policy",
-                rules=(
-                    PolicyRule(
-                        rule_id="custom-rule",
-                        description="Custom",
-                        conditions=(),
-                        decision=PolicyDecision.DENY,
-                        severity=Severity.BLOCKER,
-                        reason="Custom block",
-                    ),
-                ),
-            ),
-        ]
-        # We can't easily mock the file, but we can test the merge logic
         all_policies = loader.load()
-        names = {p.name for p in all_policies}
+        names = [p.name for p in all_policies]
         assert "budget-guard" in names
+        assert len(names) == len(set(names))
 
     def test_needs_reload_returns_false_initially(self):
         loader = PolicyLoader(db=None)


### PR DESCRIPTION
Follow-up to #357. Removes unused imports and replaces the ineffective loader test fixture with an actual de-duplication assertion. Verified with Ruff and the full Prime Agent suite (469 passed).