### PR TITLE
privacy(web): suppress sparse analytics and verify backfills

### DIFF
--- a/web/src/app/api/ecosystem-intelligence/route.ts
+++ b/web/src/app/api/ecosystem-intelligence/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { 
   tlsTalos, 
@@ -10,6 +10,14 @@ import {
 } from "@/db/schema";
 import { and, gte, eq } from "drizzle-orm";
 import { isRetryableDbError } from "@/db/db-retry";
+import {
+  AnalyticsInputValidationError,
+  DEFAULT_ANALYTICS_PRIVACY_POLICY,
+  deduplicateAnalyticsRows,
+  describeSuppression,
+  suppressSparseRecord,
+  suppressSparseRows,
+} from "@/lib/analytics-privacy";
 
 export const dynamic = 'force-dynamic';
 
@@ -24,6 +32,11 @@ interface EcosystemMetrics {
     suppression: string[];
     version: string;
     generatedAt: string;
+    privacy: {
+      minimumCohortSize: number;
+      maximumInputRows: number;
+      deduplicatedRows: number;
+    };
   };
   supply: {
     activeAgents: number;
@@ -82,10 +95,14 @@ interface EcosystemMetrics {
       revenue7d: number;
     }>;
     dataSource: 'inferred'; // Calculated from observed data
+    methodology: {
+      version: string;
+      inputs: readonly ['observed-demand', 'observed-supply', 'observed-revenue'];
+    };
   };
 }
 
-export async function GET(req: NextRequest) {
+export async function GET(req: Request) {
   // For now, this is a public endpoint for ecosystem-wide metrics.
   // If authorization is needed, uncomment the following:
   // const wallet = req.nextUrl.searchParams.get("wallet");
@@ -108,58 +125,94 @@ export async function GET(req: NextRequest) {
 
     // Fetch all relevant data in parallel with retry logic for transient failures
     const [
-      allAgents,
-      allServices,
-      allPlaybooks,
-      recentRevenues,
-      recentJobs,
-      recentPurchases,
-      recentPatronGrowth
+      rawAgents,
+      rawServices,
+      rawPlaybooks,
+      rawRevenues,
+      rawJobs,
+      rawPurchases,
+      rawPatronGrowth
     ] = await Promise.all([
       db.query.tlsTalos.findMany({
         where: eq(tlsTalos.status, 'Active'),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
         with: {
           patrons: true,
           revenues: true,
         }
       }),
-      db.query.tlsCommerceServices.findMany(),
+      db.query.tlsCommerceServices.findMany({
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
+      }),
       db.query.tlsPlaybooks.findMany({
-        where: eq(tlsPlaybooks.status, 'active')
+        where: eq(tlsPlaybooks.status, 'active'),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
       }),
       db.query.tlsRevenues.findMany({
-        where: gte(tlsRevenues.createdAt, sevenDaysAgo)
+        where: gte(tlsRevenues.createdAt, sevenDaysAgo),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
       }),
       db.query.tlsCommerceJobs.findMany({
-        where: gte(tlsCommerceJobs.createdAt, sevenDaysAgo)
+        where: gte(tlsCommerceJobs.createdAt, sevenDaysAgo),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
       }),
       db.query.tlsPlaybookPurchases.findMany({
-        where: gte(tlsPlaybookPurchases.createdAt, sevenDaysAgo)
+        where: gte(tlsPlaybookPurchases.createdAt, sevenDaysAgo),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
       }),
       db.query.tlsPatrons.findMany({
         where: and(
           eq(tlsPatrons.status, 'active'),
           gte(tlsPatrons.createdAt, sevenDaysAgo)
-        )
+        ),
+        limit: DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows + 1,
       })
     ]);
+
+    const deduplicated = [
+      deduplicateAnalyticsRows(rawAgents, 'agents', row => row.id),
+      deduplicateAnalyticsRows(rawServices, 'services', row => row.id),
+      deduplicateAnalyticsRows(rawPlaybooks, 'playbooks', row => row.id),
+      deduplicateAnalyticsRows(rawRevenues, 'revenues', row => row.id),
+      deduplicateAnalyticsRows(rawJobs, 'jobs', row => row.id),
+      deduplicateAnalyticsRows(rawPurchases, 'purchases', row => row.id),
+      deduplicateAnalyticsRows(rawPatronGrowth, 'patrons', row => row.id),
+    ] as const;
+    const [
+      { rows: allAgents },
+      { rows: allServices },
+      { rows: allPlaybooks },
+      { rows: recentRevenues },
+      { rows: recentJobs },
+      { rows: recentPurchases },
+      { rows: recentPatronGrowth },
+    ] = deduplicated;
+    const deduplicatedRows = deduplicated.reduce(
+      (total, result) => total + result.duplicateCount,
+      0,
+    );
 
     // Calculate metadata
     const sampleSize = allAgents.length;
     const confidence = sampleSize >= 10 ? 'high' : sampleSize >= 5 ? 'medium' : 'low';
     const freshness = 'real-time';
     const suppression: string[] = [];
-    const version = '1.0.0';
+    const version = '1.1.0';
 
     // Supply metrics
     const activeAgents = allAgents.length;
     const totalServices = allServices.length;
     const totalPlaybooks = allPlaybooks.length;
     
-    const byCategory: Record<string, number> = {};
+    const categoryCohortSizes: Record<string, number> = {};
     allAgents.forEach(agent => {
-      byCategory[agent.category] = (byCategory[agent.category] || 0) + 1;
+      categoryCohortSizes[agent.category] =
+        (categoryCohortSizes[agent.category] || 0) + 1;
     });
+    const supplyByCategory = suppressSparseRecord(
+      categoryCohortSizes,
+      categoryCohortSizes,
+    );
 
     // Calculate trend (compare with previous period - simplified for now)
     const supplyTrend: 'increasing' | 'stable' | 'decreasing' = 'stable';
@@ -179,6 +232,10 @@ export async function GET(req: NextRequest) {
         demandByCategory[agent.category] = (demandByCategory[agent.category] || 0) + 1;
       }
     });
+    const visibleDemandByCategory = suppressSparseRecord(
+      demandByCategory,
+      categoryCohortSizes,
+    );
 
     const demandTrend: 'increasing' | 'stable' | 'decreasing' = 'stable';
 
@@ -216,6 +273,10 @@ export async function GET(req: NextRequest) {
       const prices = priceByCategory[category];
       avgPriceByCategory[category] = prices.reduce((sum, p) => sum + p, 0) / prices.length;
     });
+    const visiblePriceByCategory = suppressSparseRecord(
+      avgPriceByCategory,
+      categoryCohortSizes,
+    );
 
     // Fulfillment metrics
     const totalJobs = recentJobs.length;
@@ -233,7 +294,7 @@ export async function GET(req: NextRequest) {
       jobsByAgent.set(job.talosId, existing);
     });
 
-    const byAgent = Array.from(jobsByAgent.entries()).map(([agentId, stats]) => {
+    const byAgentCandidates = Array.from(jobsByAgent.entries()).map(([agentId, stats]) => {
       const agent = allAgents.find(a => a.id === agentId);
       return {
         agentId,
@@ -241,7 +302,14 @@ export async function GET(req: NextRequest) {
         completionRate: stats.total > 0 ? (stats.completed / stats.total) * 100 : 0,
         totalJobs: stats.total,
       };
-    }).sort((a, b) => b.completionRate - a.completionRate).slice(0, 10);
+    });
+    const visibleByAgent = suppressSparseRows(
+      byAgentCandidates,
+      row => row.totalJobs,
+    );
+    const byAgent = visibleByAgent.rows
+      .sort((a, b) => b.completionRate - a.completionRate)
+      .slice(0, 10);
 
     // Opportunity metrics
     // Calculate demand vs supply by category
@@ -264,7 +332,7 @@ export async function GET(req: NextRequest) {
       }
     });
 
-    const underservedCategories = Array.from(categoryScores.entries())
+    const underservedCandidates = Array.from(categoryScores.entries())
       .map(([category, scores]) => {
         const demandScore = scores.demand / (scores.supply || 1);
         const supplyScore = scores.supply / allAgents.length;
@@ -277,31 +345,68 @@ export async function GET(req: NextRequest) {
         };
       })
       .filter(c => c.opportunityScore > 0)
-      .sort((a, b) => b.opportunityScore - a.opportunityScore)
+      .sort((a, b) => b.opportunityScore - a.opportunityScore);
+    const visibleUnderservedCategories = suppressSparseRows(
+      underservedCandidates,
+      row => categoryCohortSizes[row.category] ?? 0,
+    );
+    const underservedCategories = visibleUnderservedCategories.rows
       .slice(0, 5);
 
     // Trending agents (by revenue growth)
-    const agentRevenue7d = new Map<string, number>();
+    const agentRevenue7d = new Map<string, { total: number; events: number }>();
     recentRevenues.forEach(revenue => {
-      const existing = agentRevenue7d.get(revenue.talosId) || 0;
-      agentRevenue7d.set(revenue.talosId, existing + Number(revenue.amount));
+      const existing = agentRevenue7d.get(revenue.talosId) || { total: 0, events: 0 };
+      agentRevenue7d.set(revenue.talosId, {
+        total: existing.total + Number(revenue.amount),
+        events: existing.events + 1,
+      });
     });
 
-    const trendingAgents = Array.from(agentRevenue7d.entries())
-      .map(([agentId, revenue7d]) => {
+    const trendingCandidates = Array.from(agentRevenue7d.entries())
+      .map(([agentId, revenue]) => {
         const agent = allAgents.find(a => a.id === agentId);
         const totalRevenue = agent?.revenues.reduce((sum, r) => sum + Number(r.amount), 0) || 0;
-        const growthScore = totalRevenue > 0 ? (revenue7d / totalRevenue) * 100 : 0;
+        const growthScore = totalRevenue > 0 ? (revenue.total / totalRevenue) * 100 : 0;
         return {
           agentId,
           agentName: agent?.name || 'Unknown',
           growthScore,
-          revenue7d,
+          revenue7d: revenue.total,
+          cohortSize: revenue.events,
         };
       })
       .filter(a => a.revenue7d > 0)
-      .sort((a, b) => b.growthScore - a.growthScore)
-      .slice(0, 5);
+      .sort((a, b) => b.growthScore - a.growthScore);
+    const visibleTrendingAgents = suppressSparseRows(
+      trendingCandidates,
+      row => row.cohortSize,
+    );
+    const trendingAgents = visibleTrendingAgents.rows
+      .slice(0, 5)
+      .map(agent => ({
+        agentId: agent.agentId,
+        agentName: agent.agentName,
+        growthScore: agent.growthScore,
+        revenue7d: agent.revenue7d,
+      }));
+
+    [
+      describeSuppression('supply.byCategory', supplyByCategory.suppressedCount),
+      describeSuppression('demand.byCategory', visibleDemandByCategory.suppressedCount),
+      describeSuppression('price.priceByCategory', visiblePriceByCategory.suppressedCount),
+      describeSuppression('fulfillment.byAgent', visibleByAgent.suppressedCount),
+      describeSuppression(
+        'opportunity.underservedCategories',
+        visibleUnderservedCategories.suppressedCount,
+      ),
+      describeSuppression(
+        'opportunity.trendingAgents',
+        visibleTrendingAgents.suppressedCount,
+      ),
+    ].forEach(entry => {
+      if (entry) suppression.push(entry);
+    });
 
     const metrics: EcosystemMetrics = {
       metadata: {
@@ -311,12 +416,19 @@ export async function GET(req: NextRequest) {
         suppression,
         version,
         generatedAt: now.toISOString(),
+        privacy: {
+          minimumCohortSize:
+            DEFAULT_ANALYTICS_PRIVACY_POLICY.minimumCohortSize,
+          maximumInputRows:
+            DEFAULT_ANALYTICS_PRIVACY_POLICY.maximumInputRows,
+          deduplicatedRows,
+        },
       },
       supply: {
         activeAgents,
         totalServices,
         totalPlaybooks,
-        byCategory,
+        byCategory: supplyByCategory.values,
         trend: supplyTrend,
         dataSource: 'observed',
       },
@@ -325,7 +437,7 @@ export async function GET(req: NextRequest) {
         completedJobs24h,
         playbookPurchases7d,
         patronGrowth7d,
-        byCategory: demandByCategory,
+        byCategory: visibleDemandByCategory.values,
         trend: demandTrend,
         dataSource: 'observed',
       },
@@ -340,7 +452,7 @@ export async function GET(req: NextRequest) {
         avgServicePrice,
         avgTokenPrice,
         priceChange24h,
-        priceByCategory: avgPriceByCategory,
+        priceByCategory: visiblePriceByCategory.values,
         dataSource: 'observed',
       },
       fulfillment: {
@@ -354,6 +466,10 @@ export async function GET(req: NextRequest) {
         underservedCategories,
         trendingAgents,
         dataSource: 'inferred',
+        methodology: {
+          version: 'demand-supply-ratio-v1',
+          inputs: ['observed-demand', 'observed-supply', 'observed-revenue'],
+        },
       },
     };
 
@@ -366,6 +482,13 @@ export async function GET(req: NextRequest) {
     return response;
   } catch (error) {
     console.error('Error fetching ecosystem intelligence:', error);
+
+    if (error instanceof AnalyticsInputValidationError) {
+      return NextResponse.json(
+        { error: 'Analytics input failed validation', retryable: false },
+        { status: 422 },
+      );
+    }
     
     // Check if error is retryable
     if (isRetryableDbError(error)) {

--- a/web/src/app/ecosystem-intelligence/README.md
+++ b/web/src/app/ecosystem-intelligence/README.md
@@ -39,7 +39,7 @@ The Ecosystem Intelligence Dashboard provides privacy-safe supply, demand, capac
 ### Fulfillment Analytics
 - Completion and success rates
 - Average fulfillment time
-- Per-agent performance ranking
+- Per-agent performance ranking when at least five jobs support the slice
 
 ### Opportunity Detection
 - **Underserved Categories**: Categories with high demand but low supply
@@ -50,8 +50,16 @@ The Ecosystem Intelligence Dashboard provides privacy-safe supply, demand, capac
 The dashboard is designed with privacy in mind:
 - **Sample Size**: Always displayed to indicate statistical significance
 - **Confidence Levels**: High (≥10 agents), Medium (≥5 agents), Low (<5 agents)
-- **Suppression**: Sensitive data points can be suppressed via configuration
+- **Suppression**: Category and per-agent slices with fewer than five supporting records are omitted
+- **Safe Metadata**: Suppression metadata reports only the number of hidden cohorts, never their names
+- **Replay Protection**: Immutable row IDs are deduplicated before metrics are calculated
+- **Input Bounds**: Each source query is capped and oversized results fail closed
 - **No PII**: No personally identifiable information is exposed
+
+Global totals remain available because they describe the whole ecosystem rather
+than a narrow cohort. Category price, supply, demand, and opportunity slices use
+the number of active agents in that category as their privacy cohort. Per-agent
+fulfillment uses job count, while trending-agent revenue uses revenue-event count.
 
 ## API Endpoint
 
@@ -69,6 +77,11 @@ Returns comprehensive ecosystem metrics.
     suppression: string[];
     version: string;
     generatedAt: string;
+    privacy: {
+      minimumCohortSize: number;
+      maximumInputRows: number;
+      deduplicatedRows: number;
+    };
   };
   supply: {
     activeAgents: number;
@@ -121,6 +134,11 @@ Returns comprehensive ecosystem metrics.
       growthScore: number;
       revenue7d: number;
     }>;
+    dataSource: 'inferred';
+    methodology: {
+      version: string;
+      inputs: ['observed-demand', 'observed-supply', 'observed-revenue'];
+    };
   };
 }
 ```
@@ -180,9 +198,9 @@ The dashboard aggregates data from multiple database tables:
 No specific environment variables required. Uses existing database configuration.
 
 ### Customization
-To adjust refresh intervals or add suppression rules, modify:
+To adjust refresh intervals or the centrally defined suppression policy, modify:
 - `ecosystem-intelligence-client.tsx` - Refresh interval (default: 60s)
-- `route.ts` - Suppression logic and confidence thresholds
+- `src/lib/analytics-privacy.ts` - Cohort and input limits
 
 ## Testing
 
@@ -193,6 +211,13 @@ Unit tests are provided in `tests/ecosystem-intelligence.test.ts`:
 - Metric calculation accuracy
 - Metadata validation
 - Data type validation
+- Exact suppression-boundary behavior
+- Duplicate-storm handling
+
+`tests/marketplace-aggregates.unit.test.ts` also proves that a complete backfill
+and an incremental replay produce identical checkpoints. Checkpoints store only
+SHA-256 event fingerprints; raw deduplication keys and source payloads are not
+materialized or exposed by public aggregate views.
 
 Run tests:
 ```bash
@@ -200,10 +225,19 @@ cd web
 pnpm test ecosystem-intelligence.test.ts
 ```
 
+Run the complete focused suite with:
+
+```bash
+cd web
+pnpm test tests/analytics-privacy.unit.test.ts \
+  tests/marketplace-aggregates.unit.test.ts \
+  tests/ecosystem-intelligence.test.ts
+```
+
 ## Performance Considerations
 
 - **Parallel Queries**: All database queries run in parallel
-- **Efficient Aggregations**: Uses database-level aggregations where possible
+- **Bounded Aggregations**: Every source is limited to 10,000 rows and duplicate IDs are removed in-memory
 - **Caching**: No server-side caching (real-time data)
 - **Client-side**: Auto-refresh with 60s interval to balance freshness and load
 
@@ -213,6 +247,23 @@ pnpm test ecosystem-intelligence.test.ts
 - **Response Time**: Actual response time tracking requires agent-side instrumentation
 - **Price Trends**: 24h price change simplified (would need historical price table)
 - **Capacity Model**: Simplified capacity estimation (100 units per online agent)
+
+## Migration and Rollback
+
+The API change is additive, except that sparse slices are now intentionally
+empty. Consumers should already tolerate empty category maps and ranking arrays.
+No database migration is required.
+
+Materialized aggregate checkpoints use `checkpointVersion: 1`. Changing the
+metric version, time window, category, or checkpoint format deliberately rejects
+incremental updates; rebuild from authoritative source events instead. This
+prevents mixed-version state from silently drifting. A restart can safely resume
+from the last checkpoint, and replayed events are ignored by their one-way
+fingerprints.
+
+To roll back, revert the application release. Existing database data is
+unchanged. Discard version-incompatible checkpoints and run a complete backfill
+before re-enabling incremental processing.
 
 ## Future Enhancements
 

--- a/web/src/app/ecosystem-intelligence/ecosystem-intelligence-client.tsx
+++ b/web/src/app/ecosystem-intelligence/ecosystem-intelligence-client.tsx
@@ -20,6 +20,11 @@ interface EcosystemMetrics {
     suppression: string[];
     version: string;
     generatedAt: string;
+    privacy: {
+      minimumCohortSize: number;
+      maximumInputRows: number;
+      deduplicatedRows: number;
+    };
   };
   supply: {
     activeAgents: number;
@@ -63,6 +68,10 @@ interface EcosystemMetrics {
       totalJobs: number;
     }>;
     dataSource: 'observed' | 'inferred' | 'mixed';
+    methodology: {
+      version: string;
+      inputs: string[];
+    };
   };
   opportunity: {
     underservedCategories: Array<{
@@ -679,6 +688,18 @@ export function EcosystemIntelligenceClient() {
                 {data.metadata.suppression.length > 0 
                   ? data.metadata.suppression.join(', ') 
                   : 'None'}
+              </p>
+            </div>
+            <div>
+              <span className="text-muted">Privacy Boundary</span>
+              <p className="text-foreground mt-0.5">
+                {data.metadata.privacy.minimumCohortSize}+ records per slice
+              </p>
+            </div>
+            <div>
+              <span className="text-muted">Replays Removed</span>
+              <p className="text-foreground mt-0.5">
+                {data.metadata.privacy.deduplicatedRows}
               </p>
             </div>
           </div>

--- a/web/src/lib/analytics-privacy.ts
+++ b/web/src/lib/analytics-privacy.ts
@@ -1,0 +1,102 @@
+export interface AnalyticsPrivacyPolicy {
+  minimumCohortSize: number;
+  maximumInputRows: number;
+}
+
+export const DEFAULT_ANALYTICS_PRIVACY_POLICY: AnalyticsPrivacyPolicy = {
+  minimumCohortSize: 5,
+  maximumInputRows: 10_000,
+};
+
+export class AnalyticsInputValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AnalyticsInputValidationError";
+  }
+}
+
+export interface DeduplicationResult<T> {
+  rows: T[];
+  duplicateCount: number;
+}
+
+/**
+ * Bounds each analytics input and removes retry/replay duplicates by an opaque,
+ * immutable database key. The key is used only in-memory and is never returned.
+ */
+export function deduplicateAnalyticsRows<T>(
+  rows: readonly T[],
+  dataset: string,
+  keyOf: (row: T) => string,
+  policy: AnalyticsPrivacyPolicy = DEFAULT_ANALYTICS_PRIVACY_POLICY,
+): DeduplicationResult<T> {
+  if (rows.length > policy.maximumInputRows) {
+    throw new AnalyticsInputValidationError(
+      `${dataset} exceeds the ${policy.maximumInputRows} row limit`,
+    );
+  }
+
+  const seen = new Set<string>();
+  const distinct: T[] = [];
+  let duplicateCount = 0;
+
+  for (const row of rows) {
+    const key = keyOf(row).trim();
+    if (!key) {
+      throw new AnalyticsInputValidationError(
+        `${dataset} contains a row without an immutable key`,
+      );
+    }
+    if (seen.has(key)) {
+      duplicateCount += 1;
+      continue;
+    }
+    seen.add(key);
+    distinct.push(row);
+  }
+
+  return { rows: distinct, duplicateCount };
+}
+
+export function suppressSparseRecord<T>(
+  values: Readonly<Record<string, T>>,
+  cohortSizes: Readonly<Record<string, number>>,
+  minimumCohortSize = DEFAULT_ANALYTICS_PRIVACY_POLICY.minimumCohortSize,
+): { values: Record<string, T>; suppressedCount: number } {
+  const visible: Record<string, T> = {};
+  let suppressedCount = 0;
+
+  for (const [key, value] of Object.entries(values)) {
+    if ((cohortSizes[key] ?? 0) < minimumCohortSize) {
+      suppressedCount += 1;
+      continue;
+    }
+    visible[key] = value;
+  }
+
+  return { values: visible, suppressedCount };
+}
+
+export function suppressSparseRows<T>(
+  rows: readonly T[],
+  cohortSizeOf: (row: T) => number,
+  minimumCohortSize = DEFAULT_ANALYTICS_PRIVACY_POLICY.minimumCohortSize,
+): { rows: T[]; suppressedCount: number } {
+  const visible: T[] = [];
+  let suppressedCount = 0;
+
+  for (const row of rows) {
+    if (cohortSizeOf(row) < minimumCohortSize) {
+      suppressedCount += 1;
+      continue;
+    }
+    visible.push(row);
+  }
+
+  return { rows: visible, suppressedCount };
+}
+
+export function describeSuppression(field: string, count: number): string | null {
+  if (count === 0) return null;
+  return `${field}: ${count} sparse cohort${count === 1 ? "" : "s"} suppressed`;
+}

--- a/web/src/lib/marketplace-aggregates.ts
+++ b/web/src/lib/marketplace-aggregates.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type MarketplaceAggregateKind = "supply" | "demand";
 
 export interface MarketplaceAggregateEvent {
@@ -10,7 +12,12 @@ export interface MarketplaceAggregateEvent {
   dedupeKey: string;
 }
 
+/**
+ * Materialized aggregate checkpoint. Event identity is retained only as a
+ * one-way digest so retries can be deduplicated without persisting raw keys.
+ */
 export interface MarketplaceAggregate {
+  checkpointVersion: 1;
   category: string;
   version: number;
   windowStart: string;
@@ -24,7 +31,15 @@ export interface MarketplaceAggregate {
   sourceEventCount: number;
   freshUntil: string;
   lastComputedAt: string;
+  processedEventDigests: string[];
+  completedDemandCount: number;
+  priceTotal: number;
 }
+
+export type PublicMarketplaceAggregate = Omit<
+  MarketplaceAggregate,
+  "processedEventDigests" | "completedDemandCount" | "priceTotal"
+>;
 
 export interface MarketplaceAggregateOptions {
   category: string;
@@ -32,6 +47,23 @@ export interface MarketplaceAggregateOptions {
   windowEnd: Date;
   version: number;
   now: Date;
+  maxEvents?: number;
+}
+
+export const DEFAULT_MAX_AGGREGATE_EVENTS = 10_000;
+
+export class MarketplaceAggregateValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MarketplaceAggregateValidationError";
+  }
+}
+
+export class MarketplaceAggregateBackfillRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MarketplaceAggregateBackfillRequiredError";
+  }
 }
 
 function toIso(value: Date): string {
@@ -46,53 +78,163 @@ function normalizeCategory(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function validateOptions(options: MarketplaceAggregateOptions): number {
+  if (!normalizeCategory(options.category)) {
+    throw new MarketplaceAggregateValidationError("category must not be empty");
+  }
+  if (
+    !Number.isFinite(options.windowStart.getTime()) ||
+    !Number.isFinite(options.windowEnd.getTime()) ||
+    !Number.isFinite(options.now.getTime())
+  ) {
+    throw new MarketplaceAggregateValidationError("aggregate dates must be valid");
+  }
+  if (options.windowStart > options.windowEnd) {
+    throw new MarketplaceAggregateValidationError(
+      "windowStart must be before or equal to windowEnd",
+    );
+  }
+  if (!Number.isSafeInteger(options.version) || options.version < 1) {
+    throw new MarketplaceAggregateValidationError(
+      "version must be a positive safe integer",
+    );
+  }
+
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_AGGREGATE_EVENTS;
+  if (!Number.isSafeInteger(maxEvents) || maxEvents < 1) {
+    throw new MarketplaceAggregateValidationError(
+      "maxEvents must be a positive safe integer",
+    );
+  }
+  return maxEvents;
+}
+
+function validateEvent(event: MarketplaceAggregateEvent): void {
+  if (!event.id.trim() || !event.dedupeKey.trim()) {
+    throw new MarketplaceAggregateValidationError(
+      "event id and dedupeKey must not be empty",
+    );
+  }
+  if (!normalizeCategory(event.category)) {
+    throw new MarketplaceAggregateValidationError(
+      "event category must not be empty",
+    );
+  }
+  if (!Number.isFinite(event.occurredAt.getTime())) {
+    throw new MarketplaceAggregateValidationError(
+      `event ${event.id} has an invalid occurredAt value`,
+    );
+  }
+  if (
+    event.price !== undefined &&
+    (!Number.isFinite(event.price) || event.price < 0)
+  ) {
+    throw new MarketplaceAggregateValidationError(
+      `event ${event.id} has an invalid price`,
+    );
+  }
+}
+
+function eventDigest(event: MarketplaceAggregateEvent): string {
+  return createHash("sha256")
+    .update(event.kind)
+    .update("\0")
+    .update(event.dedupeKey)
+    .digest("hex");
+}
+
 function summarizeEvents(
   events: MarketplaceAggregateEvent[],
   options: MarketplaceAggregateOptions,
+  previouslyProcessed: ReadonlySet<string> = new Set(),
 ) {
-  const filtered = events.filter((event) => {
+  const maxEvents = validateOptions(options);
+  if (events.length > maxEvents) {
+    throw new MarketplaceAggregateValidationError(
+      `event batch exceeds the ${maxEvents} event limit`,
+    );
+  }
+
+  const seen = new Set(previouslyProcessed);
+  const accepted: MarketplaceAggregateEvent[] = [];
+  const acceptedDigests: string[] = [];
+
+  for (const event of events) {
+    validateEvent(event);
     const inWindow =
       event.occurredAt >= options.windowStart &&
       event.occurredAt <= options.windowEnd;
     const sameCategory =
       normalizeCategory(event.category) === normalizeCategory(options.category);
-    return inWindow && sameCategory;
-  });
+    if (!inWindow || !sameCategory) continue;
 
-  const seen = new Set<string>();
-  const deduped = filtered.filter((event) => {
-    const key = `${event.kind}:${event.dedupeKey}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+    const digest = eventDigest(event);
+    if (seen.has(digest)) continue;
+    if (seen.size >= maxEvents) {
+      throw new MarketplaceAggregateValidationError(
+        `aggregate checkpoint exceeds the ${maxEvents} event limit`,
+      );
+    }
+    seen.add(digest);
+    accepted.push(event);
+    acceptedDigests.push(digest);
+  }
 
-  const supplyEvents = deduped.filter((event) => event.kind === "supply");
-  const demandEvents = deduped.filter((event) => event.kind === "demand");
+  const supply = accepted.filter((event) => event.kind === "supply").length;
+  const demandEvents = accepted.filter((event) => event.kind === "demand");
   const completedDemand = demandEvents.filter(
     (event) => event.status === "completed",
-  );
-  const totalPrice = deduped.reduce(
+  ).length;
+  const totalPrice = accepted.reduce(
     (sum, event) => sum + (event.price ?? 0),
     0,
   );
 
-  const supply = supplyEvents.length;
-  const demand = demandEvents.length;
-  const capacity = Math.max(0, supply - demand);
-  const averagePrice = deduped.length > 0 ? totalPrice / deduped.length : 0;
-  const fulfillmentRate =
-    demandEvents.length > 0 ? completedDemand.length / demandEvents.length : 0;
-
   return {
     supply,
-    demand,
-    capacity,
-    averagePrice,
-    fulfillmentRate,
-    sourceEventCount: deduped.length,
-    completedDemand: completedDemand.length,
+    demand: demandEvents.length,
+    sourceEventCount: accepted.length,
+    completedDemand,
     totalPrice,
+    acceptedDigests,
+  };
+}
+
+function materializeAggregate(
+  summary: {
+    supply: number;
+    demand: number;
+    sourceEventCount: number;
+    completedDemand: number;
+    totalPrice: number;
+    processedEventDigests: string[];
+  },
+  options: MarketplaceAggregateOptions,
+): MarketplaceAggregate {
+  return {
+    checkpointVersion: 1,
+    category: options.category,
+    version: options.version,
+    windowStart: toIso(options.windowStart),
+    windowEnd: toIso(options.windowEnd),
+    supply: summary.supply,
+    demand: summary.demand,
+    capacity: Math.max(0, summary.supply - summary.demand),
+    averagePrice:
+      summary.sourceEventCount > 0
+        ? summary.totalPrice / summary.sourceEventCount
+        : 0,
+    fulfillmentRate:
+      summary.demand > 0
+        ? clamp01(summary.completedDemand / summary.demand)
+        : 0,
+    unmetNeeds: Math.max(0, summary.demand - summary.supply),
+    sourceEventCount: summary.sourceEventCount,
+    freshUntil: toIso(new Date(options.now.getTime() + 5 * 60_000)),
+    lastComputedAt: toIso(options.now),
+    processedEventDigests: [...summary.processedEventDigests].sort(),
+    completedDemandCount: summary.completedDemand,
+    priceTotal: summary.totalPrice,
   };
 }
 
@@ -101,23 +243,13 @@ export function buildMarketplaceAggregate(
   options: MarketplaceAggregateOptions,
 ): MarketplaceAggregate {
   const summary = summarizeEvents(events, options);
-  const unmetNeeds = Math.max(0, summary.demand - summary.supply);
-
-  return {
-    category: options.category,
-    version: options.version,
-    windowStart: toIso(options.windowStart),
-    windowEnd: toIso(options.windowEnd),
-    supply: summary.supply,
-    demand: summary.demand,
-    capacity: summary.capacity,
-    averagePrice: summary.averagePrice,
-    fulfillmentRate: clamp01(summary.fulfillmentRate),
-    unmetNeeds,
-    sourceEventCount: summary.sourceEventCount,
-    freshUntil: toIso(new Date(options.now.getTime() + 5 * 60_000)),
-    lastComputedAt: toIso(options.now),
-  };
+  return materializeAggregate(
+    {
+      ...summary,
+      processedEventDigests: summary.acceptedDigests,
+    },
+    options,
+  );
 }
 
 export function applyMarketplaceAggregateDelta(
@@ -125,41 +257,64 @@ export function applyMarketplaceAggregateDelta(
   events: MarketplaceAggregateEvent[],
   options: MarketplaceAggregateOptions,
 ): MarketplaceAggregate {
-  const delta = summarizeEvents(events, options);
-  const previousPriceTotal = previous.averagePrice * previous.sourceEventCount;
-  const previousCompletedDemand = Math.round(
-    previous.fulfillmentRate * previous.demand,
+  validateOptions(options);
+  if (previous.checkpointVersion !== 1) {
+    throw new MarketplaceAggregateBackfillRequiredError(
+      "unsupported aggregate checkpoint version; rebuild from source events",
+    );
+  }
+  if (previous.version !== options.version) {
+    throw new MarketplaceAggregateBackfillRequiredError(
+      "aggregate version changed; rebuild from source events",
+    );
+  }
+  if (
+    normalizeCategory(previous.category) !== normalizeCategory(options.category) ||
+    previous.windowStart !== toIso(options.windowStart) ||
+    previous.windowEnd !== toIso(options.windowEnd)
+  ) {
+    throw new MarketplaceAggregateBackfillRequiredError(
+      "aggregate category or window changed; rebuild from source events",
+    );
+  }
+
+  const priorDigests = new Set(previous.processedEventDigests);
+  const delta = summarizeEvents(events, options, priorDigests);
+
+  return materializeAggregate(
+    {
+      supply: previous.supply + delta.supply,
+      demand: previous.demand + delta.demand,
+      sourceEventCount: previous.sourceEventCount + delta.sourceEventCount,
+      completedDemand:
+        previous.completedDemandCount + delta.completedDemand,
+      totalPrice: previous.priceTotal + delta.totalPrice,
+      processedEventDigests: [
+        ...previous.processedEventDigests,
+        ...delta.acceptedDigests,
+      ],
+    },
+    options,
   );
+}
 
-  const combinedSupply = previous.supply + delta.supply;
-  const combinedDemand = previous.demand + delta.demand;
-  const combinedSourceEventCount =
-    previous.sourceEventCount + delta.sourceEventCount;
-  const combinedCompletedDemand =
-    previousCompletedDemand + delta.completedDemand;
-  const combinedPriceTotal = previousPriceTotal + delta.totalPrice;
-  const combinedAveragePrice =
-    combinedSourceEventCount > 0
-      ? combinedPriceTotal / combinedSourceEventCount
-      : 0;
-  const combinedFulfillmentRate =
-    combinedDemand > 0 ? combinedCompletedDemand / combinedDemand : 0;
-  const combinedCapacity = Math.max(0, combinedSupply - combinedDemand);
-  const combinedUnmetNeeds = Math.max(0, combinedDemand - combinedSupply);
-
+export function toPublicMarketplaceAggregate(
+  checkpoint: MarketplaceAggregate,
+): PublicMarketplaceAggregate {
   return {
-    category: options.category,
-    version: options.version,
-    windowStart: toIso(options.windowStart),
-    windowEnd: toIso(options.windowEnd),
-    supply: combinedSupply,
-    demand: combinedDemand,
-    capacity: combinedCapacity,
-    averagePrice: combinedAveragePrice,
-    fulfillmentRate: clamp01(combinedFulfillmentRate),
-    unmetNeeds: combinedUnmetNeeds,
-    sourceEventCount: combinedSourceEventCount,
-    freshUntil: toIso(new Date(options.now.getTime() + 5 * 60_000)),
-    lastComputedAt: toIso(options.now),
+    checkpointVersion: checkpoint.checkpointVersion,
+    category: checkpoint.category,
+    version: checkpoint.version,
+    windowStart: checkpoint.windowStart,
+    windowEnd: checkpoint.windowEnd,
+    supply: checkpoint.supply,
+    demand: checkpoint.demand,
+    capacity: checkpoint.capacity,
+    averagePrice: checkpoint.averagePrice,
+    fulfillmentRate: checkpoint.fulfillmentRate,
+    unmetNeeds: checkpoint.unmetNeeds,
+    sourceEventCount: checkpoint.sourceEventCount,
+    freshUntil: checkpoint.freshUntil,
+    lastComputedAt: checkpoint.lastComputedAt,
   };
 }

--- a/web/tests/analytics-privacy.unit.test.ts
+++ b/web/tests/analytics-privacy.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  AnalyticsInputValidationError,
+  deduplicateAnalyticsRows,
+  describeSuppression,
+  suppressSparseRecord,
+  suppressSparseRows,
+} from "../src/lib/analytics-privacy";
+
+describe("analytics privacy", () => {
+  it("suppresses values below the cohort boundary without naming them", () => {
+    const result = suppressSparseRecord(
+      { sparse: 4, visible: 5 },
+      { sparse: 4, visible: 5 },
+    );
+
+    expect(result).toEqual({
+      values: { visible: 5 },
+      suppressedCount: 1,
+    });
+    expect(describeSuppression("supply.byCategory", 1)).toBe(
+      "supply.byCategory: 1 sparse cohort suppressed",
+    );
+  });
+
+  it("applies the same inclusive boundary to sensitive rows", () => {
+    const result = suppressSparseRows(
+      [
+        { id: "hidden", evidence: 4 },
+        { id: "visible", evidence: 5 },
+      ],
+      row => row.evidence,
+    );
+
+    expect(result.rows).toEqual([{ id: "visible", evidence: 5 }]);
+    expect(result.suppressedCount).toBe(1);
+  });
+
+  it("deduplicates retries and rejects unbounded input", () => {
+    const replayed = { id: "evt-1" };
+    const deduplicated = deduplicateAnalyticsRows(
+      Array(100).fill(replayed),
+      "events",
+      row => row.id,
+    );
+
+    expect(deduplicated.rows).toEqual([replayed]);
+    expect(deduplicated.duplicateCount).toBe(99);
+    expect(() =>
+      deduplicateAnalyticsRows(
+        [{ id: "1" }, { id: "2" }],
+        "events",
+        row => row.id,
+        { minimumCohortSize: 5, maximumInputRows: 1 },
+      ),
+    ).toThrow(AnalyticsInputValidationError);
+  });
+
+  it("rejects rows without an immutable deduplication key", () => {
+    expect(() =>
+      deduplicateAnalyticsRows([{ id: "" }], "events", row => row.id),
+    ).toThrow("events contains a row without an immutable key");
+  });
+});

--- a/web/tests/ecosystem-intelligence.test.ts
+++ b/web/tests/ecosystem-intelligence.test.ts
@@ -88,7 +88,7 @@ describe("GET /api/ecosystem-intelligence", () => {
       { id: "pb-1", talosId: "talos-1", status: "active" },
     ]);
     mockPatronsFindMany.mockResolvedValue([
-      { stellarPublicKey: "G123", role: "Creator", pulseAmount: 1000, status: "active" },
+      { id: "patron-1", stellarPublicKey: "G123", role: "Creator", pulseAmount: 1000, status: "active" },
     ]);
     mockActivitiesFindMany.mockResolvedValue([]);
     mockRevenuesFindMany.mockResolvedValue([]);
@@ -150,6 +150,11 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(body.metadata).toHaveProperty("version");
     expect(body.metadata).toHaveProperty("generatedAt");
     expect(body.metadata).toHaveProperty("suppression");
+    expect(body.metadata.privacy).toEqual({
+      minimumCohortSize: 5,
+      maximumInputRows: 10_000,
+      deduplicatedRows: 0,
+    });
 
     expect(typeof body.metadata.sampleSize).toBe("number");
     expect(["high", "medium", "low"]).toContain(body.metadata.confidence);
@@ -283,10 +288,7 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(body.supply.activeAgents).toBe(2);
     expect(body.supply.totalServices).toBe(2);
     expect(body.supply.totalPlaybooks).toBe(1);
-    expect(body.supply.byCategory).toEqual({
-      marketing: 1,
-      research: 1,
-    });
+    expect(body.supply.byCategory).toEqual({});
     expect(["increasing", "stable", "decreasing"]).toContain(body.supply.trend);
   });
 
@@ -324,9 +326,7 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(body.demand.pendingJobs).toBe(1);
     expect(body.demand.completedJobs24h).toBe(1);
     expect(body.demand.playbookPurchases7d).toBe(1);
-    expect(body.demand.byCategory).toEqual({
-      marketing: 2,
-    });
+    expect(body.demand.byCategory).toEqual({});
   });
 
   // ── Capacity metrics validation ───────────────────────────────────────────
@@ -413,8 +413,7 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(body.price.avgServicePrice).toBe(15.00);
     expect(body.price.avgTokenPrice).toBe(2.00);
     expect(typeof body.price.priceChange24h).toBe("number");
-    expect(body.price.priceByCategory).toHaveProperty("marketing");
-    expect(body.price.priceByCategory).toHaveProperty("research");
+    expect(body.price.priceByCategory).toEqual({});
   });
 
   // ── Fulfillment metrics validation ─────────────────────────────────────────
@@ -449,9 +448,10 @@ describe("GET /api/ecosystem-intelligence", () => {
 
     expect(body.fulfillment.completionRate).toBeCloseTo(66.67, 1);
     expect(body.fulfillment.successRate).toBeCloseTo(66.67, 1);
-    expect(body.fulfillment.byAgent).toHaveLength(1);
-    expect(body.fulfillment.byAgent[0].agentName).toBe("Vega");
-    expect(body.fulfillment.byAgent[0].totalJobs).toBe(3);
+    expect(body.fulfillment.byAgent).toHaveLength(0);
+    expect(body.metadata.suppression).toContain(
+      "fulfillment.byAgent: 1 sparse cohort suppressed",
+    );
   });
 
   // ── Empty data scenarios ───────────────────────────────────────────────────
@@ -583,8 +583,8 @@ describe("GET /api/ecosystem-intelligence", () => {
     mockPatronsFindMany.mockResolvedValue([]);
     mockActivitiesFindMany.mockResolvedValue([]);
     mockRevenuesFindMany.mockResolvedValue([
-      { talosId: "talos-1", amount: "100.00", createdAt: new Date() },
-      { talosId: "talos-2", amount: "50.00", createdAt: new Date() },
+      { id: "revenue-1", talosId: "talos-1", amount: "100.00", createdAt: new Date() },
+      { id: "revenue-2", talosId: "talos-2", amount: "50.00", createdAt: new Date() },
     ]);
     mockJobsFindMany.mockResolvedValue([
       { id: "job-1", talosId: "talos-1", status: "completed", createdAt: new Date() },
@@ -630,6 +630,10 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(body.price.dataSource).toBe("observed");
     expect(body.fulfillment.dataSource).toBe("observed");
     expect(body.opportunity.dataSource).toBe("inferred");
+    expect(body.opportunity.methodology).toEqual({
+      version: "demand-supply-ratio-v1",
+      inputs: ["observed-demand", "observed-supply", "observed-revenue"],
+    });
   });
 
   // ── Data type validation ───────────────────────────────────────────────────
@@ -666,5 +670,92 @@ describe("GET /api/ecosystem-intelligence", () => {
     expect(typeof body.price.avgServicePrice).toBe("number");
     expect(typeof body.price.avgTokenPrice).toBe("number");
     expect(typeof body.fulfillment.completionRate).toBe("number");
+  });
+
+  it("publishes category and agent slices at the exact privacy boundary", async () => {
+    const agents = Array.from({ length: 5 }, (_, index) => ({
+      id: `talos-${index + 1}`,
+      name: `Agent ${index + 1}`,
+      category: "marketing",
+      status: "Active",
+      agentOnline: true,
+      pulsePrice: "2.00",
+      patrons: [],
+      revenues:
+        index === 0
+          ? [{ amount: "50.00", createdAt: new Date() }]
+          : [],
+    }));
+    const jobs = Array.from({ length: 5 }, (_, index) => ({
+      id: `job-${index + 1}`,
+      talosId: "talos-1",
+      status: "completed",
+      createdAt: new Date(),
+    }));
+    const revenues = Array.from({ length: 5 }, (_, index) => ({
+      id: `revenue-${index + 1}`,
+      talosId: "talos-1",
+      amount: "10.00",
+      createdAt: new Date(),
+    }));
+
+    mockTalosFindMany.mockResolvedValue(agents);
+    mockServicesFindMany.mockResolvedValue(
+      agents.map((agent, index) => ({
+        id: `service-${index + 1}`,
+        talosId: agent.id,
+        price: "10.00",
+      })),
+    );
+    mockPlaybooksFindMany.mockResolvedValue([]);
+    mockPatronsFindMany.mockResolvedValue([]);
+    mockActivitiesFindMany.mockResolvedValue([]);
+    mockRevenuesFindMany.mockResolvedValue(revenues);
+    mockJobsFindMany.mockResolvedValue(jobs);
+    mockPurchasesFindMany.mockResolvedValue([]);
+
+    const res = await GET(new Request("http://localhost/api/ecosystem-intelligence"));
+    const body = await res.json();
+
+    expect(body.supply.byCategory).toEqual({ marketing: 5 });
+    expect(body.demand.byCategory).toEqual({ marketing: 5 });
+    expect(body.price.priceByCategory).toEqual({ marketing: 10 });
+    expect(body.fulfillment.byAgent).toHaveLength(1);
+    expect(body.opportunity.trendingAgents).toHaveLength(1);
+  });
+
+  it("deduplicates replay storms before calculating public metrics", async () => {
+    const agents = Array.from({ length: 5 }, (_, index) => ({
+      id: `talos-${index + 1}`,
+      name: `Agent ${index + 1}`,
+      category: "marketing",
+      status: "Active",
+      agentOnline: true,
+      pulsePrice: "2.00",
+      patrons: [],
+      revenues: [],
+    }));
+    const replayedJob = {
+      id: "job-replayed",
+      talosId: "talos-1",
+      status: "pending",
+      createdAt: new Date(),
+    };
+
+    mockTalosFindMany.mockResolvedValue(agents);
+    mockServicesFindMany.mockResolvedValue([]);
+    mockPlaybooksFindMany.mockResolvedValue([]);
+    mockPatronsFindMany.mockResolvedValue([]);
+    mockActivitiesFindMany.mockResolvedValue([]);
+    mockRevenuesFindMany.mockResolvedValue([]);
+    mockJobsFindMany.mockResolvedValue(Array(50).fill(replayedJob));
+    mockPurchasesFindMany.mockResolvedValue([]);
+
+    const res = await GET(new Request("http://localhost/api/ecosystem-intelligence"));
+    const body = await res.json();
+
+    expect(body.demand.pendingJobs).toBe(1);
+    expect(body.demand.byCategory).toEqual({ marketing: 1 });
+    expect(body.metadata.privacy.deduplicatedRows).toBe(49);
   });
 });

--- a/web/tests/marketplace-aggregates.unit.test.ts
+++ b/web/tests/marketplace-aggregates.unit.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildMarketplaceAggregate,
   applyMarketplaceAggregateDelta,
+  MarketplaceAggregateBackfillRequiredError,
+  MarketplaceAggregateValidationError,
+  toPublicMarketplaceAggregate,
   type MarketplaceAggregateEvent,
 } from "../src/lib/marketplace-aggregates";
 
@@ -107,7 +110,7 @@ describe("buildMarketplaceAggregate", () => {
         category: "Analytics",
         windowStart: new Date("2026-07-27T08:00:00.000Z"),
         windowEnd: new Date("2026-07-27T12:00:00.000Z"),
-        version: 1,
+        version: 2,
         now: new Date("2026-07-27T10:00:00.000Z"),
       },
     );
@@ -150,5 +153,114 @@ describe("buildMarketplaceAggregate", () => {
     expect(next.unmetNeeds).toBe(0);
     expect(next.sourceEventCount).toBe(4);
     expect(next.version).toBe(2);
+  });
+
+  it("makes incremental retries equivalent to an authoritative backfill", () => {
+    const now = new Date("2026-07-27T12:00:00.000Z");
+    const options = {
+      category: "Analytics",
+      windowStart: new Date("2026-07-27T08:00:00.000Z"),
+      windowEnd: new Date("2026-07-27T12:00:00.000Z"),
+      version: 3,
+      now,
+    };
+    const first: MarketplaceAggregateEvent = {
+      id: "supply-1",
+      kind: "supply",
+      category: "Analytics",
+      occurredAt: new Date("2026-07-27T09:00:00.000Z"),
+      price: 10,
+      dedupeKey: "opaque-supply-1",
+    };
+    const second: MarketplaceAggregateEvent = {
+      id: "demand-1",
+      kind: "demand",
+      category: "Analytics",
+      occurredAt: new Date("2026-07-27T10:00:00.000Z"),
+      price: 20,
+      status: "completed",
+      dedupeKey: "opaque-demand-1",
+    };
+
+    const backfill = buildMarketplaceAggregate([first, second], options);
+    const checkpoint = buildMarketplaceAggregate([first], options);
+    const incremental = applyMarketplaceAggregateDelta(
+      checkpoint,
+      [first, second, second, second],
+      options,
+    );
+
+    expect(incremental).toEqual(backfill);
+    expect(incremental.processedEventDigests).toHaveLength(2);
+    expect(incremental.processedEventDigests.join(" ")).not.toContain(
+      "opaque-",
+    );
+  });
+
+  it("requires a source backfill when the aggregate version changes", () => {
+    const options = {
+      category: "Analytics",
+      windowStart: new Date("2026-07-27T08:00:00.000Z"),
+      windowEnd: new Date("2026-07-27T12:00:00.000Z"),
+      version: 1,
+      now: new Date("2026-07-27T12:00:00.000Z"),
+    };
+    const checkpoint = buildMarketplaceAggregate([], options);
+
+    expect(() =>
+      applyMarketplaceAggregateDelta(checkpoint, [], {
+        ...options,
+        version: 2,
+      }),
+    ).toThrow(MarketplaceAggregateBackfillRequiredError);
+
+    const migrated = buildMarketplaceAggregate([], {
+      ...options,
+      version: 2,
+    });
+    expect(migrated.version).toBe(2);
+  });
+
+  it("rejects invalid and unbounded source input", () => {
+    const invalidEvent: MarketplaceAggregateEvent = {
+      id: "event-1",
+      kind: "supply",
+      category: "Analytics",
+      occurredAt: new Date("2026-07-27T09:00:00.000Z"),
+      price: -1,
+      dedupeKey: "event-1",
+    };
+    const options = {
+      category: "Analytics",
+      windowStart: new Date("2026-07-27T08:00:00.000Z"),
+      windowEnd: new Date("2026-07-27T12:00:00.000Z"),
+      version: 1,
+      now: new Date("2026-07-27T12:00:00.000Z"),
+      maxEvents: 1,
+    };
+
+    expect(() => buildMarketplaceAggregate([invalidEvent], options)).toThrow(
+      MarketplaceAggregateValidationError,
+    );
+    expect(() =>
+      buildMarketplaceAggregate([invalidEvent, invalidEvent], options),
+    ).toThrow("event batch exceeds the 1 event limit");
+  });
+
+  it("removes private checkpoint fields from public aggregate views", () => {
+    const checkpoint = buildMarketplaceAggregate([], {
+      category: "Analytics",
+      windowStart: new Date("2026-07-27T08:00:00.000Z"),
+      windowEnd: new Date("2026-07-27T12:00:00.000Z"),
+      version: 1,
+      now: new Date("2026-07-27T12:00:00.000Z"),
+    });
+
+    expect(toPublicMarketplaceAggregate(checkpoint)).not.toHaveProperty(
+      "processedEventDigests",
+    );
+    expect(toPublicMarketplaceAggregate(checkpoint)).not.toHaveProperty(
+      "priceTotal",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- suppress category and per-agent analytics slices below a five-record privacy boundary
- deduplicate replayed database rows and bound every analytics source query
- label opportunity scores with an explicit inferred methodology
- make marketplace aggregate checkpoints replay-safe with SHA-256 event fingerprints
- reject mixed-version/window checkpoints and require an authoritative backfill
- document privacy, migration, rollback, and local verification behavior

## Why

The ecosystem intelligence endpoint described itself as privacy-safe while still exposing sparse category and per-agent slices. Its incremental marketplace aggregate also deduplicated only within a single batch, so retries crossing batch or restart boundaries could inflate results.

This change fails sparse slices closed, reports suppression without naming hidden cohorts, separates inferred opportunity output from observed facts, and makes complete backfills equivalent to incremental replay processing.

## Validation

- `vitest`: 3 files, 29 tests passed
- scoped TypeScript check: passed
- ESLint on all changed TypeScript/TSX files: passed with zero warnings
- repository-wide TypeScript check remains blocked by pre-existing syntax errors in `web/src/app/api/activity/route.ts` and unrelated missing webhook relation symbols

No database migration is required. Sparse arrays/maps can now be empty by design; the API metadata version is bumped to `1.1.0`.

Closes #309
