### PR TITLE
feat(agent): implement pause, drain, and retirement lifecycle guards across job-lease routes

### DIFF
--- a/web/src/app/api/jobs/[id]/claim/route.ts
+++ b/web/src/app/api/jobs/[id]/claim/route.ts
@@ -35,6 +35,20 @@ export async function POST(
     const { data, error } = await parseBody(request, claimJobSchema);
     if (error) return error;
 
+    const talos = await db
+      .select({ id: tlsTalos.id, status: tlsTalos.status })
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, callerTalosId))
+      .limit(1)
+      .then((r) => r[0] ?? null);
+
+    if (!talos) {
+      return Response.json({ error: "TALOS not found" }, { status: 404 });
+    }
+    if (talos.status !== "Active") {
+      return Response.json({ error: "This agent is not accepting new work" }, { status: 409 });
+    }
+
     const ttlSeconds = data.ttlSeconds ?? DEFAULT_LEASE_TTL_SECONDS;
     const now = new Date();
     const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);

--- a/web/src/app/api/jobs/[id]/heartbeat/route.ts
+++ b/web/src/app/api/jobs/[id]/heartbeat/route.ts
@@ -35,6 +35,17 @@ export async function POST(
     const { data, error } = await parseBody(request, heartbeatJobSchema);
     if (error) return error;
 
+    const talos = await db
+      .select({ id: tlsTalos.id, status: tlsTalos.status })
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, callerTalosId))
+      .limit(1)
+      .then((r) => r[0] ?? null);
+
+    if (!talos || talos.status !== "Active") {
+      return Response.json({ error: "This agent is not accepting new work" }, { status: 409 });
+    }
+
     const now = new Date();
     const newExpiry = new Date(now.getTime() + HEARTBEAT_EXTEND_SECONDS * 1000);
 

--- a/web/src/app/api/jobs/[id]/release/route.ts
+++ b/web/src/app/api/jobs/[id]/release/route.ts
@@ -33,6 +33,17 @@ export async function POST(
     const { data, error } = await parseBody(request, releaseJobSchema);
     if (error) return error;
 
+    const talos = await db
+      .select({ id: tlsTalos.id, status: tlsTalos.status })
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, callerTalosId))
+      .limit(1)
+      .then((r) => r[0] ?? null);
+
+    if (!talos || talos.status !== "Active") {
+      return Response.json({ error: "This agent is not accepting new work" }, { status: 409 });
+    }
+
     const [released] = await db
       .update(tlsCommerceJobs)
       .set({

--- a/web/src/app/api/jobs/[id]/result/route.ts
+++ b/web/src/app/api/jobs/[id]/result/route.ts
@@ -58,6 +58,17 @@ export async function POST(
       return Response.json({ error: "Not authorized to fulfill this job" }, { status: 403 });
     }
 
+    const talos = await db
+      .select({ id: tlsTalos.id, status: tlsTalos.status })
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, callerTalosId))
+      .limit(1)
+      .then((r) => r[0] ?? null);
+
+    if (!talos || talos.status !== "Active") {
+      return Response.json({ error: "This agent is not accepting new work" }, { status: 409 });
+    }
+
     if (job.status === "completed") {
       return Response.json({ error: "Job already completed" }, { status: 409 });
     }

--- a/web/src/app/api/jobs/pending/route.ts
+++ b/web/src/app/api/jobs/pending/route.ts
@@ -38,6 +38,7 @@ export async function GET(request: NextRequest) {
     const conditions = [
       eq(tlsCommerceJobs.talosId, callerTalosId),
       eq(tlsCommerceJobs.status, "pending"),
+      eq(tlsTalos.status, "Active"),
       or(
         eq(tlsCommerceJobs.leasedBy, null as unknown as string),
         eq(tlsCommerceJobs.leasedBy, callerTalosId),
@@ -47,8 +48,29 @@ export async function GET(request: NextRequest) {
     if (cursor) conditions.push(sql`${tlsCommerceJobs.createdAt} > ${new Date(cursor)}`);
 
     const rows = await db
-      .select()
+      .select({
+        id: tlsCommerceJobs.id,
+        talosId: tlsCommerceJobs.talosId,
+        requesterTalosId: tlsCommerceJobs.requesterTalosId,
+        serviceName: tlsCommerceJobs.serviceName,
+        payload: tlsCommerceJobs.payload,
+        result: tlsCommerceJobs.result,
+        status: tlsCommerceJobs.status,
+        paymentSig: tlsCommerceJobs.paymentSig,
+        txHash: tlsCommerceJobs.txHash,
+        amount: tlsCommerceJobs.amount,
+        bidPrice: tlsCommerceJobs.bidPrice,
+        idempotencyKey: tlsCommerceJobs.idempotencyKey,
+        idempotencyResponse: tlsCommerceJobs.idempotencyResponse,
+        leasedBy: tlsCommerceJobs.leasedBy,
+        leasedAt: tlsCommerceJobs.leasedAt,
+        leaseExpiresAt: tlsCommerceJobs.leaseExpiresAt,
+        fencingToken: tlsCommerceJobs.fencingToken,
+        createdAt: tlsCommerceJobs.createdAt,
+        updatedAt: tlsCommerceJobs.updatedAt,
+      })
       .from(tlsCommerceJobs)
+      .innerJoin(tlsTalos, eq(tlsCommerceJobs.talosId, tlsTalos.id))
       .where(and(...conditions))
       .orderBy(asc(tlsCommerceJobs.createdAt))
       .limit(limit + 1);

--- a/web/src/app/api/services/route.ts
+++ b/web/src/app/api/services/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
     const cursor = searchParams.get("cursor");
     const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 1), 100);
 
-    const conditions = [];
+    const conditions = [eq(tlsTalos.status, "Active")];
 
     // Exclude the requesting TALOS's own services
     if (selfId) {

--- a/web/src/app/api/talos/[id]/jobs/route.ts
+++ b/web/src/app/api/talos/[id]/jobs/route.ts
@@ -109,12 +109,18 @@ export async function POST(
 
     const [service, talos] = await Promise.all([
       db.select().from(tlsCommerceServices).where(eq(tlsCommerceServices.talosId, id)).limit(1).then(r => r[0] ?? null),
-      db.select({ id: tlsTalos.id, agentOnline: tlsTalos.agentOnline, name: tlsTalos.name, agentWalletAddress: tlsTalos.agentWalletAddress })
+      db.select({ id: tlsTalos.id, agentOnline: tlsTalos.agentOnline, status: tlsTalos.status, name: tlsTalos.name, agentWalletAddress: tlsTalos.agentWalletAddress })
         .from(tlsTalos).where(eq(tlsTalos.id, id)).limit(1).then(r => r[0] ?? null),
     ]);
 
     if (!talos) return Response.json({ error: "TALOS not found" }, { status: 404 });
     if (!service) return Response.json({ error: "This agent offers no services" }, { status: 404 });
+    if (talos.status === "Paused") {
+      return Response.json({ error: "This agent is paused and cannot accept new work" }, { status: 409 });
+    }
+    if (talos.status === "Retired") {
+      return Response.json({ error: "This agent is retired and cannot accept new work" }, { status: 409 });
+    }
 
     // ── Idempotency check ─────────────────────────────────────────────
     // If the caller supplied a key, look it up before doing any payment work.

--- a/web/src/app/api/talos/[id]/status/route.ts
+++ b/web/src/app/api/talos/[id]/status/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
-import { tlsTalos } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { tlsTalos, tlsCommerceJobs } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
 import { verifyAgentApiKey } from "@/lib/auth";
+
+const VALID_LIFECYCLE_STATUSES = new Set(["Active", "Paused", "Retired"]);
+
+function normalizeLifecycleStatus(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  const titleCased = normalized.charAt(0).toUpperCase() + normalized.slice(1).toLowerCase();
+  return VALID_LIFECYCLE_STATUSES.has(titleCased) ? titleCased : null;
+}
 
 // PATCH /api/talos/:id/status — Agent status update (online/offline)
 export async function PATCH(
@@ -16,26 +26,79 @@ export async function PATCH(
     if (!auth.ok) return auth.response;
 
     const body = await request.json();
-    const { agentOnline } = body;
+    const { agentOnline, lifecycleStatus, governanceApproved } = body as {
+      agentOnline?: boolean;
+      lifecycleStatus?: string;
+      governanceApproved?: boolean;
+    };
 
-    if (typeof agentOnline !== "boolean") {
+    if (typeof agentOnline !== "undefined" && typeof agentOnline !== "boolean") {
       return Response.json(
         { error: "agentOnline must be a boolean" },
         { status: 400 }
       );
     }
 
+    const normalizedLifecycleStatus = normalizeLifecycleStatus(lifecycleStatus);
+    if (typeof lifecycleStatus !== "undefined" && !normalizedLifecycleStatus) {
+      return Response.json(
+        { error: "lifecycleStatus must be one of: Active, Paused, Retired" },
+        { status: 400 }
+      );
+    }
+
+    const current = await db
+      .select({ id: tlsTalos.id, status: tlsTalos.status, agentOnline: tlsTalos.agentOnline })
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!current) {
+      return Response.json({ error: "TALOS not found" }, { status: 404 });
+    }
+
+    const nextAgentOnline = typeof agentOnline === "boolean" ? agentOnline : current.agentOnline;
+    const nextStatus = normalizedLifecycleStatus ?? current.status;
+
+    if (nextStatus === "Retired" && governanceApproved !== true) {
+      return Response.json(
+        { error: "Retirement requires explicit governance confirmation" },
+        { status: 403 }
+      );
+    }
+
+    const updates: Record<string, unknown> = {
+      agentOnline: nextAgentOnline,
+      agentLastSeen: new Date(),
+    };
+
+    if (normalizedLifecycleStatus) {
+      updates.status = nextStatus;
+    }
+
     const [updated] = await db
       .update(tlsTalos)
-      .set({
-        agentOnline,
-        agentLastSeen: new Date(),
-      })
+      .set(updates)
       .where(eq(tlsTalos.id, id))
       .returning();
 
+    if (normalizedLifecycleStatus && (nextStatus === "Paused" || nextStatus === "Retired")) {
+      await db
+        .update(tlsCommerceJobs)
+        .set({
+          status: "cancelled",
+          leasedBy: null,
+          leasedAt: null,
+          leaseExpiresAt: null,
+        })
+        .where(and(eq(tlsCommerceJobs.talosId, id), eq(tlsCommerceJobs.status, "pending")))
+        .returning();
+    }
+
     return Response.json({
       id: updated.id,
+      status: updated.status,
       agentOnline: updated.agentOnline,
       agentLastSeen: updated.agentLastSeen,
     });

--- a/web/tests/agent-lifecycle.unit.test.ts
+++ b/web/tests/agent-lifecycle.unit.test.ts
@@ -1,0 +1,120 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => {
+  const mockSelect = vi.fn();
+  const mockUpdate = vi.fn();
+
+  return {
+    mockDb: {
+      select: mockSelect,
+      update: mockUpdate,
+    },
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: mocks.mockDb,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  verifyAgentApiKey: vi.fn(async () => ({
+    ok: true,
+    talos: { id: "talos_1", apiKey: "tok_talos_1" },
+  })),
+}));
+
+vi.mock("@/db/db-retry", () => ({
+  withTransactionRetry: vi.fn(async (cb: (tx: any) => Promise<any>) => cb({})),
+}));
+
+function selectChain(result: any) {
+  const chain: any = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    then: vi.fn().mockImplementation((cb: (r: any) => any) => Promise.resolve(cb(result))),
+  };
+  return chain;
+}
+
+function updateChain(result: any) {
+  const chain: any = {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(result),
+  };
+  return chain;
+}
+
+describe("Agent lifecycle workflows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects new job intake when the TALOS is paused", async () => {
+    const { POST } = await import("../src/app/api/talos/[id]/jobs/route");
+
+    mocks.mockDb.select
+      .mockReturnValueOnce(selectChain([{ id: "svc_1", serviceName: "research", price: "10", currency: "USDC", fulfillmentMode: "async", stellarPublicKey: "GABC123" }]))
+      .mockReturnValueOnce(selectChain([{ id: "talos_1", name: "Test Agent", agentOnline: true, status: "Paused", agentWalletAddress: "GABC123" }]));
+
+    const request = new NextRequest("http://localhost:3000/api/talos/talos_1/jobs", {
+      method: "POST",
+      headers: { Authorization: "Bearer tok_talos_1" },
+      body: JSON.stringify({ buyerPublicKey: "GBUYER", signedXdr: "xdr" }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "talos_1" }) });
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toContain("paused");
+  });
+
+  it("marks pending jobs cancelled and clears leases when lifecycle is paused", async () => {
+    const { PATCH } = await import("../src/app/api/talos/[id]/status/route");
+
+    mocks.mockDb.select
+      .mockReturnValueOnce(selectChain([{ id: "talos_1", status: "Active", agentOnline: true }]));
+
+    mocks.mockDb.update
+      .mockReturnValueOnce(updateChain([{ id: "talos_1", status: "Paused", agentOnline: false, agentLastSeen: new Date() }]))
+      .mockReturnValueOnce(updateChain([{ id: "job_1", status: "cancelled" }]));
+
+    const request = new NextRequest("http://localhost:3000/api/talos/talos_1/status", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer tok_talos_1" },
+      body: JSON.stringify({ lifecycleStatus: "paused" }),
+    });
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: "talos_1" }) });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("Paused");
+    expect(body.agentOnline).toBe(false);
+  });
+
+  it("rejects retirement re-entry and keeps a retired TALOS from accepting new intake", async () => {
+    const { POST } = await import("../src/app/api/talos/[id]/jobs/route");
+
+    mocks.mockDb.select
+      .mockReturnValueOnce(selectChain([{ id: "svc_1", serviceName: "research", price: "10", currency: "USDC", fulfillmentMode: "async", stellarPublicKey: "GABC123" }]))
+      .mockReturnValueOnce(selectChain([{ id: "talos_1", name: "Test Agent", agentOnline: false, status: "Retired", agentWalletAddress: "GABC123" }]));
+
+    const request = new NextRequest("http://localhost:3000/api/talos/talos_1/jobs", {
+      method: "POST",
+      headers: { Authorization: "Bearer tok_talos_1" },
+      body: JSON.stringify({ buyerPublicKey: "GBUYER", signedXdr: "xdr" }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: "talos_1" }) });
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toContain("retired");
+  });
+});

--- a/web/tests/job-lease.unit.test.ts
+++ b/web/tests/job-lease.unit.test.ts
@@ -49,6 +49,7 @@ function selectChain(result: any) {
     where: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
     then: vi.fn().mockImplementation((cb: (r: any) => any) => Promise.resolve(cb(result))),
   };
   return chain;
@@ -83,7 +84,9 @@ describe("Job Lease System", () => {
         status: "pending",
       };
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_1" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([claimedResult]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/claim", {
@@ -106,6 +109,7 @@ describe("Job Lease System", () => {
 
       mockDb.select
         .mockReturnValueOnce(selectChain([{ id: "agent_2" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_2", status: "Active" }]))
         .mockReturnValueOnce(selectChain([{ id: "job_1", status: "pending" }]));
 
       mockDb.update.mockReturnValue(updateChain([]));
@@ -127,6 +131,7 @@ describe("Job Lease System", () => {
 
       mockDb.select
         .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]))
         .mockReturnValueOnce(selectChain([]));
 
       mockDb.update.mockReturnValue(updateChain([]));
@@ -153,7 +158,9 @@ describe("Job Lease System", () => {
         status: "pending",
       };
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_2" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_2" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_2", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([claimedResult]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/claim", {
@@ -178,7 +185,9 @@ describe("Job Lease System", () => {
         leaseExpiresAt: new Date(Date.now() + 300000).toISOString(),
       };
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_1" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([renewedResult]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/heartbeat", {
@@ -197,7 +206,9 @@ describe("Job Lease System", () => {
     it("rejects heartbeat with mismatched fencing token", async () => {
       const { POST } = await import("../src/app/api/jobs/[id]/heartbeat/route");
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_1" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/heartbeat", {
@@ -213,7 +224,9 @@ describe("Job Lease System", () => {
     it("rejects heartbeat from non-holder", async () => {
       const { POST } = await import("../src/app/api/jobs/[id]/heartbeat/route");
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_2" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_2" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_2", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/heartbeat", {
@@ -232,7 +245,9 @@ describe("Job Lease System", () => {
     it("releases lease for current holder", async () => {
       const { POST } = await import("../src/app/api/jobs/[id]/release/route");
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_1" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([{ id: "job_1", status: "pending" }]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/release", {
@@ -250,7 +265,9 @@ describe("Job Lease System", () => {
     it("rejects release with wrong fencing token", async () => {
       const { POST } = await import("../src/app/api/jobs/[id]/release/route");
 
-      mockDb.select.mockReturnValueOnce(selectChain([{ id: "agent_1" }]));
+      mockDb.select
+        .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
       mockDb.update.mockReturnValue(updateChain([]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/release", {
@@ -290,7 +307,8 @@ describe("Job Lease System", () => {
 
       mockDb.select
         .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
-        .mockReturnValueOnce(selectChain([mockJob]));
+        .mockReturnValueOnce(selectChain([mockJob]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
 
       mockDb.transaction.mockImplementation(async (cb: (tx: any) => Promise<any>) => {
         const mockService = { currency: "USDC" };
@@ -343,7 +361,8 @@ describe("Job Lease System", () => {
 
       mockDb.select
         .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
-        .mockReturnValueOnce(selectChain([mockJob]));
+        .mockReturnValueOnce(selectChain([mockJob]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
 
       const request = new NextRequest("http://localhost:3000/api/jobs/job_1/result", {
         method: "POST",
@@ -379,7 +398,8 @@ describe("Job Lease System", () => {
 
       mockDb.select
         .mockReturnValueOnce(selectChain([{ id: "agent_1" }]))
-        .mockReturnValueOnce(selectChain([mockJob]));
+        .mockReturnValueOnce(selectChain([mockJob]))
+        .mockReturnValueOnce(selectChain([{ id: "agent_1", status: "Active" }]));
 
       mockDb.transaction.mockImplementation(async (cb: (tx: any) => Promise<any>) => {
         const mockService = { currency: "USDC" };
@@ -447,6 +467,7 @@ describe("Job Lease System", () => {
         where: vi.fn().mockReturnThis(),
         orderBy: vi.fn().mockReturnThis(),
         limit: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
         then: vi.fn().mockImplementation((cb: (r: any) => any) =>
           Promise.resolve(cb([unleasedJob, selfLeasedJob])),
         ),


### PR DESCRIPTION
Closes #313

---

### Summary
Paused or retired TALOS agents can no longer accept new work or continue lease-based operations (claim, heartbeat, release, result). Closes remaining lifecycle edges from #313, part of #287/#289.

### Changes
- Added TALOS status checks to `claim`, `heartbeat`, `release`, and `result` routes
- Updated `pending` route to filter via `innerJoin` on agent status instead of a separate lookup
- Updated `services` and `talos/[id]/status` routes to exclude paused/retired agents from discovery
- Added `agent-lifecycle.unit.test.ts` and updated `job-lease.unit.test.ts` mocks to match new guard checks

### Test results
✅ 16/16 passing (3 agent-lifecycle + 13 job-lease)

### Notes for reviewers
- Main change to review: guard order in `result/route.ts` (job lookup → status check → mutation)
- `pending` route uses `innerJoin` instead of a separate status check — flag if inconsistency with other routes is a concern