### PR TITLE
feat(agent): implement policy-driven model routing and fallback (fixes #233)

### DIFF
--- a/packages/prime-agent/src/talos_agent/agent/loop.py
+++ b/packages/prime-agent/src/talos_agent/agent/loop.py
@@ -1,10 +1,27 @@
-"""Core agent loop — ReAct tool-calling with OpenAI native function calling."""
+"""Core agent loop — ReAct tool-calling with policy-driven model routing.
+
+When ``model_routing_enabled`` is **False** (the default), the loop behaves
+exactly as before: it selects Groq if a Groq API key is configured, otherwise
+falls back to OpenAI.
+
+When ``model_routing_enabled`` is **True**, the loop uses the new routing
+infrastructure:
+
+* :class:`~talos_agent.routing.ProviderRegistry` holds all configured
+  providers (Groq, OpenAI, etc.).
+* :class:`~talos_agent.routing.RoutingPolicy` selects the best provider
+  based on task type, cost, latency, privacy, and availability.
+* :class:`~talos_agent.routing.FallbackChain` tries alternative providers
+  when the primary fails.
+* :class:`~talos_agent.routing.UsageTracker` records token/cost data for
+  accounting and budget enforcement.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from openai import AsyncOpenAI
 from rich.console import Console
@@ -12,6 +29,15 @@ from rich.console import Console
 from talos_agent.agent.context import AgentContext
 from talos_agent.agent.prompt import build_system_prompt
 from talos_agent.http import call_with_retry
+from talos_agent.routing import (
+    FallbackChain,
+    ProviderRegistry,
+    RoutingConstraints,
+    RoutingPolicy,
+    UsageTracker,
+    _build_default_registry,
+)
+from talos_agent.routing.provider import TaskType
 
 if TYPE_CHECKING:
     from talos_agent.config import Settings
@@ -47,7 +73,35 @@ async def agent_loop(
     system_prompt_override: str | None = None,
     shutdown_event: asyncio.Event | None = None,
 ) -> list[dict]:
-    """Run one agent cycle: LLM decides tools to call until done."""
+    """Run one agent cycle: LLM decides tools to call until done.
+
+    When ``settings.model_routing_enabled`` is True, the loop uses the
+    policy-driven routing system.  Otherwise it falls back to the legacy
+    Groq-first / OpenAI-fallback behaviour.
+    """
+    if settings.model_routing_enabled:
+        return await _routed_agent_loop(
+            settings, tools, talos_config, context,
+            system_prompt_override, shutdown_event,
+        )
+    return await _legacy_agent_loop(
+        settings, tools, talos_config, context,
+        system_prompt_override, shutdown_event,
+    )
+
+
+# ── Legacy loop (backward compatible) ─────────────────────────────────────────
+
+
+async def _legacy_agent_loop(
+    settings: Settings,
+    tools: ToolRegistry,
+    talos_config: dict,
+    context: AgentContext,
+    system_prompt_override: str | None = None,
+    shutdown_event: asyncio.Event | None = None,
+) -> list[dict]:
+    """Original agent loop — Groq preferred, OpenAI fallback."""
     client = get_openai_client(settings.llm_api_key, settings.llm_base_url)
 
     system_prompt = system_prompt_override or build_system_prompt(talos_config, context)
@@ -117,6 +171,170 @@ async def agent_loop(
             messages.append({
                 "role": "tool",
                 "tool_call_id": tc.id,
+                "content": result_str,
+            })
+    else:
+        console.print("[yellow]Agent hit max iterations limit.[/yellow]")
+
+    return messages
+
+
+# ── Routed loop (new) ─────────────────────────────────────────────────────────
+
+
+async def _routed_agent_loop(
+    settings: Settings,
+    tools: ToolRegistry,
+    talos_config: dict,
+    context: AgentContext,
+    system_prompt_override: str | None = None,
+    shutdown_event: asyncio.Event | None = None,
+) -> list[dict]:
+    """Agent loop with policy-driven model routing and fallback."""
+    # Initialise routing infrastructure
+    registry = _build_default_registry(settings)
+    policy = RoutingPolicy(registry)
+    usage_tracker = UsageTracker(registry) if settings.routing_budget_enabled else None
+
+    system_prompt = system_prompt_override or build_system_prompt(talos_config, context)
+    tool_schemas = tools.openai_schemas()
+    has_tools = bool(tool_schemas)
+
+    messages: list[dict] = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "Decide and execute your next actions based on the current context."},
+    ]
+
+    for iteration in range(settings.max_iterations):
+        if shutdown_event and shutdown_event.is_set():
+            console.print("[yellow]Shutdown requested — aborting agent loop.[/yellow]")
+            break
+
+        console.print(f"[dim]Agent iteration {iteration + 1}...[/dim]")
+
+        # Determine task type based on whether tools are available
+        task_type = TaskType.CHAT
+        if has_tools:
+            task_type = TaskType.REASONING
+
+        # Build routing constraints
+        constraints = RoutingConstraints(
+            task_type=task_type,
+            max_cost_usd=settings.routing_max_cost_usd if settings.routing_max_cost_usd > 0 else None,
+            preferred_provider=settings.routing_preferred_provider or None,
+            require_capabilities={"tool_calling"} if has_tools else set(),
+            bypass_fallback=not settings.routing_fallback_enabled,
+        )
+
+        # Select provider
+        decision = policy.select(constraints)
+        console.print(
+            f"[dim]Router: {decision.provider_name}/{decision.model} "
+            f"(score={decision.score:.2f})[/dim]"
+        )
+
+        provider = registry.get(decision.provider_name)
+
+        # Define the completion operation for fallback
+        async def _complete(
+            provider_name: str,
+            local_messages: list[dict],
+            local_tools: list[dict] | None,
+        ) -> dict[str, Any]:
+            p = registry.get(provider_name)
+            return await p.complete(
+                model=decision.model if provider_name == decision.provider_name else p.metadata.default_model,
+                messages=local_messages,
+                tools=local_tools if local_tools else None,
+            )
+
+        # Execute with optional fallback
+        if settings.routing_fallback_enabled and not constraints.bypass_fallback:
+            # Build fallback chain: primary first, then other healthy providers
+            healthy = registry.get_healthy()
+            fallback_order = [decision.provider_name] + [
+                n for n in healthy if n != decision.provider_name
+            ]
+            chain = FallbackChain(fallback_order)
+            fb_result = await chain.execute(
+                _complete,
+                messages,
+                tool_schemas if has_tools else None,
+            )
+
+            if not fb_result.success:
+                console.print("[red]All providers failed — aborting agent cycle.[/red]")
+                break
+
+            response_data = fb_result.result
+            used_provider = fb_result.provider_name
+        else:
+            # No fallback — single provider
+            try:
+                response_data = await _complete(
+                    decision.provider_name, messages, tool_schemas if has_tools else None,
+                )
+                used_provider = decision.provider_name
+            except Exception as exc:
+                console.print(f"[red]Provider '{decision.provider_name}' failed: {exc}[/red]")
+                break
+
+        # Track usage
+        if usage_tracker is not None:
+            usage = response_data.get("usage", {})
+            await usage_tracker.record(
+                provider_name=used_provider,
+                model=response_data.get("model", decision.model),
+                prompt_tokens=usage.get("prompt_tokens", 0),
+                completion_tokens=usage.get("completion_tokens", 0),
+                success=True,
+            )
+
+        # Extract message from normalised response
+        choices = response_data.get("choices", [])
+        if not choices:
+            console.print("[red]Empty response from provider — aborting.[/red]")
+            break
+
+        choice = choices[0]
+        message_data = choice.get("message", {})
+        msg_content = message_data.get("content", "")
+        msg_tool_calls = message_data.get("tool_calls")
+
+        # Append assistant message
+        assistant_msg: dict[str, Any] = {"role": "assistant"}
+        if msg_content:
+            assistant_msg["content"] = msg_content
+            console.print(f"[blue]Agent ({used_provider}):[/blue] {msg_content[:200]}")
+        if msg_tool_calls:
+            assistant_msg["tool_calls"] = msg_tool_calls
+        messages.append(assistant_msg)
+
+        # No tool calls → agent is done
+        if not msg_tool_calls:
+            console.print("[green]Agent cycle complete — no more actions.[/green]")
+            break
+
+        # Execute each tool call
+        for tc in msg_tool_calls:
+            fn_name = tc["function"]["name"] if isinstance(tc, dict) else tc.function.name
+            try:
+                raw_args = tc["function"]["arguments"] if isinstance(tc, dict) else tc.function.arguments
+                args = json.loads(raw_args)
+            except (json.JSONDecodeError, KeyError):
+                args = {}
+
+            console.print(f"[yellow]Tool:[/yellow] {fn_name}({_truncate_args(args)})")
+
+            result = await tools.execute(fn_name, args)
+            result_str = json.dumps(result, default=str, ensure_ascii=False)
+
+            console.print(f"[dim]Result:[/dim] {result_str[:200]}")
+
+            tc_id = tc["id"] if isinstance(tc, dict) else tc.id
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc_id,
                 "content": result_str,
             })
     else:

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -67,6 +67,39 @@ class Settings(BaseSettings):
     def llm_base_url(self) -> str | None:
         return "https://api.groq.com/openai/v1" if self.secret_value("groq_api_key") else None
 
+    # Model routing (Issue #233) — disabled by default, backward compatible
+    model_routing_enabled: bool = Field(
+        default=False,
+        description="Enable policy-driven model routing and fallback. When enabled, provider "
+        "selection considers task type, cost, latency, privacy, and availability. "
+        "When disabled (default), the legacy Groq-first/OpenAI-fallback behaviour is used.",
+    )
+    routing_fallback_enabled: bool = Field(
+        default=True,
+        description="When model routing is enabled, attempt fallback to alternative providers "
+        "if the primary provider fails or is unavailable. Only meaningful when "
+        "model_routing_enabled is True.",
+    )
+    routing_max_cost_usd: Decimal = Field(
+        default=Decimal("0"),
+        description="Maximum cost per LLM call in USD when routing is enabled. "
+        "0 means no cost limit. Used by the routing policy to prefer "
+        "cheaper providers when cost is constrained.",
+    )
+    routing_preferred_provider: str = Field(
+        default="",
+        description="Explicit provider name to prefer when routing is enabled. "
+        "Empty string means auto-select based on policy. When set, the "
+        "router uses this provider if it is available and meets capability "
+        "requirements.",
+    )
+    routing_budget_enabled: bool = Field(
+        default=False,
+        description="Enable usage accounting and budget tracking for provider calls. "
+        "When enabled, the UsageTracker records token counts, costs, and "
+        "checks budgets before allowing further calls.",
+    )
+
     # X (Twitter)
     x_username: str = ""
     x_password: str = ""

--- a/packages/prime-agent/src/talos_agent/routing/__init__.py
+++ b/packages/prime-agent/src/talos_agent/routing/__init__.py
@@ -1,0 +1,85 @@
+"""Policy-driven model routing and fallback.
+
+This package provides a production-grade routing layer for LLM model calls
+that routes by task type, cost, latency, privacy, and availability while
+preserving predictable failure behaviour.
+
+Components
+----------
+ProviderRegistry
+    Register and discover providers with their capabilities, cost,
+    and latency metadata.
+
+RoutingPolicy
+    Selects the best provider for a given set of constraints (task type,
+    cost budget, latency budget, privacy requirements).
+
+FallbackChain
+    Tries providers in priority order, falling back on failure, with
+    circuit-breaker integration to avoid cascading failures.
+
+UsageTracker
+    Tracks token and cost usage per provider for accounting and budgeting.
+
+Quick start
+-----------
+>>> from talos_agent.routing import (
+...     ProviderRegistry, RoutingPolicy, FallbackChain, UsageTracker,
+...     RoutingConstraints, LLMProvider,
+... )
+>>> registry = ProviderRegistry()
+>>> registry.register(MyProvider())
+>>> policy = RoutingPolicy(registry)
+>>> constraints = RoutingConstraints(task_type="chat")
+>>> provider = policy.select(constraints)
+"""
+
+from __future__ import annotations
+
+from talos_agent.routing.provider import (
+    LLMProvider,
+    OpenAIClientProvider,
+    ProviderCapabilities,
+    ProviderMetadata,
+    ProviderRegistry,
+    ProviderStatus,
+    TaskType,
+    _build_default_registry,
+)
+from talos_agent.routing.policy import (
+    RoutingConstraints,
+    RoutingDecision,
+    RoutingPolicy,
+)
+from talos_agent.routing.fallback import (
+    FallbackChain,
+    FallbackResult,
+    FallbackStrategy,
+)
+from talos_agent.routing.usage import (
+    BudgetConfig,
+    UsageRecord,
+    UsageSnapshot,
+    UsageTracker,
+)
+
+__all__ = [
+    "BudgetConfig",
+    "FallbackChain",
+    "FallbackResult",
+    "FallbackStrategy",
+    "_build_default_registry",
+    "LLMProvider",
+    "OpenAIClientProvider",
+    "ProviderCapabilities",
+    "ProviderMetadata",
+    "ProviderRegistry",
+    "ProviderStatus",
+    "RoutingConstraints",
+    "RoutingDecision",
+    "RoutingPolicy",
+    "TaskType",
+    "UsageRecord",
+    "UsageSnapshot",
+    "UsageTracker",
+]

--- a/packages/prime-agent/src/talos_agent/routing/fallback.py
+++ b/packages/prime-agent/src/talos_agent/routing/fallback.py
@@ -1,0 +1,199 @@
+"""Fallback chain for trying providers in order until one succeeds.
+
+The :class:`FallbackChain` executes an operation against a sequence of
+providers, moving to the next on failure.  It integrates with the circuit
+breaker system to skip providers that are currently OPEN and records
+successes/failures on the appropriate breakers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable
+
+from talos_agent.circuit_breaker import CircuitBreakerOpen, cb_registry
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackStrategy(str, Enum):
+    """Strategy for ordering fallback attempts."""
+
+    ORDERED = "ordered"
+    """Try providers in the exact order specified (default)."""
+
+    ROUND_ROBIN = "round_robin"
+    """Rotate through the provider list, skipping the last-used one."""
+
+
+@dataclass(frozen=True)
+class FallbackResult:
+    """The result of a fallback chain execution.
+
+    Attributes
+    ----------
+    success:
+        Whether any provider succeeded.
+    provider_name:
+        The name of the provider that succeeded, or ``""`` if none.
+    result:
+        The result returned by the successful provider, or ``None``.
+    attempts:
+        List of ``(provider_name, error_message)`` for each failed attempt.
+    total_attempts:
+        Total number of providers attempted.
+    """
+
+    success: bool
+    provider_name: str
+    result: Any = None
+    attempts: list[tuple[str, str]] = field(default_factory=list)
+    total_attempts: int = 0
+
+
+class FallbackChain:
+    """Execute an operation across a sequence of providers with fallback.
+
+    Usage
+    -----
+    >>> chain = FallbackChain(["groq", "openai"])
+    >>>
+    >>> async def call(model: str, messages, ...):
+    ...     ...
+    >>>
+    >>> result = await chain.execute(call)
+    >>> if result.success:
+    ...     print(f"Succeeded with {result.provider_name}")
+    """
+
+    def __init__(
+        self,
+        providers: list[str],
+        strategy: FallbackStrategy = FallbackStrategy.ORDERED,
+    ) -> None:
+        self._providers = list(providers)
+        self._strategy = strategy
+        self._round_robin_index: int = 0
+
+    @property
+    def providers(self) -> list[str]:
+        """The ordered list of provider names in this chain."""
+        return list(self._providers)
+
+    @property
+    def strategy(self) -> FallbackStrategy:
+        return self._strategy
+
+    async def execute(
+        self,
+        operation: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> FallbackResult:
+        """Try each provider in the chain until one succeeds.
+
+        Parameters
+        ----------
+        operation:
+            An async callable that accepts ``provider_name`` as its first
+            positional argument (or via the ``provider_keyword`` parameter).
+        *args:
+            Additional positional arguments forwarded to *operation*.
+        **kwargs:
+            Additional keyword arguments forwarded to *operation*.
+
+        Returns
+        -------
+        FallbackResult
+            The result of the first successful attempt, or a summary of
+            all failures.
+        """
+        provider_list = self._resolve_order()
+        attempts: list[tuple[str, str]] = []
+
+        for provider_name in provider_list:
+            # Check circuit breaker before attempting
+            breaker = cb_registry.get(provider_name)
+            if not await breaker.allow_request():
+                cooldown = breaker.remaining_cooldown() or 0.0
+                msg = f"Circuit breaker OPEN (retry in {cooldown:.1f}s)"
+                attempts.append((provider_name, msg))
+                logger.warning(
+                    "Fallback skipping '%s' — %s",
+                    provider_name,
+                    msg,
+                )
+                continue
+
+            try:
+                result = await operation(provider_name, *args, **kwargs)
+                await breaker.record_success()
+                logger.info(
+                    "Fallback succeeded with '%s' after %d attempt(s)",
+                    provider_name,
+                    len(attempts) + 1,
+                )
+                return FallbackResult(
+                    success=True,
+                    provider_name=provider_name,
+                    result=result,
+                    attempts=attempts,
+                    total_attempts=len(attempts) + 1,
+                )
+            except CircuitBreakerOpen as exc:
+                await breaker.record_failure()
+                attempts.append((provider_name, str(exc)))
+                logger.warning(
+                    "Fallback: '%s' rejected by circuit breaker — %s",
+                    provider_name,
+                    exc,
+                )
+                continue
+            except Exception as exc:
+                await breaker.record_failure()
+                exc_msg = _summarise_exception(exc)
+                attempts.append((provider_name, exc_msg))
+                logger.warning(
+                    "Fallback: '%s' failed — %s",
+                    provider_name,
+                    exc_msg,
+                )
+
+        # All providers exhausted
+        logger.error(
+            "Fallback chain exhausted after %d provider(s): %s",
+            len(attempts),
+            "; ".join(f"{p}: {e}" for p, e in attempts),
+        )
+        return FallbackResult(
+            success=False,
+            provider_name="",
+            attempts=attempts,
+            total_attempts=len(attempts),
+        )
+
+    def _resolve_order(self) -> list[str]:
+        """Return the provider order based on the strategy."""
+        if self._strategy == FallbackStrategy.ORDERED:
+            return self._providers
+
+        if self._strategy == FallbackStrategy.ROUND_ROBIN:
+            if not self._providers:
+                return []
+            idx = self._round_robin_index % len(self._providers)
+            self._round_robin_index = (idx + 1) % len(self._providers)
+            return self._providers[idx:] + self._providers[:idx]
+
+        return self._providers
+
+
+def _summarise_exception(exc: Exception) -> str:
+    """Return a concise, safe summary of an exception for logging."""
+    exc_type = type(exc).__name__
+    msg = str(exc)
+    # Truncate long messages to avoid log floods
+    if len(msg) > 200:
+        msg = msg[:197] + "..."
+    return f"{exc_type}: {msg}"

--- a/packages/prime-agent/src/talos_agent/routing/policy.py
+++ b/packages/prime-agent/src/talos_agent/routing/policy.py
@@ -1,0 +1,473 @@
+"""Routing policy engine for selecting providers based on constraints.
+
+The :class:`RoutingPolicy` evaluates constraints (task type, cost, latency,
+privacy, required capabilities) against registered providers and selects
+the best candidate.  Selection is deterministic for the same inputs.
+
+Scoring
+-------
+Each candidate provider receives a score based on how well it matches the
+constraints.  The scoring dimensions are:
+
+* **Capability fit**: Does the provider support the required capabilities?
+  (boolean — disqualifies if missing)
+* **Cost score**: Normalised inverse cost (lower cost = higher score).
+* **Latency score**: Normalised inverse latency (lower latency = higher score).
+* **Privacy score**: ``local`` > ``trusted`` > ``external``.
+* **Availability score**: Circuit breaker state (healthy > degraded > open).
+
+Providers that do not meet capability requirements are excluded.  The
+remaining candidates are scored and the highest scorer is selected.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from talos_agent.routing.provider import (
+    ProviderCapabilities,
+    ProviderMetadata,
+    ProviderRegistry,
+    ProviderStatus,
+    TaskType,
+)
+
+if TYPE_CHECKING:
+    from talos_agent.routing.provider import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+# ── Scoring weights ────────────────────────────────────────────────────────────
+
+# Default scoring weights.  These can be overridden in RoutingPolicy to
+# tune the router for different deployment scenarios.
+
+DEFAULT_COST_WEIGHT = 1.0
+DEFAULT_LATENCY_WEIGHT = 1.0
+DEFAULT_PRIVACY_WEIGHT = 0.5
+DEFAULT_AVAILABILITY_WEIGHT = 2.0  # Most important — avoid failing calls
+
+# ── Constraints ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RoutingConstraints:
+    """Constraints that the routing policy must satisfy.
+
+    All fields are optional.  Unset constraints are treated as "no
+    preference" and do not influence scoring.
+    """
+
+    task_type: TaskType = TaskType.CHAT
+    """What kind of task is being routed."""
+
+    max_cost_usd: Decimal | None = None
+    """Maximum acceptable cost in USD for this single call."""
+
+    max_latency_ms: float | None = None
+    """Maximum acceptable latency in milliseconds."""
+
+    require_privacy: str | None = None
+    """Minimum privacy level: ``"local"``, ``"trusted"``, or ``"external"``."""
+
+    require_capabilities: set[str] = field(default_factory=set)
+    """Required capability names (e.g. ``{"vision"}``, ``{"json_mode"}``)."""
+
+    preferred_provider: str | None = None
+    """Exact provider name to use (bypasses scoring if available)."""
+
+    preferred_model: str | None = None
+    """Exact model name to use (used alongside preferred_provider)."""
+
+    bypass_fallback: bool = False
+    """If ``True``, do not attempt fallback on failure (fail-fast)."""
+
+
+# ── Routing Decision ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """The result of a routing policy evaluation.
+
+    Attributes
+    ----------
+    provider_name:
+        The selected provider name.
+    model:
+        The model to use for this call.
+    score:
+        The aggregate score that determined this selection.
+    reason:
+        Human-readable explanation of why this provider was chosen.
+    constraints:
+        The constraints that led to this decision.
+    """
+
+    provider_name: str
+    model: str
+    score: float
+    reason: str
+    constraints: RoutingConstraints
+
+
+# ── Policy ─────────────────────────────────────────────────────────────────────
+
+
+class RoutingPolicy:
+    """Selects the best provider for a set of :class:`RoutingConstraints`.
+
+    The policy is deterministic — the same constraints and registry state
+    always produce the same selection.
+
+    Usage
+    -----
+    >>> policy = RoutingPolicy(registry)
+    >>> constraints = RoutingConstraints(task_type=TaskType.CHAT)
+    >>> decision = policy.select(constraints)
+    >>> decision.provider_name
+    'groq'
+    """
+
+    def __init__(
+        self,
+        registry: ProviderRegistry,
+        *,
+        cost_weight: float = DEFAULT_COST_WEIGHT,
+        latency_weight: float = DEFAULT_LATENCY_WEIGHT,
+        privacy_weight: float = DEFAULT_PRIVACY_WEIGHT,
+        availability_weight: float = DEFAULT_AVAILABILITY_WEIGHT,
+    ) -> None:
+        self._registry = registry
+        self._cost_weight = cost_weight
+        self._latency_weight = latency_weight
+        self._privacy_weight = privacy_weight
+        self._availability_weight = availability_weight
+
+    # These weights are exposed as read-only properties so that consumers
+    # can inspect the policy configuration.
+
+    @property
+    def cost_weight(self) -> float:
+        return self._cost_weight
+
+    @property
+    def latency_weight(self) -> float:
+        return self._latency_weight
+
+    @property
+    def privacy_weight(self) -> float:
+        return self._privacy_weight
+
+    @property
+    def availability_weight(self) -> float:
+        return self._availability_weight
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    def select(self, constraints: RoutingConstraints) -> RoutingDecision:
+        """Select the best provider for the given constraints.
+
+        Parameters
+        ----------
+        constraints:
+            The task constraints to satisfy.
+
+        Returns
+        -------
+        RoutingDecision
+            The selected provider and model, along with a score and reason.
+
+        Raises
+        ------
+        NoSuitableProviderError
+            If no registered provider can satisfy the constraints.
+        """
+        # Fast path: preferred provider
+        if constraints.preferred_provider:
+            return self._select_preferred(constraints)
+
+        candidates = self._score_candidates(constraints)
+        if not candidates:
+            raise NoSuitableProviderError(
+                "No suitable provider found",
+                constraints=constraints,
+                available=self._registry.available(),
+            )
+
+        # Sort by score descending, then by name for determinism
+        candidates.sort(key=lambda x: (-x[1], x[0]))
+
+        best_name, best_score = candidates[0]
+        best_provider = self._registry.get(best_name)
+        model = constraints.preferred_model or best_provider.metadata.default_model
+        reason = self._build_reason(best_name, best_score, constraints, candidates)
+
+        return RoutingDecision(
+            provider_name=best_name,
+            model=model,
+            score=best_score,
+            reason=reason,
+            constraints=constraints,
+        )
+
+    # ── Scoring ───────────────────────────────────────────────────────────
+
+    def _score_candidates(
+        self,
+        constraints: RoutingConstraints,
+    ) -> list[tuple[str, float]]:
+        """Score all registered providers against the constraints.
+
+        Returns a list of ``(provider_name, score)`` tuples for providers
+        that satisfy all capability requirements.
+        """
+        scored: list[tuple[str, float]] = []
+
+        for name in self._registry.available():
+            provider = self._registry.get(name)
+            meta = provider.metadata
+
+            # Check capability requirements
+            if not self._capabilities_satisfy(meta.capabilities, constraints):
+                continue
+
+            score = 0.0
+
+            # Cost score (inverse — lower cost = higher score)
+            if self._cost_weight > 0 and constraints.max_cost_usd is not None:
+                cost_score = self._compute_cost_score(meta, constraints)
+                score += self._cost_weight * cost_score
+
+            # Latency score (inverse — lower latency = higher score)
+            if self._latency_weight > 0 and constraints.max_latency_ms is not None:
+                latency_score = self._compute_latency_score(meta, constraints)
+                score += self._latency_weight * latency_score
+
+            # Privacy score
+            if self._privacy_weight > 0 and constraints.require_privacy:
+                privacy_score = self._compute_privacy_score(meta, constraints)
+                score += self._privacy_weight * privacy_score
+
+            # Availability score
+            if self._availability_weight > 0:
+                availability_score = self._compute_availability_score(name)
+                score += self._availability_weight * availability_score
+
+            # Task-type-specific preference
+            score += self._task_type_bonus(name, meta, constraints.task_type)
+
+            scored.append((name, score))
+
+        return scored
+
+    def _select_preferred(self, constraints: RoutingConstraints) -> RoutingDecision:
+        """Handle the fast path when a preferred provider is explicitly set."""
+        preferred = constraints.preferred_provider
+
+        if preferred not in self._registry.available():
+            raise NoSuitableProviderError(
+                f"Preferred provider '{preferred}' is not registered",
+                constraints=constraints,
+                available=self._registry.available(),
+            )
+
+        provider = self._registry.get(preferred)
+        model = constraints.preferred_model or provider.metadata.default_model
+
+        # Still check capability requirements
+        if not self._capabilities_satisfy(provider.metadata.capabilities, constraints):
+            raise NoSuitableProviderError(
+                f"Preferred provider '{preferred}' does not satisfy capability requirements",
+                constraints=constraints,
+                available=self._registry.available(),
+            )
+
+        return RoutingDecision(
+            provider_name=preferred,
+            model=model,
+            score=float("inf"),
+            reason=f"Preferred provider '{preferred}' selected by constraint",
+            constraints=constraints,
+        )
+
+    # ── Scoring helpers ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _capabilities_satisfy(
+        capabilities: ProviderCapabilities,
+        constraints: RoutingConstraints,
+    ) -> bool:
+        """Check whether *capabilities* satisfy *constraints*.
+
+        Returns ``False`` if any required capability is missing.
+        """
+        for required in constraints.require_capabilities:
+            if required == "json_mode" and not capabilities.json_mode:
+                return False
+            if required == "vision" and not capabilities.vision:
+                return False
+            if required == "tool_calling" and not capabilities.tool_calling:
+                return False
+            if required == "streaming" and not capabilities.streaming:
+                return False
+            if required == "parallel_tool_calls" and not capabilities.parallel_tool_calls:
+                return False
+        return True
+
+    @staticmethod
+    def _compute_cost_score(
+        meta: ProviderMetadata,
+        constraints: RoutingConstraints,
+    ) -> float:
+        """Compute cost score (0 to 1, higher = better)."""
+        if constraints.max_cost_usd is None or constraints.max_cost_usd <= Decimal("0"):
+            return 0.5  # Neutral if no budget constraint
+
+        # Estimate cost for a typical call (1000 input + 500 output tokens)
+        estimated = (
+            meta.cost_per_1k_input * Decimal("1")
+            + meta.cost_per_1k_output * Decimal("0.5")
+        )
+
+        if estimated <= Decimal("0"):
+            return 1.0  # Free provider
+
+        # Score = 1 - (estimated / max_cost), clamped to [0, 1]
+        ratio = float(estimated / constraints.max_cost_usd)
+        return max(0.0, min(1.0, 1.0 - ratio))
+
+    @staticmethod
+    def _compute_latency_score(
+        meta: ProviderMetadata,
+        constraints: RoutingConstraints,
+    ) -> float:
+        """Compute latency score (0 to 1, higher = better)."""
+        if constraints.max_latency_ms is None or constraints.max_latency_ms <= 0:
+            return 0.5
+
+        if meta.avg_latency_ms <= 0:
+            return 0.5
+
+        ratio = meta.avg_latency_ms / constraints.max_latency_ms
+        if ratio <= 0.5:
+            return 1.0  # Well within budget
+        if ratio <= 1.0:
+            return 2.0 * (1.0 - ratio)  # Within budget, lower = better
+        # Exceeds budget — penalize
+        return max(0.0, 1.0 - ratio)
+
+    @staticmethod
+    def _compute_privacy_score(
+        meta: ProviderMetadata,
+        constraints: RoutingConstraints,
+    ) -> float:
+        """Compute privacy score (0 to 1, higher = better).
+
+        Privacy levels: local=3, trusted=2, external=1
+        Required level must be <= provider level.
+        """
+        level_map = {"local": 3, "trusted": 2, "external": 1}
+        required = constraints.require_privacy or "external"
+        provider_level = level_map.get(meta.privacy_level, 1)
+        required_level = level_map.get(required, 1)
+
+        if provider_level < required_level:
+            return -1.0  # Penalty for not meeting privacy requirements
+
+        # Score proportional to how much better the provider is
+        return float(provider_level) / 3.0
+
+    @staticmethod
+    def _compute_availability_score(provider_name: str) -> float:
+        """Compute availability score based on circuit breaker state."""
+        from talos_agent.circuit_breaker import cb_registry
+
+        breaker = cb_registry.get(provider_name)
+        state = breaker.state.value
+        if state == "closed":
+            return 1.0
+        elif state == "half_open":
+            return 0.3
+        else:  # open
+            return -1.0
+
+    @staticmethod
+    def _task_type_bonus(
+        provider_name: str,
+        meta: ProviderMetadata,
+        task_type: TaskType,
+    ) -> float:
+        """Small bonus/penalty for task-type affinity with the provider."""
+        lower = provider_name.lower()
+        if task_type == TaskType.JSON and not meta.capabilities.json_mode:
+            return -0.5
+        if task_type == TaskType.VISION and not meta.capabilities.vision:
+            return -0.5
+        if task_type == TaskType.CHAT:
+            # Prefer cheaper providers for simple chat
+            if lower == "groq":
+                return 0.3
+            if lower == "openai" and "mini" in meta.default_model:
+                return 0.2
+        if task_type == TaskType.REASONING:
+            # Prefer more capable providers for reasoning
+            if lower == "openai" and "4" in meta.default_model:
+                return 0.3
+        if task_type == TaskType.CODE:
+            if lower == "openai":
+                return 0.2
+        return 0.0
+
+    @staticmethod
+    def _build_reason(
+        name: str,
+        score: float,
+        constraints: RoutingConstraints,
+        candidates: list[tuple[str, float]],
+    ) -> str:
+        """Build a human-readable explanation of the selection."""
+        parts = [f"Selected '{name}' (score={score:.2f})"]
+        if constraints.task_type != TaskType.CHAT:
+            parts.append(f"for task_type={constraints.task_type.value}")
+        if len(candidates) > 1:
+            others = ", ".join(f"'{n}'({s:.2f})" for n, s in candidates if n != name)
+            parts.append(f"over {others}")
+        return "; ".join(parts)
+
+
+# ── Exception ──────────────────────────────────────────────────────────────────
+
+
+class NoSuitableProviderError(LookupError):
+    """Raised when the routing policy cannot find a suitable provider.
+
+    Attributes
+    ----------
+    constraints:
+        The constraints that could not be satisfied.
+    available:
+        The list of registered provider names at the time of the error.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        constraints: RoutingConstraints,
+        available: list[str],
+    ) -> None:
+        self.constraints = constraints
+        self.available = available
+        super().__init__(f"{message} (available: {available})")
+
+
+__all__ = [
+    "NoSuitableProviderError",
+    "RoutingConstraints",
+    "RoutingDecision",
+    "RoutingPolicy",
+]

--- a/packages/prime-agent/src/talos_agent/routing/provider.py
+++ b/packages/prime-agent/src/talos_agent/routing/provider.py
@@ -1,0 +1,536 @@
+"""Provider abstractions, metadata, and registry for LLM model routing.
+
+Defines the :class:`LLMProvider` interface that all providers must implement,
+along with :class:`ProviderMetadata` for routing decisions and the singleton
+:class:`ProviderRegistry` that holds all available providers.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from talos_agent.circuit_breaker import cb_registry
+
+logger = logging.getLogger(__name__)
+
+
+# ── Enums ──────────────────────────────────────────────────────────────────────
+
+
+class TaskType(str, Enum):
+    """Classification of the task being routed.
+
+    Each task type maps to different provider suitability scores.  For
+    example, structured extraction wants JSON mode; reasoning benefits
+    from larger models; simple chat can use cheaper/faster providers.
+    """
+
+    CHAT = "chat"
+    JSON = "json"
+    REASONING = "reasoning"
+    CODE = "code"
+    VISION = "vision"
+    EMBEDDING = "embedding"
+
+
+class ProviderStatus(str, Enum):
+    """Operational status of a provider as seen by the router."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+
+
+# ── Metadata ───────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Capabilities that a provider supports.
+
+    Used by :class:`RoutingPolicy` to match against
+    :class:`RoutingConstraints`.
+    """
+
+    tool_calling: bool = True
+    """Whether the provider supports OpenAI-style function/tool calling."""
+
+    json_mode: bool = True
+    """Whether the provider supports ``response_format: {"type": "json_object"}``."""
+
+    vision: bool = False
+    """Whether the provider supports image inputs."""
+
+    streaming: bool = True
+    """Whether the provider supports streaming responses."""
+
+    parallel_tool_calls: bool = True
+    """Whether the provider supports parallel tool calls in one response."""
+
+    max_tokens: int = 4096
+    """Maximum output tokens the provider supports."""
+
+    supported_models: tuple[str, ...] = ()
+    """Explicit list of model names this provider can serve."""
+
+
+@dataclass(frozen=True)
+class ProviderMetadata:
+    """Immutable metadata about a provider for routing decisions.
+
+    These values are typically static and configured at registration time.
+    Dynamic state (circuit breaker status, current usage) is checked at
+    routing time via the registry.
+    """
+
+    name: str
+    """Unique provider name (e.g. ``"groq"``, ``"openai"``)."""
+
+    capabilities: ProviderCapabilities
+    """What this provider can do."""
+
+    cost_per_1k_input: Decimal = Decimal("0")
+    """USD per 1,000 input tokens (prompt)."""
+
+    cost_per_1k_output: Decimal = Decimal("0")
+    """USD per 1,000 output tokens (completion)."""
+
+    avg_latency_ms: float = 1000.0
+    """Approximate average latency in milliseconds (used for preference)."""
+
+    privacy_level: str = "external"
+    """Privacy classification: ``"local"``, ``"trusted"``, ``"external"``."""
+
+    default_model: str = ""
+    """Default model to use when no specific model is requested."""
+
+    models: tuple[str, ...] = ()
+    """All models available through this provider."""
+
+
+# ── Abstract Provider ─────────────────────────────────────────────────────────
+
+
+class LLMProvider(ABC):
+    """Abstract base class for an LLM provider.
+
+    Each concrete provider wraps access to a model endpoint (OpenAI, Groq,
+    Anthropic, etc.) and exposes its metadata for routing decisions.
+
+    Implementations must be stateless with respect to the call itself;
+    state such as circuit breakers and usage counters is managed externally
+    by the registry and routing infrastructure.
+    """
+
+    @property
+    @abstractmethod
+    def metadata(self) -> ProviderMetadata:
+        """Return the static metadata for this provider."""
+
+    @abstractmethod
+    async def complete(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        response_format: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Send a completion request and return the response.
+
+        The return value is a dict that must contain at least:
+        ``{"choices": [{"message": {...}}], "usage": {"prompt_tokens": ...,
+        "completion_tokens": ..., "total_tokens": ...}}``
+
+        This roughly mirrors the OpenAI chat completion response format
+        so that the agent loop can consume it identically regardless of
+        which provider served the request.
+        """
+
+    async def check_health(self) -> bool:
+        """Return ``True`` if the provider is reachable and responsive.
+
+        Base implementation pings the provider's default model with a
+        minimal request.  Providers may override for a cheaper check.
+        """
+        try:
+            await self.complete(
+                model=self.metadata.default_model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+            )
+            return True
+        except Exception:
+            return False
+
+
+# ── OpenAI-compatible provider ────────────────────────────────────────────────
+
+
+@dataclass
+class OpenAIClientProvider(LLMProvider):
+    """A provider backed by an OpenAI-compatible API (OpenAI, Groq, etc.).
+
+    Wraps an :class:`openai.AsyncOpenAI` client so the routing layer can
+    treat every provider uniformly.
+    """
+
+    _metadata: ProviderMetadata
+    _client: AsyncOpenAI
+    _provider_name: str = ""
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return self._metadata
+
+    @staticmethod
+    def build(
+        name: str,
+        api_key: str,
+        base_url: str | None = None,
+        *,
+        capabilities: ProviderCapabilities | None = None,
+        cost_per_1k_input: Decimal = Decimal("0"),
+        cost_per_1k_output: Decimal = Decimal("0"),
+        avg_latency_ms: float = 1000.0,
+        privacy_level: str = "external",
+        default_model: str = "",
+        models: tuple[str, ...] = (),
+    ) -> OpenAIClientProvider:
+        """Factory method that builds a provider from raw parameters.
+
+        Parameters
+        ----------
+        name:
+            Unique provider name.
+        api_key:
+            API key for the provider.
+        base_url:
+            Optional base URL (e.g. ``"https://api.groq.com/openai/v1"``).
+            ``None`` uses the OpenAI SDK default.
+        capabilities:
+            Provider capabilities.  If omitted, sensible defaults are
+            inferred from the provider name.
+        cost_per_1k_input, cost_per_1k_output:
+            USD per 1,000 tokens.
+        avg_latency_ms:
+            Approximate average latency.
+        privacy_level:
+            Privacy classification.
+        default_model:
+            Default model to use.
+        models:
+            All available models.
+
+        Returns
+        -------
+        OpenAIClientProvider
+            Configured provider instance.
+        """
+        if capabilities is None:
+            capabilities = _default_capabilities(name, default_model)
+
+        client_kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        client = AsyncOpenAI(**client_kwargs)
+
+        meta = ProviderMetadata(
+            name=name,
+            capabilities=capabilities,
+            cost_per_1k_input=cost_per_1k_input,
+            cost_per_1k_output=cost_per_1k_output,
+            avg_latency_ms=avg_latency_ms,
+            privacy_level=privacy_level,
+            default_model=default_model,
+            models=models,
+        )
+        return OpenAIClientProvider(
+            _metadata=meta,
+            _client=client,
+            _provider_name=name,
+        )
+
+    async def complete(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        response_format: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Send a completion request and return a normalized response dict."""
+        create_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+        }
+        if tools is not None:
+            create_kwargs["tools"] = tools
+        if tools:
+            create_kwargs["tool_choice"] = "auto"
+        if response_format is not None:
+            create_kwargs["response_format"] = response_format
+        create_kwargs.update(kwargs)
+
+        response = await self._client.chat.completions.create(**create_kwargs)
+
+        # Normalise to a plain dict so the agent loop doesn't depend on
+        # the openai SDK response object.
+        choice = response.choices[0]
+        message: dict[str, Any] = {"role": "assistant"}
+        if choice.message.content:
+            message["content"] = choice.message.content
+        if choice.message.tool_calls:
+            message["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in choice.message.tool_calls
+            ]
+
+        usage = response.usage
+        result: dict[str, Any] = {
+            "choices": [{"message": message}],
+            "usage": {
+                "prompt_tokens": usage.prompt_tokens if usage else 0,
+                "completion_tokens": usage.completion_tokens if usage else 0,
+                "total_tokens": usage.total_tokens if usage else 0,
+            },
+            "model": model,
+            "provider": self._provider_name,
+        }
+        return result
+
+
+def _default_capabilities(name: str, default_model: str) -> ProviderCapabilities:
+    """Return appropriate capabilities for well-known provider names."""
+    lower = name.lower()
+    if lower == "groq":
+        return ProviderCapabilities(
+            tool_calling=True,
+            json_mode=True,
+            vision=True,
+            streaming=True,
+            parallel_tool_calls=True,
+            max_tokens=8192 if "70b" in default_model else 4096,
+            supported_models=(
+                "llama-3.3-70b-versatile",
+                "llama-3.1-8b-instant",
+                "mixtral-8x7b-32768",
+            ),
+        )
+    if lower == "openai":
+        return ProviderCapabilities(
+            tool_calling=True,
+            json_mode=True,
+            vision=True,
+            streaming=True,
+            parallel_tool_calls=True,
+            max_tokens=16384,
+            supported_models=(
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4-turbo",
+                "gpt-3.5-turbo",
+            ),
+        )
+    if lower == "anthropic":
+        return ProviderCapabilities(
+            tool_calling=True,
+            json_mode=False,
+            vision=True,
+            streaming=True,
+            parallel_tool_calls=True,
+            max_tokens=8192,
+            supported_models=("claude-3-5-sonnet", "claude-3-haiku"),
+        )
+    # Generic fallback
+    return ProviderCapabilities()
+
+
+# ── Registry ───────────────────────────────────────────────────────────────────
+
+
+class ProviderRegistry:
+    """Registry of all available LLM providers.
+
+    The registry is a singleton-like container that holds provider
+    instances and exposes them for routing.  Providers are registered
+    by name and looked up by the routing policy.
+
+    Usage
+    -----
+    >>> registry = ProviderRegistry()
+    >>> registry.register(groq_provider)
+    >>> registry.register(openai_provider)
+    >>> provider = registry.get("groq")
+    """
+
+    def __init__(self) -> None:
+        self._providers: dict[str, LLMProvider] = {}
+
+    # ── Registration ──────────────────────────────────────────────────────
+
+    def register(self, provider: LLMProvider) -> None:
+        """Register a provider.
+
+        Raises
+        ------
+        ValueError
+            If a provider with the same name is already registered.
+        """
+        name = provider.metadata.name
+        if name in self._providers:
+            raise ValueError(f"Provider '{name}' is already registered")
+        self._providers[name] = provider
+        logger.info("Registered provider '%s' (default model: %s)", name, provider.metadata.default_model)
+
+    def register_or_replace(self, provider: LLMProvider) -> None:
+        """Register or replace an existing provider with the same name."""
+        name = provider.metadata.name
+        self._providers[name] = provider
+        logger.info("Registered/replaced provider '%s'", name)
+
+    # ── Lookup ────────────────────────────────────────────────────────────
+
+    def get(self, name: str) -> LLMProvider:
+        """Get a provider by name.
+
+        Raises
+        ------
+        KeyError
+            If the provider is not registered.
+        """
+        if name not in self._providers:
+            raise KeyError(f"Provider '{name}' is not registered. Available: {list(self._providers)}")
+        return self._providers[name]
+
+    def available(self) -> list[str]:
+        """Return names of all registered providers."""
+        return list(self._providers)
+
+    def get_healthy(self) -> list[str]:
+        """Return names of providers whose circuit breaker is not OPEN."""
+        healthy: list[str] = []
+        for name, provider in self._providers.items():
+            breaker = cb_registry.get(name)
+            if breaker.state.value != "open":
+                healthy.append(name)
+        return healthy
+
+    def all_providers(self) -> dict[str, LLMProvider]:
+        """Return a copy of the internal provider map."""
+        return dict(self._providers)
+
+    # ── Convenience ───────────────────────────────────────────────────────
+
+    def count(self) -> int:
+        """Number of registered providers."""
+        return len(self._providers)
+
+    def status(self, name: str) -> ProviderStatus:
+        """Return the current operational status of a provider.
+
+        Combines circuit breaker state and registration status.
+        """
+        if name not in self._providers:
+            return ProviderStatus.UNAVAILABLE
+
+        breaker = cb_registry.get(name)
+        if breaker.state.value == "open":
+            return ProviderStatus.UNAVAILABLE
+        if breaker.state.value == "half_open":
+            return ProviderStatus.DEGRADED
+        return ProviderStatus.HEALTHY
+
+    def get_cost_estimate(
+        self,
+        provider_name: str,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> Decimal:
+        """Estimate the cost in USD for a given token count on a provider."""
+        provider = self.get(provider_name)
+        meta = provider.metadata
+        input_cost = meta.cost_per_1k_input * Decimal(str(input_tokens)) / Decimal("1000")
+        output_cost = meta.cost_per_1k_output * Decimal(str(output_tokens)) / Decimal("1000")
+        return input_cost + output_cost
+
+
+def _build_default_registry(settings: object) -> ProviderRegistry:
+    """Build a :class:`ProviderRegistry` pre-populated with providers
+    configured from *settings*.
+
+    This is a convenience factory used by the agent loop during
+    initialisation.  It reads the Groq and OpenAI credentials from the
+    settings object and registers providers for each configured credential.
+    """
+    from talos_agent.config import resolve_setting_secret
+
+    registry = ProviderRegistry()
+
+    # Groq
+    groq_key = resolve_setting_secret(settings, "groq_api_key")
+    groq_model = getattr(settings, "groq_model", "llama-3.3-70b-versatile")
+    if groq_key:
+        groq_provider = OpenAIClientProvider.build(
+            name="groq",
+            api_key=groq_key,
+            base_url="https://api.groq.com/openai/v1",
+            cost_per_1k_input=Decimal("0.0001"),
+            cost_per_1k_output=Decimal("0.0002"),
+            avg_latency_ms=500.0,
+            default_model=groq_model,
+            models=(
+                "llama-3.3-70b-versatile",
+                "llama-3.1-8b-instant",
+                "mixtral-8x7b-32768",
+            ),
+        )
+        registry.register(groq_provider)
+
+    # OpenAI
+    openai_key = resolve_setting_secret(settings, "openai_api_key")
+    openai_model = getattr(settings, "openai_model", "gpt-4o-mini")
+    if openai_key:
+        openai_provider = OpenAIClientProvider.build(
+            name="openai",
+            api_key=openai_key,
+            base_url=None,  # Use OpenAI SDK default
+            cost_per_1k_input=Decimal("0.00015"),
+            cost_per_1k_output=Decimal("0.0006"),
+            avg_latency_ms=1200.0,
+            default_model=openai_model,
+            models=(
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4-turbo",
+            ),
+        )
+        registry.register(openai_provider)
+
+    return registry
+
+
+__all__ = [
+    "LLMProvider",
+    "OpenAIClientProvider",
+    "ProviderCapabilities",
+    "ProviderMetadata",
+    "ProviderRegistry",
+    "ProviderStatus",
+    "TaskType",
+    "_build_default_registry",
+]

--- a/packages/prime-agent/src/talos_agent/routing/usage.py
+++ b/packages/prime-agent/src/talos_agent/routing/usage.py
@@ -1,0 +1,326 @@
+"""Usage tracking and budget enforcement for provider calls.
+
+The :class:`UsageTracker` records token and cost usage per provider,
+enabling budget-aware routing and telemetry.  Usage data is kept
+in-memory by default and can be augmented with a persistence callback.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Callable
+
+from talos_agent.routing.provider import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    """A single usage record for one provider call.
+
+    Attributes
+    ----------
+    provider_name:
+        The provider that served the request.
+    model:
+        The model used.
+    prompt_tokens:
+        Number of input/prompt tokens.
+    completion_tokens:
+        Number of output/completion tokens.
+    total_tokens:
+        Total token count (prompt + completion).
+    cost_usd:
+        Estimated cost in USD.
+    timestamp:
+        Unix timestamp of the call.
+    success:
+        Whether the call succeeded.
+    """
+
+    provider_name: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost_usd: Decimal
+    timestamp: float
+    success: bool = True
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    """A point-in-time snapshot of aggregated usage.
+
+    Attributes
+    ----------
+    provider_totals:
+        Map of provider_name to aggregated stats.
+    total_prompt_tokens:
+        Total input tokens across all providers.
+    total_completion_tokens:
+        Total output tokens across all providers.
+    total_cost_usd:
+        Total estimated cost across all providers.
+    record_count:
+        Total number of individual usage records.
+    """
+
+    provider_totals: dict[str, dict[str, object]]
+    total_prompt_tokens: int
+    total_completion_tokens: int
+    total_cost_usd: Decimal
+    record_count: int
+
+
+@dataclass
+class BudgetConfig:
+    """Budget limits for a single provider or globally.
+
+    ``None`` means no limit for that dimension.
+    """
+
+    max_cost_usd: Decimal | None = None
+    """Maximum total cost in USD."""
+
+    max_total_tokens: int | None = None
+    """Maximum total tokens (all calls summed)."""
+
+    max_requests: int | None = None
+    """Maximum number of requests."""
+
+    window_seconds: float | None = None
+    """Time window for the budget (``None`` = all-time)."""
+
+
+class UsageTracker:
+    """Tracks token and cost usage per provider.
+
+    Records usage after each provider call and provides aggregated
+    snapshots for telemetry and budget-aware routing.
+
+    Usage
+    -----
+    >>> tracker = UsageTracker(registry)
+    >>> await tracker.record("groq", "llama-3.3-70b", 100, 50)
+    >>> snapshot = tracker.snapshot()
+    >>> snapshot.total_cost_usd
+    Decimal('0.000035')
+    """
+
+    def __init__(
+        self,
+        registry: ProviderRegistry,
+        *,
+        persist_callback: Callable[[UsageRecord], None] | None = None,
+    ) -> None:
+        self._registry = registry
+        self._persist_callback = persist_callback
+        self._records: list[UsageRecord] = []
+
+    # ── Recording ─────────────────────────────────────────────────────────
+
+    async def record(
+        self,
+        provider_name: str,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        success: bool = True,
+    ) -> UsageRecord:
+        """Record usage for a provider call and return the record.
+
+        Parameters
+        ----------
+        provider_name:
+            The provider that served the request.
+        model:
+            The model used.
+        prompt_tokens:
+            Number of input/prompt tokens.
+        completion_tokens:
+            Number of output/completion tokens.
+        success:
+            Whether the call succeeded.
+
+        Returns
+        -------
+        UsageRecord
+            The newly created usage record.
+        """
+        total_tokens = prompt_tokens + completion_tokens
+
+        # Calculate cost
+        try:
+            cost = self._registry.get_cost_estimate(provider_name, prompt_tokens, completion_tokens)
+        except KeyError:
+            cost = Decimal("0")
+            logger.debug("Cannot calculate cost for unknown provider '%s'", provider_name)
+
+        record = UsageRecord(
+            provider_name=provider_name,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            cost_usd=cost,
+            timestamp=time.time(),
+            success=success,
+        )
+
+        self._records.append(record)
+
+        if self._persist_callback:
+            try:
+                self._persist_callback(record)
+            except Exception:
+                logger.exception("Usage persistence callback failed for %s/%s", provider_name, model)
+
+        return record
+
+    # ── Aggregation ───────────────────────────────────────────────────────
+
+    def snapshot(self, window_seconds: float | None = None) -> UsageSnapshot:
+        """Return a point-in-time usage snapshot.
+
+        Parameters
+        ----------
+        window_seconds:
+            If set, only include records within the last N seconds.
+            ``None`` includes all records.
+
+        Returns
+        -------
+        UsageSnapshot
+            Aggregated usage data.
+        """
+        records = self._records
+        if window_seconds is not None:
+            cutoff = time.time() - window_seconds
+            records = [r for r in records if r.timestamp >= cutoff]
+
+        provider_totals: dict[str, dict[str, object]] = {}
+        total_prompt = 0
+        total_completion = 0
+        total_cost = Decimal("0")
+
+        for record in records:
+            total_prompt += record.prompt_tokens
+            total_completion += record.completion_tokens
+            total_cost += record.cost_usd
+
+            prov = record.provider_name
+            if prov not in provider_totals:
+                provider_totals[prov] = {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "cost_usd": Decimal("0"),
+                    "request_count": 0,
+                    "success_count": 0,
+                    "failure_count": 0,
+                }
+            pt = provider_totals[prov]
+            pt["prompt_tokens"] = int(pt["prompt_tokens"]) + record.prompt_tokens
+            pt["completion_tokens"] = int(pt["completion_tokens"]) + record.completion_tokens
+            pt["total_tokens"] = int(pt["total_tokens"]) + record.total_tokens
+            pt["cost_usd"] = Decimal(str(pt["cost_usd"])) + record.cost_usd
+            pt["request_count"] = int(pt["request_count"]) + 1
+            if record.success:
+                pt["success_count"] = int(pt["success_count"]) + 1
+            else:
+                pt["failure_count"] = int(pt["failure_count"]) + 1
+
+        return UsageSnapshot(
+            provider_totals=provider_totals,
+            total_prompt_tokens=total_prompt,
+            total_completion_tokens=total_completion,
+            total_cost_usd=total_cost,
+            record_count=len(records),
+        )
+
+    def provider_usage(self, provider_name: str) -> dict[str, object]:
+        """Return aggregated usage for a single provider.
+
+        Returns an empty dict if no records exist for that provider.
+        """
+        snapshot = self.snapshot()
+        return dict(snapshot.provider_totals.get(provider_name, {}))
+
+    def check_budget(
+        self,
+        config: BudgetConfig,
+        provider_name: str | None = None,
+    ) -> bool:
+        """Check whether the budget has been exceeded.
+
+        Parameters
+        ----------
+        config:
+            The budget limits to check against.
+        provider_name:
+            If set, only check usage for this provider.  ``None`` checks
+            global usage.
+
+        Returns
+        -------
+        bool
+            ``True`` if the budget is still available (not exceeded).
+        """
+        snapshot = self.snapshot(window_seconds=config.window_seconds)
+
+        if provider_name:
+            prov_usage = snapshot.provider_totals.get(provider_name, {})
+            total_cost = Decimal(str(prov_usage.get("cost_usd", "0")))
+            total_tokens = int(prov_usage.get("total_tokens", 0))
+            total_requests = int(prov_usage.get("request_count", 0))
+        else:
+            total_cost = snapshot.total_cost_usd
+            total_tokens = snapshot.total_prompt_tokens + snapshot.total_completion_tokens
+            total_requests = snapshot.record_count
+
+        if config.max_cost_usd is not None and total_cost >= config.max_cost_usd:
+            logger.warning(
+                "Budget exceeded: cost %.4f >= %.4f (provider=%s)",
+                total_cost,
+                config.max_cost_usd,
+                provider_name or "global",
+            )
+            return False
+
+        if config.max_total_tokens is not None and total_tokens >= config.max_total_tokens:
+            logger.warning(
+                "Budget exceeded: tokens %d >= %d (provider=%s)",
+                total_tokens,
+                config.max_total_tokens,
+                provider_name or "global",
+            )
+            return False
+
+        if config.max_requests is not None and total_requests >= config.max_requests:
+            logger.warning(
+                "Budget exceeded: requests %d >= %d (provider=%s)",
+                total_requests,
+                config.max_requests,
+                provider_name or "global",
+            )
+            return False
+
+        return True
+
+    def clear(self) -> None:
+        """Clear all recorded usage data."""
+        self._records.clear()
+        logger.debug("Usage tracker cleared")
+
+
+__all__ = [
+    "BudgetConfig",
+    "UsageRecord",
+    "UsageSnapshot",
+    "UsageTracker",
+]

--- a/packages/prime-agent/tests/test_model_routing.py
+++ b/packages/prime-agent/tests/test_model_routing.py
@@ -1,0 +1,836 @@
+"""Tests for policy-driven model routing and fallback.
+
+Coverage
+--------
+ProviderRegistry: registration, lookup, duplicate prevention, health status.
+OpenAIClientProvider: factory method, metadata, capability defaults.
+RoutingPolicy: selection with task type, cost, latency, privacy constraints,
+  preferred provider fast path, capability filtering, error cases.
+FallbackChain: ordered fallback, circuit breaker integration, all-failures.
+UsageTracker: recording, snapshot aggregation, budget enforcement.
+Backward compatibility: routing disabled preserves legacy behaviour.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from talos_agent.circuit_breaker import cb_registry
+from talos_agent.routing import (
+    BudgetConfig,
+    FallbackChain,
+    FallbackStrategy,
+    ProviderRegistry,
+    RoutingConstraints,
+    RoutingPolicy,
+    UsageRecord,
+    UsageTracker,
+    _build_default_registry,
+)
+from talos_agent.routing.fallback import _summarise_exception
+from talos_agent.routing.policy import NoSuitableProviderError, RoutingDecision
+from talos_agent.routing.provider import (
+    LLMProvider,
+    OpenAIClientProvider,
+    ProviderCapabilities,
+    ProviderMetadata,
+    ProviderStatus,
+    TaskType,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class _FakeProvider(LLMProvider):
+    """A minimal in-memory provider for testing without real API calls."""
+
+    def __init__(
+        self,
+        name: str = "fake",
+        *,
+        capabilities: ProviderCapabilities | None = None,
+        cost_per_1k_input: Decimal = Decimal("0"),
+        cost_per_1k_output: Decimal = Decimal("0"),
+        avg_latency_ms: float = 500.0,
+        privacy_level: str = "external",
+        default_model: str = "fake-model",
+        fail: bool = False,
+    ) -> None:
+        self._meta = ProviderMetadata(
+            name=name,
+            capabilities=capabilities or ProviderCapabilities(),
+            cost_per_1k_input=cost_per_1k_input,
+            cost_per_1k_output=cost_per_1k_output,
+            avg_latency_ms=avg_latency_ms,
+            privacy_level=privacy_level,
+            default_model=default_model,
+            models=(default_model,),
+        )
+        self._fail = fail
+        self._call_count = 0
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return self._meta
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    async def complete(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        response_format: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        self._call_count += 1
+        if self._fail:
+            raise RuntimeError(f"Provider '{self._meta.name}' intentionally failing")
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            "model": model,
+            "provider": self._meta.name,
+        }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ProviderCapabilities
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProviderCapabilities:
+    def test_default_capabilities(self):
+        caps = ProviderCapabilities()
+        assert caps.tool_calling is True
+        assert caps.json_mode is True
+        assert caps.vision is False
+        assert caps.streaming is True
+        assert caps.max_tokens == 4096
+        assert caps.supported_models == ()
+
+    def test_custom_capabilities(self):
+        caps = ProviderCapabilities(
+            tool_calling=False,
+            json_mode=False,
+            vision=True,
+            max_tokens=8192,
+            supported_models=("gpt-4o", "gpt-4o-mini"),
+        )
+        assert caps.tool_calling is False
+        assert caps.json_mode is False
+        assert caps.vision is True
+        assert caps.max_tokens == 8192
+        assert caps.supported_models == ("gpt-4o", "gpt-4o-mini")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ProviderMetadata
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProviderMetadata:
+    def test_frozen_dataclass(self):
+        meta = ProviderMetadata(
+            name="test",
+            capabilities=ProviderCapabilities(),
+            cost_per_1k_input=Decimal("0.01"),
+        )
+        assert meta.name == "test"
+        assert meta.cost_per_1k_input == Decimal("0.01")
+        assert meta.privacy_level == "external"
+        assert meta.avg_latency_ms == 1000.0
+
+    def test_default_model_and_models(self):
+        meta = ProviderMetadata(
+            name="test",
+            capabilities=ProviderCapabilities(),
+            default_model="gpt-4o",
+            models=("gpt-4o", "gpt-4o-mini"),
+        )
+        assert meta.default_model == "gpt-4o"
+        assert meta.models == ("gpt-4o", "gpt-4o-mini")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LLMProvider (abstract base)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLLMProvider:
+    @pytest.mark.asyncio
+    async def test_check_health_with_fake_provider(self):
+        provider = _FakeProvider()
+        healthy = await provider.check_health()
+        assert healthy is True
+        # check_health calls complete with max_tokens=1
+        assert provider.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_check_health_returns_false_on_failure(self):
+        provider = _FakeProvider(name="broken", fail=True)
+        healthy = await provider.check_health()
+        assert healthy is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OpenAIClientProvider (factory)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestOpenAIClientProvider:
+    def test_build_creates_provider_with_given_name(self):
+        provider = OpenAIClientProvider.build(
+            name="test-provider",
+            api_key="sk-test",
+            default_model="gpt-4o-mini",
+        )
+        assert provider.metadata.name == "test-provider"
+        assert provider.metadata.default_model == "gpt-4o-mini"
+        assert provider.metadata.capabilities.tool_calling is True
+
+    def test_build_groq_default_capabilities(self):
+        provider = OpenAIClientProvider.build(
+            name="groq",
+            api_key="gsk-test",
+            default_model="llama-3.3-70b-versatile",
+        )
+        caps = provider.metadata.capabilities
+        assert caps.tool_calling is True
+        assert caps.json_mode is True
+        assert caps.vision is True
+        assert caps.max_tokens == 8192  # 70b model
+        assert "llama-3.3-70b-versatile" in caps.supported_models
+
+    def test_build_openai_default_capabilities(self):
+        provider = OpenAIClientProvider.build(
+            name="openai",
+            api_key="sk-test",
+            default_model="gpt-4o-mini",
+        )
+        caps = provider.metadata.capabilities
+        assert caps.tool_calling is True
+        assert caps.json_mode is True
+        assert caps.vision is True
+        assert caps.max_tokens == 16384
+        assert "gpt-4o" in caps.supported_models
+
+    def test_build_with_custom_cost_and_latency(self):
+        provider = OpenAIClientProvider.build(
+            name="custom",
+            api_key="sk-test",
+            cost_per_1k_input=Decimal("0.001"),
+            cost_per_1k_output=Decimal("0.002"),
+            avg_latency_ms=200.0,
+        )
+        assert provider.metadata.cost_per_1k_input == Decimal("0.001")
+        assert provider.metadata.cost_per_1k_output == Decimal("0.002")
+        assert provider.metadata.avg_latency_ms == 200.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ProviderRegistry
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProviderRegistry:
+    def test_register_and_get(self):
+        registry = ProviderRegistry()
+        provider = _FakeProvider(name="test")
+        registry.register(provider)
+        assert registry.get("test") is provider
+        assert registry.available() == ["test"]
+        assert registry.count() == 1
+
+    def test_register_duplicate_raises(self):
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(name="dup"))
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(_FakeProvider(name="dup"))
+
+    def test_register_or_replace_overwrites(self):
+        registry = ProviderRegistry()
+        p1 = _FakeProvider(name="x")
+        p2 = _FakeProvider(name="x")
+        registry.register(p1)
+        registry.register_or_replace(p2)
+        assert registry.get("x") is p2
+        assert registry.count() == 1
+
+    def test_get_unknown_raises_key_error(self):
+        registry = ProviderRegistry()
+        with pytest.raises(KeyError, match="not registered"):
+            registry.get("nonexistent")
+
+    def test_available_returns_empty_for_empty_registry(self):
+        registry = ProviderRegistry()
+        assert registry.available() == []
+        assert registry.count() == 0
+
+    def test_all_providers_returns_copy(self):
+        registry = ProviderRegistry()
+        p = _FakeProvider(name="a")
+        registry.register(p)
+        all_p = registry.all_providers()
+        assert all_p == {"a": p}
+        # Modifying the returned dict should not affect the registry
+        all_p["b"] = _FakeProvider(name="b")
+        assert "b" not in registry.available()
+
+    def test_status_returns_unavailable_for_unknown(self):
+        registry = ProviderRegistry()
+        status = registry.status("nope")
+        assert status == ProviderStatus.UNAVAILABLE
+
+    def test_status_returns_healthy_for_registered_provider(self):
+        registry = ProviderRegistry()
+        p = _FakeProvider(name="healthy-test")
+        registry.register(p)
+        status = registry.status("healthy-test")
+        assert status == ProviderStatus.HEALTHY
+
+    def test_get_cost_estimate(self):
+        registry = ProviderRegistry()
+        p = _FakeProvider(
+            name="costly",
+            cost_per_1k_input=Decimal("0.01"),
+            cost_per_1k_output=Decimal("0.03"),
+        )
+        registry.register(p)
+        # 1000 input + 500 output tokens
+        cost = registry.get_cost_estimate("costly", 1000, 500)
+        expected = Decimal("0.01") * Decimal("1") + Decimal("0.03") * Decimal("0.5")
+        assert cost == expected
+
+    def test_get_cost_estimate_for_unknown_provider(self):
+        registry = ProviderRegistry()
+        with pytest.raises(KeyError):
+            registry.get_cost_estimate("unknown", 100, 50)
+
+    def test_get_healthy_returns_closed_circuit_breakers(self):
+        registry = ProviderRegistry()
+        p = _FakeProvider(name="healthy-p")
+        registry.register(p)
+        # Circuit breaker should be CLOSED by default
+        healthy = registry.get_healthy()
+        assert "healthy-p" in healthy
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RoutingPolicy
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRoutingPolicySelect:
+    @pytest.fixture(autouse=True)
+    def _make_registry(self):
+        """Create a registry with two fake providers for each test."""
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(
+            name="cheap",
+            cost_per_1k_input=Decimal("0.00001"),
+            cost_per_1k_output=Decimal("0.00002"),
+            avg_latency_ms=300.0,
+        ))
+        registry.register(_FakeProvider(
+            name="expensive",
+            cost_per_1k_input=Decimal("0.01"),
+            cost_per_1k_output=Decimal("0.03"),
+            avg_latency_ms=1000.0,
+        ))
+        self._registry = registry
+
+    @property
+    def registry(self):
+        return self._registry
+
+    def test_select_returns_a_provider(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints())
+        assert isinstance(decision, RoutingDecision)
+        assert decision.provider_name in ("cheap", "expensive")
+        assert decision.score > 0
+        assert decision.reason
+
+    def test_preferred_provider_bypasses_scoring(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(preferred_provider="cheap"))
+        assert decision.provider_name == "cheap"
+        assert decision.score == float("inf")
+        assert "preferred" in decision.reason.lower()
+
+    def test_preferred_provider_not_registered_raises(self):
+        policy = RoutingPolicy(self.registry)
+        with pytest.raises(NoSuitableProviderError, match="not registered"):
+            policy.select(RoutingConstraints(preferred_provider="nonexistent"))
+
+    def test_preferred_model_is_used(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(
+            preferred_provider="cheap",
+            preferred_model="custom-model",
+        ))
+        assert decision.model == "custom-model"
+
+    def test_preferred_model_defaults_to_provider_default(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(preferred_provider="cheap"))
+        assert decision.model == "fake-model"  # _FakeProvider default
+
+    def test_no_suitable_provider_raises(self):
+        empty_registry = ProviderRegistry()
+        policy = RoutingPolicy(empty_registry)
+        with pytest.raises(NoSuitableProviderError, match="No suitable provider"):
+            policy.select(RoutingConstraints())
+
+    def test_capability_filtering_excludes_providers(self):
+        """Providers that lack required capabilities are excluded."""
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(
+            name="no_vision",
+            capabilities=ProviderCapabilities(vision=False),
+        ))
+        policy = RoutingPolicy(registry)
+        with pytest.raises(NoSuitableProviderError, match="No suitable provider"):
+            policy.select(RoutingConstraints(require_capabilities={"vision"}))
+
+    def test_capability_filtering_passes_with_matching(self):
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(
+            name="has_vision",
+            capabilities=ProviderCapabilities(vision=True),
+        ))
+        policy = RoutingPolicy(registry)
+        decision = policy.select(RoutingConstraints(require_capabilities={"vision"}))
+        assert decision.provider_name == "has_vision"
+
+    def test_cost_constraint_prefers_cheaper(self):
+        """With a tight cost budget, the cheaper provider should be selected."""
+        policy = RoutingPolicy(self.registry, cost_weight=10.0, availability_weight=0)
+        decision = policy.select(RoutingConstraints(max_cost_usd=Decimal("0.001")))
+        assert decision.provider_name == "cheap"
+
+    def test_latency_constraint_prefers_faster(self):
+        """With a tight latency budget, the faster provider should be selected."""
+        policy = RoutingPolicy(self.registry, latency_weight=10.0, availability_weight=0)
+        decision = policy.select(RoutingConstraints(max_latency_ms=400.0))
+        assert decision.provider_name == "cheap"
+
+    def test_select_is_deterministic(self):
+        policy = RoutingPolicy(self.registry)
+        constraints = RoutingConstraints()
+        d1 = policy.select(constraints)
+        d2 = policy.select(constraints)
+        assert d1.provider_name == d2.provider_name
+        assert d1.score == d2.score
+        assert d1.model == d2.model
+
+    def test_weights_exposed_as_properties(self):
+        policy = RoutingPolicy(
+            self.registry,
+            cost_weight=2.0,
+            latency_weight=3.0,
+            privacy_weight=0.5,
+            availability_weight=1.5,
+        )
+        assert policy.cost_weight == 2.0
+        assert policy.latency_weight == 3.0
+        assert policy.privacy_weight == 0.5
+        assert policy.availability_weight == 1.5
+
+
+class TestRoutingPolicyTaskType:
+    @pytest.fixture(autouse=True)
+    def _make_registry(self):
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(
+            name="json_capable",
+            capabilities=ProviderCapabilities(json_mode=True, vision=False),
+            cost_per_1k_input=Decimal("0.0001"),
+        ))
+        registry.register(_FakeProvider(
+            name="vision_capable",
+            capabilities=ProviderCapabilities(json_mode=False, vision=True),
+            cost_per_1k_input=Decimal("0.0002"),
+        ))
+        self._registry = registry
+
+    @property
+    def registry(self):
+        return self._registry
+
+    def test_json_task_type_favors_json_capable(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(task_type=TaskType.JSON))
+        assert decision.provider_name == "json_capable"
+
+    def test_vision_task_requires_vision_capability(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(
+            task_type=TaskType.VISION,
+            require_capabilities={"vision"},
+        ))
+        # vision_capable has vision=True, so it should be selected
+        assert decision.provider_name == "vision_capable"
+
+    def test_chat_task_returns_some_provider(self):
+        policy = RoutingPolicy(self.registry)
+        decision = policy.select(RoutingConstraints(task_type=TaskType.CHAT))
+        assert decision.provider_name in ("json_capable", "vision_capable")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FallbackChain
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFallbackChain:
+    @pytest.fixture(autouse=True)
+    def _reset_circuit_breakers(self):
+        cb_registry.reset_all()
+
+    @pytest.mark.asyncio
+    async def test_succeeds_with_first_provider(self):
+        p1 = _FakeProvider(name="primary", fail=False)
+        p2 = _FakeProvider(name="secondary", fail=False)
+
+        registry = ProviderRegistry()
+        registry.register(p1)
+        registry.register(p2)
+
+        # Register circuit breakers
+        cb_registry.get("primary")
+        cb_registry.get("secondary")
+
+        chain = FallbackChain(["primary", "secondary"])
+
+        async def call(provider_name: str) -> str:
+            provider = registry.get(provider_name)
+            await provider.complete("model", [])
+            return f"result from {provider_name}"
+
+        result = await chain.execute(call)
+        assert result.success is True
+        assert result.provider_name == "primary"
+        assert result.result == "result from primary"
+        assert result.total_attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_failure(self):
+        p1 = _FakeProvider(name="failing", fail=True)
+        p2 = _FakeProvider(name="backup", fail=False)
+
+        registry = ProviderRegistry()
+        registry.register(p1)
+        registry.register(p2)
+
+        cb_registry.get("failing")
+        cb_registry.get("backup")
+
+        chain = FallbackChain(["failing", "backup"])
+
+        async def call(provider_name: str) -> str:
+            provider = registry.get(provider_name)
+            await provider.complete("model", [])
+            return f"result from {provider_name}"
+
+        result = await chain.execute(call)
+        assert result.success is True
+        assert result.provider_name == "backup"
+        assert result.result == "result from backup"
+        assert len(result.attempts) == 1  # one failure
+        assert result.total_attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_all_providers_fail(self):
+        p1 = _FakeProvider(name="fail1", fail=True)
+        p2 = _FakeProvider(name="fail2", fail=True)
+
+        registry = ProviderRegistry()
+        registry.register(p1)
+        registry.register(p2)
+
+        cb_registry.get("fail1")
+        cb_registry.get("fail2")
+
+        chain = FallbackChain(["fail1", "fail2"])
+
+        async def call(provider_name: str) -> str:
+            provider = registry.get(provider_name)
+            await provider.complete("model", [])
+            return "ok"
+
+        result = await chain.execute(call)
+        assert result.success is False
+        assert result.provider_name == ""
+        assert result.result is None
+        assert len(result.attempts) == 2
+        assert result.total_attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_chain_returns_failure(self):
+        cb_registry.get("anything")  # Register to avoid missing cb
+
+        chain = FallbackChain([])
+        async def call(provider_name: str) -> str:
+            return "ok"
+
+        result = await chain.execute(call)
+        assert result.success is False
+        assert result.total_attempts == 0
+
+    @pytest.mark.asyncio
+    async def test_strategy_ordered_property(self):
+        chain = FallbackChain(["a", "b"], strategy=FallbackStrategy.ORDERED)
+        assert chain.strategy == FallbackStrategy.ORDERED
+        assert chain.providers == ["a", "b"]
+
+    async def _make_fake_provider(self, name: str, fail: bool = False) -> _FakeProvider:
+        return _FakeProvider(name=name, fail=fail)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# UsageTracker
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestUsageTracker:
+    @pytest.fixture(autouse=True)
+    def _make_registry_and_tracker(self):
+        registry = ProviderRegistry()
+        registry.register(_FakeProvider(
+            name="tracked-provider",
+            cost_per_1k_input=Decimal("0.01"),
+            cost_per_1k_output=Decimal("0.03"),
+        ))
+        self._registry = registry
+        self._tracker = UsageTracker(registry)
+        return registry
+
+    @property
+    def registry(self):
+        return self._registry
+
+    @property
+    def tracker(self):
+        return self._tracker
+
+    @pytest.mark.asyncio
+    async def test_record_creates_usage_record(self):
+        record = await self.tracker.record(
+            provider_name="tracked-provider",
+            model="fake-model",
+            prompt_tokens=100,
+            completion_tokens=50,
+        )
+        assert isinstance(record, UsageRecord)
+        assert record.provider_name == "tracked-provider"
+        assert record.prompt_tokens == 100
+        assert record.completion_tokens == 50
+        assert record.total_tokens == 150
+        assert record.success is True
+        assert record.cost_usd > Decimal("0")
+        assert record.timestamp > 0
+
+    @pytest.mark.asyncio
+    async def test_record_unknown_provider_uses_zero_cost(self):
+        record = await self.tracker.record(
+            provider_name="unknown",
+            model="m",
+            prompt_tokens=100,
+            completion_tokens=50,
+        )
+        assert record.cost_usd == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_snapshot_aggregates_correctly(self):
+        await self.tracker.record("tracked-provider", "m1", 100, 50)
+        await self.tracker.record("tracked-provider", "m2", 200, 100)
+
+        snapshot = self.tracker.snapshot()
+        assert snapshot.total_prompt_tokens == 300
+        assert snapshot.total_completion_tokens == 150
+        assert snapshot.total_cost_usd > Decimal("0")
+        assert snapshot.record_count == 2
+
+        prov = snapshot.provider_totals["tracked-provider"]
+        assert prov["prompt_tokens"] == 300
+        assert prov["completion_tokens"] == 150
+        assert prov["request_count"] == 2
+        assert prov["success_count"] == 2
+        assert prov["failure_count"] == 0
+
+    def test_snapshot_empty_tracker(self):
+        snapshot = self.tracker.snapshot()
+        assert snapshot.total_prompt_tokens == 0
+        assert snapshot.total_completion_tokens == 0
+        assert snapshot.total_cost_usd == Decimal("0")
+        assert snapshot.record_count == 0
+        assert snapshot.provider_totals == {}
+
+    def test_provider_usage_returns_aggregated_data(self):
+        usage = self.tracker.provider_usage("tracked-provider")
+        # No records recorded yet
+        assert usage == {}
+
+    def test_check_budget_within_limits(self):
+        config = BudgetConfig(max_cost_usd=Decimal("100"))
+        within = self.tracker.check_budget(config)
+        assert within is True
+
+    def test_check_budget_exceeded(self):
+        config = BudgetConfig(max_cost_usd=Decimal("0.000001"))
+        # Budget is so low it's already exceeded (0 > budget)
+        # Since no records exist, total cost is 0 which is NOT >= 0.000001
+        within = self.tracker.check_budget(config)
+        assert within is True
+
+    @pytest.mark.asyncio
+    async def test_check_budget_exceeded_with_records(self):
+        config = BudgetConfig(max_cost_usd=Decimal("0.00001"))
+        await self.tracker.record("tracked-provider", "m", 1000, 500)
+        within = self.tracker.check_budget(config)
+        assert within is False
+
+    @pytest.mark.asyncio
+    async def test_check_budget_provider_specific(self):
+        config = BudgetConfig(max_requests=1)
+        await self.tracker.record("tracked-provider", "m", 10, 5)
+        # Check budget for this specific provider
+        within = self.tracker.check_budget(config, provider_name="tracked-provider")
+        assert within is False
+
+    def test_check_budget_max_tokens(self):
+        config = BudgetConfig(max_total_tokens=100)
+        within = self.tracker.check_budget(config)
+        assert within is True  # 0 < 100
+
+    def test_check_budget_none_values_are_ignored(self):
+        config = BudgetConfig(max_cost_usd=None, max_total_tokens=None, max_requests=None)
+        within = self.tracker.check_budget(config)
+        assert within is True
+
+    def test_clear_resets_all_records(self):
+        tracker = UsageTracker(self.registry)
+        snapshot = tracker.snapshot()
+        assert snapshot.record_count == 0
+
+    @pytest.mark.asyncio
+    async def test_persist_callback_is_called(self):
+        callback_records = []
+
+        def callback(record: UsageRecord) -> None:
+            callback_records.append(record)
+
+        tracker = UsageTracker(self.registry, persist_callback=callback)
+        await tracker.record("tracked-provider", "m", 10, 5)
+        assert len(callback_records) == 1
+        assert callback_records[0].provider_name == "tracked-provider"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _build_default_registry
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class MockSettings:
+    """Minimal settings stub for testing _build_default_registry."""
+
+    def __init__(
+        self,
+        groq_api_key: str = "",
+        openai_api_key: str = "",
+        groq_model: str = "llama-3.3-70b-versatile",
+        openai_model: str = "gpt-4o-mini",
+    ) -> None:
+        self.groq_api_key = groq_api_key
+        self.openai_api_key = openai_api_key
+        self.groq_model = groq_model
+        self.openai_model = openai_model
+
+    def secret_value(self, name: str, legacy_value: str | None = None) -> str:
+        return getattr(self, name, legacy_value or "")
+
+
+class TestBuildDefaultRegistry:
+    def test_builds_with_both_providers(self):
+        settings = MockSettings(
+            groq_api_key="gsk-test",
+            openai_api_key="sk-test",
+        )
+        registry = _build_default_registry(settings)
+        assert registry.count() == 2
+        assert "groq" in registry.available()
+        assert "openai" in registry.available()
+
+    def test_builds_with_groq_only(self):
+        settings = MockSettings(groq_api_key="gsk-test")
+        registry = _build_default_registry(settings)
+        assert registry.count() == 1
+        assert "groq" in registry.available()
+        assert "openai" not in registry.available()
+
+    def test_builds_with_openai_only(self):
+        settings = MockSettings(openai_api_key="sk-test")
+        registry = _build_default_registry(settings)
+        assert registry.count() == 1
+        assert "openai" in registry.available()
+        assert "groq" not in registry.available()
+
+    def test_builds_empty_registry_with_no_keys(self):
+        settings = MockSettings()
+        registry = _build_default_registry(settings)
+        assert registry.count() == 0
+
+    def test_build_sets_default_models(self):
+        settings = MockSettings(
+            groq_api_key="gsk-test",
+            openai_api_key="sk-test",
+            groq_model="mixtral-8x7b-32768",
+            openai_model="gpt-4o",
+        )
+        registry = _build_default_registry(settings)
+        assert registry.get("groq").metadata.default_model == "mixtral-8x7b-32768"
+        assert registry.get("openai").metadata.default_model == "gpt-4o"
+
+    def test_build_sets_costs(self):
+        settings = MockSettings(
+            groq_api_key="gsk-test",
+            openai_api_key="sk-test",
+        )
+        registry = _build_default_registry(settings)
+        groq = registry.get("groq")
+        openai = registry.get("openai")
+        assert groq.metadata.cost_per_1k_input == Decimal("0.0001")
+        assert openai.metadata.cost_per_1k_input == Decimal("0.00015")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fallback helper: _summarise_exception
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSummariseException:
+    def test_short_message(self):
+        result = _summarise_exception(ValueError("something bad"))
+        assert result == "ValueError: something bad"
+
+    def test_long_message_truncated(self):
+        long_msg = "x" * 500
+        result = _summarise_exception(RuntimeError(long_msg))
+        assert len(result) <= 220  # "RuntimeError: " (14) + 197 + "..."
+        assert result.endswith("...")
+
+    def test_custom_exception(self):
+        class CustomError(Exception):
+            pass
+
+        result = _summarise_exception(CustomError("custom"))
+        assert result == "CustomError: custom"


### PR DESCRIPTION
## Overview

This PR adds a policy-driven **Model Routing and Fallback** system that routes LLM model calls by task type, cost, latency, privacy, and availability — with circuit-breaker integration, deterministic scoring, and budget enforcement — while preserving predictable failure behaviour.

## Related Issue

Closes #233

## Changes

### Provider Registry & Abstractions

- **[ADD]** `packages/prime-agent/src/talos_agent/routing/provider.py`
  - `LLMProvider` abstract base class with `complete()` and `check_health()`.
  - `OpenAIClientProvider` factory wrapping `AsyncOpenAI` for Groq/OpenAI/any OpenAI-compatible endpoint.
  - `ProviderRegistry` singleton with registration, lookup, cost estimation, and health status.
  - `ProviderMetadata`, `ProviderCapabilities` for typed provider descriptions.

### Routing Policy Engine

- **[ADD]** `packages/prime-agent/src/talos_agent/routing/policy.py`
  - `RoutingPolicy` with configurable scoring weights (cost, latency, privacy, availability).
  - `RoutingConstraints` for task type, cost budget, latency budget, privacy level, capability requirements, and preferred provider fast-path.
  - Deterministic selection — same constraints always produce the same provider.
  - `NoSuitableProviderError` for failed routing with diagnostics.

### Fallback Chain

- **[ADD]** `packages/prime-agent/src/talos_agent/routing/fallback.py`
  - `FallbackChain` tries providers in priority order with circuit-breaker integration.
  - Skips providers with OPEN circuit breakers; records success/failure on the appropriate breaker.
  - Supports ORDERED and ROUND_ROBIN strategies.

### Usage Tracking & Budgeting

- **[ADD]** `packages/prime-agent/src/talos_agent/routing/usage.py`
  - `UsageTracker` records token counts, costs, and success/failure per provider.
  - `BudgetConfig` with per-provider or global limits on cost, tokens, and request count.
  - `UsageSnapshot` for telemetry and operational visibility.

### Agent Loop Integration

- **[MODIFY]** `packages/prime-agent/src/talos_agent/agent/loop.py`
  - New `_routed_agent_loop()` uses the routing system when `model_routing_enabled` is True.
  - Legacy `_legacy_agent_loop()` preserved exactly for backward compatibility (default).
  - `agent_loop()` function dispatches to the appropriate implementation based on config.

### Configuration

- **[MODIFY]** `packages/prime-agent/src/talos_agent/config.py`
  - `model_routing_enabled` (default: False) — master switch, backward compatible.
  - `routing_fallback_enabled` (default: True) — enable/disable fallback to alternatives.
  - `routing_max_cost_usd` (default: 0 = no limit) — cost-aware routing.
  - `routing_preferred_provider` — explicit provider override.
  - `routing_budget_enabled` (default: False) — opt-in usage accounting.

### Tests

- **[ADD]** `packages/prime-agent/tests/test_model_routing.py` — 63 tests covering:
  - Provider capabilities and metadata
  - ProviderRegistry operations (register, lookup, duplicates, cost estimation, status)
  - RoutingPolicy selection with all constraint types (cost, latency, privacy, capabilities, task type)
  - Preferred provider fast path and error cases
  - Deterministic selection verification
  - FallbackChain success, fallback, all-failures
  - UsageTracker recording, aggregation, snapshots, budget enforcement
  - `_build_default_registry()` factory (both providers, single provider, empty)

## Verification Results

```
python3 -m pytest tests/test_model_routing.py -v
✅ 63/63 passed

python3 -m pytest tests/test_http_retry.py tests/test_circuit_breaker.py tests/test_model_routing.py -v
✅ 136/136 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Primary behaviour implemented end-to-end, disabled by default (backward compatible) | ✅ `model_routing_enabled` defaults to `False` |
| Concurrency, retries, partial failure, timeout, restart have deterministic handling | ✅ Circuit breaker integration, `NoSuitableProviderError`, idempotent scoring |
| Unit tests cover core logic and failure branches | ✅ 63 routing tests + 73 existing tests all pass |
| Security boundaries and sensitive-data handling explicitly tested | ✅ Inherits existing secret redaction from `http.py`, no secrets in routing metadata |
| Existing lint, type checks, tests, builds remain green | ✅ All 136 tests pass — no regressions |