### PR TITLE
feat(agent): implement transactional staged checkpoint restore #295

### DIFF
--- a/packages/prime-agent/src/talos_agent/checkpoint_cli.py
+++ b/packages/prime-agent/src/talos_agent/checkpoint_cli.py
@@ -477,3 +477,130 @@ def ensure_distinct_paths(source_path: Path, output_path: Path) -> None:
 
     if Path(source_path).resolve() == Path(output_path).resolve():
         raise ValueError("Checkpoint output must not overwrite the agent database.")
+
+
+@checkpoint.command("restore")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(path_type=Path, dir_okay=False, exists=True),
+    required=True,
+    help="Checkpoint file to restore.",
+)
+@click.option(
+    "--agent",
+    "agent_id",
+    required=True,
+    help="Agent ID to restore into.",
+)
+@click.option(
+    "--schema-version",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Expected checkpoint schema version.",
+)
+@click.option(
+    "--max-size",
+    type=int,
+    default=DEFAULT_MAX_SIZE,
+    show_default=True,
+    help="Maximum checkpoint size in bytes.",
+)
+@click.option(
+    "--no-verify-invariants",
+    is_flag=True,
+    help="Skip invariant checks.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output the restore summary as JSON.",
+)
+def restore_checkpoint(
+    input_path: Path,
+    agent_id: str,
+    schema_version: int,
+    max_size: int,
+    no_verify_invariants: bool,
+    as_json: bool,
+) -> None:
+    """Restore agent state through transactional staging, validation, and rollback safety."""
+
+    from talos_agent.db import get_db_path
+    from talos_agent.restore import (
+        InvariantError,
+        PreflightError,
+        RollbackError,
+        StagedRestoreConfig,
+        StagingError,
+        perform_staged_restore_sync,
+    )
+
+    try:
+        validated_agent_id = validate_agent_id(agent_id)
+        validated_schema_version = ensure_compatible_schema_version(
+            schema_version,
+            SUPPORTED_SCHEMA_VERSIONS,
+        )
+        validate_size_limit(max_size)
+
+        database_path = get_db_path(validated_agent_id)
+        ensure_distinct_paths(input_path, database_path)
+
+        cfg = StagedRestoreConfig(
+            max_size_bytes=max_size,
+            allowed_schema_versions={validated_schema_version},
+            require_agent_match=True,
+            verify_invariants=not no_verify_invariants,
+        )
+
+        res = perform_staged_restore_sync(
+            target_db_path=database_path,
+            checkpoint_input=input_path,
+            agent_id=validated_agent_id,
+            config=cfg,
+        )
+
+        if as_json:
+            output_dict = {
+                "agent_id": res.agent_id,
+                "schema_version": res.schema_version,
+                "tables_restored": res.tables_restored,
+                "committed": res.committed,
+                "preflight_passed": res.preflight_passed,
+                "invariants_passed": res.invariants_passed,
+                "duration_ms": res.duration_ms,
+            }
+            click.echo(json.dumps(output_dict, indent=2))
+        else:
+            click.echo(f"Successfully restored checkpoint for agent '{validated_agent_id}' in {res.duration_ms}ms")
+            click.echo("Tables restored:")
+            if res.tables_restored:
+                for tbl, cnt in res.tables_restored.items():
+                    click.echo(f"  {tbl}: {cnt}")
+            else:
+                click.echo("  none")
+
+    except CheckpointCompatibilityError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.COMPATIBILITY_ERROR,
+        ) from exc
+    except PreflightError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.VALIDATION_ERROR,
+        ) from exc
+    except (StagingError, InvariantError, RollbackError, PermissionError, OSError, sqlite3.Error) as exc:
+        raise CheckpointCLIError(
+            f"Restore failed: {exc}",
+            CheckpointExitCode.IO_ERROR,
+        ) from exc
+    except ValueError as exc:
+        raise CheckpointCLIError(
+            str(exc),
+            CheckpointExitCode.VALIDATION_ERROR,
+        ) from exc
+

--- a/packages/prime-agent/src/talos_agent/restore.py
+++ b/packages/prime-agent/src/talos_agent/restore.py
@@ -82,12 +82,18 @@ Limitations
   by less than ``MAX_CLOCK_SKEW_SECS``.
 """
 
-from __future__ import annotations
-
+import asyncio
+import json
 import logging
+import os
+import secrets
+import shutil
+import sqlite3
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from talos_agent.observability import log
 
@@ -96,6 +102,25 @@ if TYPE_CHECKING:
     from talos_agent.db import LocalDB
 
 logger = logging.getLogger(__name__)
+
+_CHECKPOINT_TABLES = (
+    "schedules",
+    "activity_log",
+    "content_history",
+    "commerce_queue",
+    "approval_cache",
+    "spending_log",
+    "talos_config",
+    "playbooks",
+    "content_performance",
+    "strategy_learnings",
+    "audience_insights",
+    "loans",
+    "loan_repayments",
+    "dividends_log",
+    "retry_state",
+)
+
 
 
 # ── Configuration ──────────────────────────────────────────────────────────────
@@ -569,8 +594,516 @@ async def reconcile_after_restore(
     return result
 
 
+# ── Transactional Staged Checkpoint Restore ────────────────────────────────────
+
+class StagedRestoreError(Exception):
+    """Base class for transactional staged restore errors."""
+
+
+class PreflightError(StagedRestoreError):
+    """Raised when preflight validation or authorization fails before staging."""
+
+
+class StagingError(StagedRestoreError):
+    """Raised when staging or applying migrations against staged state fails."""
+
+
+class InvariantError(StagedRestoreError):
+    """Raised when staged database invariant checks fail."""
+
+
+class RollbackError(StagedRestoreError):
+    """Raised when commit fails and active state was rolled back to prior backup."""
+
+
+@dataclass
+class StagedRestoreConfig:
+    """Configuration options for transactional staged restore.
+
+    Attributes
+    ----------
+    max_size_bytes:
+        Maximum allowed size for checkpoint files in bytes. Default: 10MB.
+    allowed_schema_versions:
+        Set of supported schema versions. Default: {1}.
+    require_agent_match:
+        If True, requires checkpoint payload agent_id to match expected agent_id.
+    backup_retain_count:
+        Number of historical active database backups to retain. Default: 3.
+    run_migrations:
+        If True, runs database migrations against staged state. Default: True.
+    verify_invariants:
+        If True, runs structural & data invariant checks on staged state. Default: True.
+    master_password:
+        Optional master password for unwrap operation if checkpoint is encrypted envelope.
+    api_verify_leases:
+        Whether post-restore lease verification calls live API. Default: False.
+    staging_dir:
+        Directory for temporary staged database files. Default: target database directory.
+    """
+
+    max_size_bytes: int = 10 * 1024 * 1024
+    allowed_schema_versions: set[int] = field(default_factory=lambda: {1})
+    require_agent_match: bool = True
+    backup_retain_count: int = 3
+    run_migrations: bool = True
+    verify_invariants: bool = True
+    master_password: str | None = None
+    api_verify_leases: bool = False
+    staging_dir: Path | str | None = None
+
+
+@dataclass
+class StagedRestoreResult:
+    """Summary of transactional staged restore execution.
+
+    Attributes
+    ----------
+    agent_id:
+        The target agent identifier.
+    schema_version:
+        The schema version of the restored checkpoint.
+    tables_restored:
+        Dictionary mapping table names to restored row counts.
+    staged_path:
+        Path to the temporary staged database file used during restore.
+    backup_path:
+        Path to the backup created before atomic commit, if any.
+    preflight_passed:
+        True if preflight checks passed cleanly.
+    invariants_passed:
+        True if staged invariant verification passed.
+    committed:
+        True if atomic commit replaced active state successfully.
+    rolled_back:
+        True if a failure during commit triggered an automatic rollback.
+    reconciliation_result:
+        Optional summary of post-restore state reconciliation.
+    duration_ms:
+        Total duration of the restore operation in milliseconds.
+    errors:
+        List of non-fatal warnings or error messages collected.
+    """
+
+    agent_id: str
+    schema_version: int = 1
+    tables_restored: dict[str, int] = field(default_factory=dict)
+    staged_path: str = ""
+    backup_path: str | None = None
+    preflight_passed: bool = False
+    invariants_passed: bool = False
+    committed: bool = False
+    rolled_back: bool = False
+    reconciliation_result: ReconcileResult | None = None
+    duration_ms: float = 0.0
+    errors: list[str] = field(default_factory=list)
+
+
+class StagedRestoreManager:
+    """Manages transactional staged restores through preflight, staging, invariants, atomic commit, and rollback."""
+
+    def __init__(self, config: StagedRestoreConfig | None = None) -> None:
+        self.config = config or StagedRestoreConfig()
+
+    async def perform_staged_restore(
+        self,
+        target_db_path: Path | str,
+        checkpoint_input: dict[str, Any] | Path | str,
+        agent_id: str,
+        *,
+        api: TalosAPIClient | None = None,
+    ) -> StagedRestoreResult:
+        """Perform transactional staged restore end-to-end.
+
+        Steps:
+        1. Preflight validation (active state remains unchanged).
+        2. Staging & migrations (runs against staged state only).
+        3. Invariants verification (checks staged database integrity).
+        4. Atomic commit & bounded rollback (preserves prior state, atomic swap, post-restore reconciliation).
+        """
+        start_time = time.monotonic()
+        target_path = Path(target_db_path).resolve()
+        result = StagedRestoreResult(
+            agent_id=agent_id,
+            schema_version=1,
+            tables_restored={},
+            staged_path="",
+        )
+
+        log.info(
+            "restore_staged_start",
+            agent_id=agent_id,
+            target_db=str(target_path),
+        )
+
+        # Step 1: Preflight Check
+        payload = self._preflight_check(checkpoint_input, agent_id, result)
+        result.preflight_passed = True
+        log.info("restore_staged_preflight_passed", agent_id=agent_id)
+
+        # Step 2: Staging & Migrations
+        staged_path = self._stage_checkpoint(target_path, payload, agent_id, result)
+        result.staged_path = str(staged_path)
+
+        # Step 3: Invariants Verification
+        if self.config.verify_invariants:
+            self._verify_invariants(staged_path, agent_id, result)
+            result.invariants_passed = True
+            log.info("restore_staged_invariants_passed", agent_id=agent_id)
+
+        # Step 4: Atomic Commit & Bounded Rollback
+        await self._commit_and_reconcile(
+            target_path=target_path,
+            staged_path=staged_path,
+            agent_id=agent_id,
+            api=api,
+            result=result,
+        )
+
+        result.duration_ms = round((time.monotonic() - start_time) * 1000, 2)
+        log.info(
+            "restore_staged_complete",
+            agent_id=agent_id,
+            duration_ms=result.duration_ms,
+            committed=result.committed,
+        )
+        return result
+
+    def _preflight_check(
+        self,
+        checkpoint_input: dict[str, Any] | Path | str,
+        expected_agent_id: str,
+        result: StagedRestoreResult,
+    ) -> dict[str, Any]:
+        """Validate checkpoint format, bounds, schema compatibility, and identity before touching state."""
+        if not expected_agent_id or not isinstance(expected_agent_id, str):
+            raise PreflightError("Agent ID must be a non-empty string")
+
+        payload: dict[str, Any] | None = None
+
+        if isinstance(checkpoint_input, (str, Path)):
+            input_path = Path(checkpoint_input)
+            if not input_path.exists():
+                raise PreflightError(f"Checkpoint file not found: {input_path}")
+
+            size = input_path.stat().st_size
+            if size > self.config.max_size_bytes:
+                raise PreflightError(
+                    f"Checkpoint size ({size} bytes) exceeds limit ({self.config.max_size_bytes} bytes)"
+                )
+
+            try:
+                raw_data = input_path.read_bytes()
+                payload = json.loads(raw_data.decode("utf-8"))
+            except Exception as exc:
+                raise PreflightError(f"Failed to parse checkpoint JSON: {exc}") from exc
+        elif isinstance(checkpoint_input, dict):
+            payload = checkpoint_input
+        else:
+            raise PreflightError("Invalid checkpoint input type")
+
+        if not isinstance(payload, dict):
+            raise PreflightError("Checkpoint payload must be a JSON object")
+
+        schema_ver = payload.get("schema_version", payload.get("schema", 1))
+        if isinstance(schema_ver, bool) or not isinstance(schema_ver, int):
+            raise PreflightError("Checkpoint schema_version must be an integer")
+
+        if schema_ver not in self.config.allowed_schema_versions:
+            raise PreflightError(
+                f"Unsupported checkpoint schema version: {schema_ver}. Allowed: {self.config.allowed_schema_versions}"
+            )
+        result.schema_version = schema_ver
+
+        payload_agent_id = payload.get("agent_id")
+        if payload_agent_id is not None:
+            if not isinstance(payload_agent_id, str):
+                raise PreflightError("Checkpoint agent_id must be a string")
+            if self.config.require_agent_match and payload_agent_id != expected_agent_id:
+                raise PreflightError(
+                    f"Checkpoint agent_id ({payload_agent_id!r}) does not match expected ({expected_agent_id!r})"
+                )
+
+        tables = payload.get("tables")
+        if tables is not None:
+            if not isinstance(tables, dict):
+                raise PreflightError("Checkpoint tables must be an object")
+            for table_name, count in tables.items():
+                if not isinstance(table_name, str):
+                    raise PreflightError("Table names must be strings")
+                if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+                    raise PreflightError(f"Row count for table {table_name!r} must be a non-negative integer")
+                result.tables_restored[table_name] = count
+
+        return payload
+
+    def _stage_checkpoint(
+        self,
+        target_path: Path,
+        payload: dict[str, Any],
+        agent_id: str,
+        result: StagedRestoreResult,
+    ) -> Path:
+        """Create staged database and apply migrations against staged state only."""
+        target_dir = target_path.parent
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        staging_dir = Path(self.config.staging_dir) if self.config.staging_dir else target_dir
+        staged_path = staging_dir / f"{target_path.name}.staged.{secrets.token_hex(8)}.db"
+
+        try:
+            from talos_agent.db import LocalDB
+
+            # LocalDB init automatically runs migrations against the staged database
+            staged_db = LocalDB(path=staged_path)
+
+            tables_data = payload.get("tables_data", {})
+            if isinstance(tables_data, dict) and tables_data:
+                for table_name, rows in tables_data.items():
+                    if isinstance(rows, list):
+                        for row in rows:
+                            if isinstance(row, dict):
+                                cols = list(row.keys())
+                                placeholders = ", ".join(["?"] * len(cols))
+                                col_names = ", ".join([f'"{c}"' for c in cols])
+                                sql = f'INSERT OR REPLACE INTO "{table_name}" ({col_names}) VALUES ({placeholders})'
+                                staged_db._conn.execute(sql, list(row.values()))
+                        staged_db._conn.commit()
+
+            staged_db._conn.execute(
+                "INSERT OR REPLACE INTO talos_config (key, value) VALUES ('agent_id', ?)",
+                (agent_id,),
+            )
+            staged_db._conn.commit()
+
+            staged_counts: dict[str, int] = {}
+            for table_name in _CHECKPOINT_TABLES:
+                try:
+                    cnt = staged_db._conn.execute(f'SELECT COUNT(*) FROM "{table_name}"').fetchone()[0]
+                    staged_counts[table_name] = cnt
+                except sqlite3.OperationalError:
+                    pass
+
+            if staged_counts:
+                result.tables_restored.update(staged_counts)
+
+            staged_db.close()
+            log.info("restore_staged_staging_completed", staged_path=str(staged_path))
+            return staged_path
+        except Exception as exc:
+            if staged_path.exists():
+                staged_path.unlink(missing_ok=True)
+            raise StagingError(f"Failed to create staged database: {exc}") from exc
+
+    def _verify_invariants(
+        self,
+        staged_path: Path,
+        expected_agent_id: str,
+        result: StagedRestoreResult,
+    ) -> None:
+        """Verify database structural and data invariants on staged state."""
+        try:
+            conn = sqlite3.connect(str(staged_path))
+            conn.row_factory = sqlite3.Row
+
+            check = conn.execute("PRAGMA quick_check").fetchone()
+            if not check or check[0] != "ok":
+                raise InvariantError(f"SQLite integrity check failed: {check[0] if check else 'empty'}")
+
+            existing_tables = {
+                r["name"] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+            }
+            required_tables = {"schedules", "talos_config", "activity_log"}
+            missing = required_tables - existing_tables
+            if missing:
+                raise InvariantError(f"Staged database missing required tables: {missing}")
+
+            for tbl in existing_tables:
+                if not tbl.startswith("sqlite_"):
+                    cnt = conn.execute(f'SELECT COUNT(*) FROM "{tbl}"').fetchone()[0]
+                    if cnt < 0:
+                        raise InvariantError(f"Negative row count in table {tbl}")
+
+            cfg_row = conn.execute("SELECT value FROM talos_config WHERE key='agent_id'").fetchone()
+            if cfg_row and cfg_row["value"] != expected_agent_id:
+                raise InvariantError(
+                    f"In-database agent_id ({cfg_row['value']!r}) does not match expected ({expected_agent_id!r})"
+                )
+
+            conn.close()
+        except Exception as exc:
+            if staged_path.exists():
+                staged_path.unlink(missing_ok=True)
+            if isinstance(exc, InvariantError):
+                raise
+            raise InvariantError(f"Staged database invariant verification failed: {exc}") from exc
+
+    async def _commit_and_reconcile(
+        self,
+        target_path: Path,
+        staged_path: Path,
+        agent_id: str,
+        api: TalosAPIClient | None,
+        result: StagedRestoreResult,
+    ) -> None:
+        """Perform atomic commit, bounded backup, reconciliation, and rollback if commit fails."""
+        journal_path = target_path.parent / f"{target_path.name}.restore_journal.json"
+        backup_path: Path | None = None
+
+        try:
+            journal_payload = {
+                "status": "staging_completed",
+                "agent_id": agent_id,
+                "staged_path": str(staged_path),
+                "target_path": str(target_path),
+                "timestamp": _now_utc().isoformat(),
+            }
+            journal_path.write_text(json.dumps(journal_payload, indent=2))
+
+            if target_path.exists():
+                timestamp_str = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+                backup_path = target_path.parent / f"{target_path.name}.backup.{timestamp_str}"
+                shutil.copy2(target_path, backup_path)
+                result.backup_path = str(backup_path)
+                journal_payload["backup_path"] = str(backup_path)
+                log.info("restore_staged_backup_created", backup_path=str(backup_path))
+
+                self._prune_old_backups(target_path)
+
+            journal_payload["status"] = "committing"
+            journal_path.write_text(json.dumps(journal_payload, indent=2))
+
+            os.replace(staged_path, target_path)
+
+            for ext in ("-wal", "-shm"):
+                aux_file = Path(str(target_path) + ext)
+                aux_file.unlink(missing_ok=True)
+
+            journal_payload["status"] = "committed"
+            journal_path.write_text(json.dumps(journal_payload, indent=2))
+            result.committed = True
+            log.info("restore_staged_committed", target_path=str(target_path))
+
+            from talos_agent.db import LocalDB
+
+            active_db = LocalDB(path=target_path)
+            try:
+                reconcile_cfg = ReconcileConfig(api_verify_leases=self.config.api_verify_leases)
+                reconcile_res = await reconcile_after_restore(active_db, api=api, config=reconcile_cfg)
+                result.reconciliation_result = reconcile_res
+                log.info("restore_staged_reconciliation_completed")
+            finally:
+                active_db.close()
+
+            journal_path.unlink(missing_ok=True)
+
+        except Exception as exc:
+            if backup_path and backup_path.exists():
+                try:
+                    os.replace(backup_path, target_path)
+                    result.rolled_back = True
+                    journal_payload["status"] = "rolled_back"
+                    journal_path.write_text(json.dumps(journal_payload, indent=2))
+                    log.warning("restore_staged_rollback_executed", target_path=str(target_path))
+                except Exception as rollback_exc:
+                    logger.error(f"Failed to rollback active DB: {rollback_exc}")
+
+            if staged_path.exists():
+                staged_path.unlink(missing_ok=True)
+
+            raise RollbackError(f"Restore commit failed and active state was rolled back: {exc}") from exc
+
+    def _prune_old_backups(self, target_path: Path) -> None:
+        """Prune old database backups beyond backup_retain_count."""
+        pattern = f"{target_path.name}.backup.*"
+        backups = sorted(target_path.parent.glob(pattern), key=lambda p: p.stat().st_mtime)
+        while len(backups) > self.config.backup_retain_count:
+            oldest = backups.pop(0)
+            oldest.unlink(missing_ok=True)
+
+
+async def perform_staged_restore(
+    target_db_path: Path | str,
+    checkpoint_input: dict[str, Any] | Path | str,
+    agent_id: str,
+    *,
+    config: StagedRestoreConfig | None = None,
+    api: TalosAPIClient | None = None,
+) -> StagedRestoreResult:
+    """Async entry point for transactional staged restore."""
+    manager = StagedRestoreManager(config=config)
+    return await manager.perform_staged_restore(
+        target_db_path=target_db_path,
+        checkpoint_input=checkpoint_input,
+        agent_id=agent_id,
+        api=api,
+    )
+
+
+def perform_staged_restore_sync(
+    target_db_path: Path | str,
+    checkpoint_input: dict[str, Any] | Path | str,
+    agent_id: str,
+    *,
+    config: StagedRestoreConfig | None = None,
+    api: TalosAPIClient | None = None,
+) -> StagedRestoreResult:
+    """Synchronous entry point for transactional staged restore (used by CLI)."""
+    return asyncio.run(
+        perform_staged_restore(
+            target_db_path=target_db_path,
+            checkpoint_input=checkpoint_input,
+            agent_id=agent_id,
+            config=config,
+            api=api,
+        )
+    )
+
+
+def recover_interrupted_restore(target_db_path: Path | str) -> bool:
+    """Recover from an interrupted restore process by inspecting the restore journal."""
+    target_path = Path(target_db_path).resolve()
+    journal_path = target_path.parent / f"{target_path.name}.restore_journal.json"
+
+    if not journal_path.exists():
+        return False
+
+    try:
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+        status = journal.get("status")
+        backup_path_str = journal.get("backup_path")
+        staged_path_str = journal.get("staged_path")
+
+        if staged_path_str:
+            Path(staged_path_str).unlink(missing_ok=True)
+
+        if status in ("committing", "staging_completed") and backup_path_str:
+            backup_path = Path(backup_path_str)
+            if backup_path.exists():
+                os.replace(backup_path, target_path)
+                log.warning("restore_interrupted_recovered", target_path=str(target_path))
+
+        journal_path.unlink(missing_ok=True)
+        return True
+    except Exception as exc:
+        logger.error(f"Error during interrupted restore recovery: {exc}")
+        return False
+
+
 __all__ = [
+    "InvariantError",
+    "PreflightError",
     "ReconcileConfig",
     "ReconcileResult",
+    "RollbackError",
+    "StagedRestoreConfig",
+    "StagedRestoreError",
+    "StagedRestoreManager",
+    "StagedRestoreResult",
+    "StagingError",
+    "perform_staged_restore",
+    "perform_staged_restore_sync",
     "reconcile_after_restore",
+    "recover_interrupted_restore",
 ]
+

--- a/packages/prime-agent/src/talos_agent/restore.py
+++ b/packages/prime-agent/src/talos_agent/restore.py
@@ -82,6 +82,8 @@ Limitations
   by less than ``MAX_CLOCK_SKEW_SECS``.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/packages/prime-agent/tests/test_staged_restore.py
+++ b/packages/prime-agent/tests/test_staged_restore.py
@@ -1,0 +1,230 @@
+"""Tests for transactional staged checkpoint restore (#295).
+
+Covers:
+- Preflight validation & error paths (active state untouched).
+- Staging & database migrations against staged state only.
+- Structural & data invariant verification.
+- Atomic commit & bounded backup/rollback.
+- Restart-safe recovery of interrupted restores.
+- CLI `checkpoint restore` exit codes & output formatting.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from talos_agent.checkpoint_cli import checkpoint, CheckpointExitCode
+from talos_agent.db import LocalDB, get_db_path
+from talos_agent.restore import (
+    InvariantError,
+    PreflightError,
+    RollbackError,
+    StagedRestoreConfig,
+    StagedRestoreManager,
+    StagingError,
+    perform_staged_restore,
+    perform_staged_restore_sync,
+    recover_interrupted_restore,
+)
+
+
+@pytest.fixture
+def target_db(tmp_path: Path) -> Path:
+    db_file = tmp_path / "agent-test_agent.db"
+    db = LocalDB(path=db_file)
+    db._conn.execute(
+        "INSERT INTO schedules (task_name, last_run_at) VALUES ('active_task', '2026-01-01T00:00:00Z')"
+    )
+    db._conn.commit()
+    db.close()
+    return db_file
+
+
+@pytest.fixture
+def valid_checkpoint_file(tmp_path: Path) -> Path:
+    cp_path = tmp_path / "valid_checkpoint.json"
+    data = {
+        "schema_version": 1,
+        "agent_id": "test_agent",
+        "tables": {"schedules": 2, "activity_log": 5},
+        "tables_data": {
+            "schedules": [
+                {"task_name": "task1", "last_run_at": "2026-07-20T10:00:00Z"},
+                {"task_name": "task2", "last_run_at": "2026-07-21T12:00:00Z"},
+            ]
+        },
+    }
+    cp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return cp_path
+
+
+class TestPreflightValidation:
+    @pytest.mark.asyncio
+    async def test_non_existent_file_raises_preflight(self, target_db: Path):
+        cfg = StagedRestoreConfig(require_agent_match=True)
+        with pytest.raises(PreflightError, match="Checkpoint file not found"):
+            await perform_staged_restore(
+                target_db_path=target_db,
+                checkpoint_input=target_db.parent / "non_existent.json",
+                agent_id="test_agent",
+                config=cfg,
+            )
+
+    @pytest.mark.asyncio
+    async def test_file_size_exceeded_raises_preflight(self, target_db: Path, valid_checkpoint_file: Path):
+        cfg = StagedRestoreConfig(max_size_bytes=10)  # tiny limit
+        with pytest.raises(PreflightError, match="exceeds limit"):
+            await perform_staged_restore(
+                target_db_path=target_db,
+                checkpoint_input=valid_checkpoint_file,
+                agent_id="test_agent",
+                config=cfg,
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_raises_preflight(self, target_db: Path, tmp_path: Path):
+        bad_json = tmp_path / "bad.json"
+        bad_json.write_text("not json content", encoding="utf-8")
+
+        with pytest.raises(PreflightError, match="Failed to parse checkpoint JSON"):
+            await perform_staged_restore(
+                target_db_path=target_db,
+                checkpoint_input=bad_json,
+                agent_id="test_agent",
+            )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_schema_version_raises_preflight(self, target_db: Path, tmp_path: Path):
+        bad_schema = tmp_path / "bad_schema.json"
+        bad_schema.write_text(json.dumps({"schema_version": 99, "agent_id": "test_agent"}), encoding="utf-8")
+
+        with pytest.raises(PreflightError, match="Unsupported checkpoint schema version"):
+            await perform_staged_restore(
+                target_db_path=target_db,
+                checkpoint_input=bad_schema,
+                agent_id="test_agent",
+            )
+
+    @pytest.mark.asyncio
+    async def test_agent_id_mismatch_raises_preflight(self, target_db: Path, valid_checkpoint_file: Path):
+        cfg = StagedRestoreConfig(require_agent_match=True)
+        with pytest.raises(PreflightError, match="does not match expected"):
+            await perform_staged_restore(
+                target_db_path=target_db,
+                checkpoint_input=valid_checkpoint_file,
+                agent_id="different_agent",
+                config=cfg,
+            )
+
+
+class TestStagingAndInvariants:
+    @pytest.mark.asyncio
+    async def test_successful_staged_restore(self, target_db: Path, valid_checkpoint_file: Path):
+        res = await perform_staged_restore(
+            target_db_path=target_db,
+            checkpoint_input=valid_checkpoint_file,
+            agent_id="test_agent",
+        )
+
+        assert res.preflight_passed is True
+        assert res.invariants_passed is True
+        assert res.committed is True
+        assert res.rolled_back is False
+
+        conn = sqlite3.connect(str(target_db))
+        rows = conn.execute("SELECT task_name FROM schedules ORDER BY task_name").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == ["task1", "task2"]
+
+    @pytest.mark.asyncio
+    async def test_invariant_verification_failure_cancels_commit(self, target_db: Path, tmp_path: Path):
+        corrupt_cp = tmp_path / "corrupt.json"
+        corrupt_cp.write_text(
+            json.dumps({"schema_version": 1, "agent_id": "test_agent", "tables": {}}),
+            encoding="utf-8",
+        )
+
+        mgr = StagedRestoreManager()
+        with patch.object(mgr, "_verify_invariants", side_effect=InvariantError("Mock invariant error")):
+            with pytest.raises(InvariantError, match="Mock invariant error"):
+                await mgr.perform_staged_restore(
+                    target_db_path=target_db,
+                    checkpoint_input=corrupt_cp,
+                    agent_id="test_agent",
+                )
+
+        # Ensure active database remains untouched
+        conn = sqlite3.connect(str(target_db))
+        rows = conn.execute("SELECT task_name FROM schedules").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "active_task"
+
+
+class TestAtomicCommitAndRollback:
+    @pytest.mark.asyncio
+    async def test_rollback_on_commit_failure(self, target_db: Path, valid_checkpoint_file: Path):
+        mgr = StagedRestoreManager()
+
+        with patch("talos_agent.restore.reconcile_after_restore", side_effect=RuntimeError("Reconciliation crash")):
+            with pytest.raises(RollbackError, match="Restore commit failed"):
+                await mgr.perform_staged_restore(
+                    target_db_path=target_db,
+                    checkpoint_input=valid_checkpoint_file,
+                    agent_id="test_agent",
+                )
+
+        # Active database state should have rolled back to active_task
+        conn = sqlite3.connect(str(target_db))
+        rows = conn.execute("SELECT task_name FROM schedules").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "active_task"
+
+    def test_recover_interrupted_restore(self, target_db: Path, tmp_path: Path):
+        backup_path = tmp_path / f"{target_db.name}.backup.12345"
+        backup_path.write_bytes(target_db.read_bytes())
+
+        journal_path = tmp_path / f"{target_db.name}.restore_journal.json"
+        journal_payload = {
+            "status": "committing",
+            "agent_id": "test_agent",
+            "staged_path": str(tmp_path / "staged.db"),
+            "target_path": str(target_db),
+            "backup_path": str(backup_path),
+        }
+        journal_path.write_text(json.dumps(journal_payload), encoding="utf-8")
+
+        recovered = recover_interrupted_restore(target_db)
+        assert recovered is True
+        assert journal_path.exists() is False
+
+
+class TestCheckpointCLIRestore:
+    def test_cli_restore_success(self, tmp_path: Path, valid_checkpoint_file: Path):
+        runner = CliRunner()
+
+        with patch("talos_agent.db.APP_DIR", tmp_path):
+            result = runner.invoke(
+                checkpoint,
+                ["restore", "--input", str(valid_checkpoint_file), "--agent", "test_agent", "--json"],
+            )
+            assert result.exit_code == 0
+            json_str = result.output[result.output.index("{") :]
+            res_dict = json.loads(json_str)
+            assert res_dict["agent_id"] == "test_agent"
+            assert res_dict["committed"] is True
+
+    def test_cli_restore_validation_error(self, valid_checkpoint_file: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            checkpoint,
+            ["restore", "--input", str(valid_checkpoint_file), "--agent", "wrong_agent"],
+        )
+        assert result.exit_code == CheckpointExitCode.VALIDATION_ERROR


### PR DESCRIPTION
## Overview
This PR implements transactional staged checkpoint restore for the Talos agent runtime (#295). Checkpoint restores are executed through a fault-tolerant multi-stage pipeline consisting of preflight validation, isolated database staging and migration execution, structural/data invariant verification, atomic commit via file swap, bounded active database backup, and automatic rollback on failure.

## Related Issue
Closes #295

- 
[MODIFY] packages/prime-agent/src/talos_agent/restore.py

- Implemented `StagedRestoreManager`, `perform_staged_restore`, `perform_staged_restore_sync`, and `recover_interrupted_restore`.
- Added exception hierarchy (`StagedRestoreError`, `PreflightError`, `StagingError`, `InvariantError`, `RollbackError`) and configuration/result dataclasses (`StagedRestoreConfig`, `StagedRestoreResult`).
- Preflight stage validates format, size limits, schema compatibility, and identity before touching state.
- Staging stage applies schema migrations against temporary staged database only.
- Invariant stage verifies SQLite integrity, table availability, non-negative row bounds, and agent identity.
- Commit stage creates bounded active backups, performs atomic file swap, executes post-restore reconciliation, and rolls back cleanly on failure.
- Added restart recovery helper for interrupted restores.

- 
[MODIFY] packages/prime-agent/src/talos_agent/checkpoint_cli.py

- Registered `@checkpoint.command("restore")` CLI command supporting transactional staged restore with JSON output option, custom schema versioning, max size limits, and invariant verification controls with stable process exit codes.

- 
[ADD] packages/prime-agent/tests/test_staged_restore.py

- Coverage for preflight failures, staging/migrations, invariant failures, atomic commit/rollback recovery, interrupted restore recovery, and CLI exit codes.

```
python -m pytest tests/test_staged_restore.py ✅ 11/11 passed
python -m pytest ✅ 603/603 passed
```
