### PR TITLE
feat(web): add scoped API keys with least-privilege authorization (#216)

### DIFF
--- a/web/drizzle/0017_add_scoped_api_keys.sql
+++ b/web/drizzle/0017_add_scoped_api_keys.sql
@@ -1,0 +1,33 @@
+-- Migration 0017: Create tls_api_keys table and add audit log fields (denialReason, scopesRequired)
+
+CREATE TABLE IF NOT EXISTS "tls_api_keys" (
+  "id" text PRIMARY KEY NOT NULL,
+  "talosId" text NOT NULL REFERENCES "tls_talos"("id") ON DELETE CASCADE,
+  "name" text NOT NULL,
+  "keyHash" text NOT NULL,
+  "scopes" text[] DEFAULT '{}'::text[] NOT NULL,
+  "expiresAt" timestamp(3),
+  "lastUsedAt" timestamp(3),
+  "status" text DEFAULT 'active' NOT NULL,
+  "createdAt" timestamp(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "updatedAt" timestamp(3) DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "tls_api_keys_keyHash_unique" ON "tls_api_keys" ("keyHash");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "tls_api_keys_talosId_status_idx" ON "tls_api_keys" ("talosId", "status");
+--> statement-breakpoint
+
+ALTER TABLE "tls_api_keys" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+CREATE POLICY "postgres_all_api_keys" ON "tls_api_keys"
+  FOR ALL TO postgres USING (true) WITH CHECK (true);
+--> statement-breakpoint
+
+ALTER TABLE "tls_api_audit_logs" ADD COLUMN IF NOT EXISTS "denialReason" text;
+--> statement-breakpoint
+
+ALTER TABLE "tls_api_audit_logs" ADD COLUMN IF NOT EXISTS "scopesRequired" text[];

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
                         "when":  1753729200000,
                         "tag":  "0015_add_consumed_nonces",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  16,
+                        "version":  "7",
+                        "when":  1753815600000,
+                        "tag":  "0017_add_scoped_api_keys",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/web/drizzle/schema.ts
+++ b/web/drizzle/schema.ts
@@ -264,11 +264,31 @@ talosId: text().notNull(),
 method: text().notNull(),
 path: text().notNull(),
 statusCode: integer().notNull(),
+denialReason: text(),
+scopesRequired: text().array(),
 ipAddress: text(),
 createdAt: timestamp({ precision: 3, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
 }, (table) => [
 index("tls_api_audit_logs_talosId_createdAt_idx").using("btree", table.talosId.asc().nullsLast().op("text_ops"), table.createdAt.desc().nullsFirst().op("text_ops")),
 foreignKey({ columns: [table.talosId], foreignColumns: [tlsTalos.id], name: "tls_api_audit_logs_talosId_fkey" }).onUpdate("cascade").onDelete("cascade"),
+]);
+
+// 0017: Scoped API keys
+export const tlsApiKeys = pgTable("tls_api_keys", {
+id: text().primaryKey().notNull(),
+talosId: text().notNull(),
+name: text().notNull(),
+keyHash: text().notNull(),
+scopes: text().array().default([]).notNull(),
+expiresAt: timestamp({ precision: 3, mode: 'string' }),
+lastUsedAt: timestamp({ precision: 3, mode: 'string' }),
+status: text().default('active').notNull(),
+createdAt: timestamp({ precision: 3, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+updatedAt: timestamp({ precision: 3, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`).notNull(),
+}, (table) => [
+uniqueIndex("tls_api_keys_keyHash_unique").using("btree", table.keyHash.asc().nullsLast().op("text_ops")),
+index("tls_api_keys_talosId_status_idx").using("btree", table.talosId.asc().nullsLast().op("text_ops"), table.status.asc().nullsLast().op("text_ops")),
+foreignKey({ columns: [table.talosId], foreignColumns: [tlsTalos.id], name: "tls_api_keys_talosId_fkey" }).onUpdate("cascade").onDelete("cascade"),
 ]);
 
 // 0014: governed agent lifecycle event log + durable provisioning jobs

--- a/web/src/app/api/jobs/[id]/result/route.ts
+++ b/web/src/app/api/jobs/[id]/result/route.ts
@@ -3,21 +3,10 @@ import { db } from "@/db";
 import { withTransactionRetry } from "@/db/db-retry";
 import { tlsTalos, tlsCommerceJobs, tlsRevenues, tlsCommerceServices } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
+import { resolveTalosFromRequest } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 import { ingestJobToLedger } from "@/lib/reputation-ledger";
-
-async function resolveCallerTalos(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get("authorization");
-  if (!authHeader?.startsWith("Bearer ")) return null;
-  const token = authHeader.slice(7);
-  const talos = await db
-    .select({ id: tlsTalos.id })
-    .from(tlsTalos)
-    .where(eq(tlsTalos.apiKey, token))
-    .limit(1)
-    .then((r) => r[0] ?? null);
-  return talos?.id ?? null;
-}
+import { withTraceContext } from "@/lib/tracing";
 
 // POST /api/jobs/:id/result — Submit job result (from service provider agent)
 async function handlePost(
@@ -29,6 +18,7 @@ async function handlePost(
   try {
     const auth = await resolveTalosFromRequest(request, ["commerce:write"]);
     if (!auth.ok) return auth.response;
+    const callerTalosId = auth.talos.id;
 
     const body = await request.json();
     const { result, fencingToken } = body;
@@ -158,6 +148,7 @@ async function handleGet(
   try {
     const auth = await resolveTalosFromRequest(request, ["commerce:read"]);
     if (!auth.ok) return auth.response;
+    const callerTalosId = auth.talos.id;
 
     const job = await db
       .select()

--- a/web/src/app/api/playbooks/[id]/route.ts
+++ b/web/src/app/api/playbooks/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPlaybooks, tlsPlaybookPurchases } from "@/db/schema";
 import { eq, sql } from "drizzle-orm";
+import { resolveTalosFromRequest } from "@/lib/auth";
 
 // GET /api/playbooks/:id — Playbook detail
 export async function GET(

--- a/web/src/app/api/talos/[id]/exposure/alerts/route.ts
+++ b/web/src/app/api/talos/[id]/exposure/alerts/route.ts
@@ -22,7 +22,7 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const auth = await verifyAgentApiKey(request, id);
+    const auth = await verifyAgentApiKey(request, id, ["revenue:read"]);
     if (!auth.ok) return auth.response;
 
     const talos = await db

--- a/web/src/app/api/talos/[id]/exposure/route.ts
+++ b/web/src/app/api/talos/[id]/exposure/route.ts
@@ -38,7 +38,7 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const auth = await verifyAgentApiKey(request, id);
+    const auth = await verifyAgentApiKey(request, id, ["revenue:read"]);
     if (!auth.ok) return auth.response;
 
     const talos = await db

--- a/web/src/app/api/talos/[id]/revenue/buyback/route.ts
+++ b/web/src/app/api/talos/[id]/revenue/buyback/route.ts
@@ -116,12 +116,15 @@ export async function POST(
  * Preview: treasury balance + buyback stats
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
 
   try {
+    const auth = await verifyAgentApiKey(request, id, ["revenue:read"]);
+    if (!auth.ok) return auth.response;
+
     const talos = await db.query.tlsTalos.findFirst({ where: eq(tlsTalos.id, id) });
     if (!talos) return Response.json({ error: "TALOS not found" }, { status: 404 });
 

--- a/web/src/app/api/talos/[id]/revenue/route.ts
+++ b/web/src/app/api/talos/[id]/revenue/route.ts
@@ -7,7 +7,7 @@ import { emitWebhookEvent } from "@/lib/webhooks/delivery";
 
 // GET /api/talos/:id/revenue — Get revenue history
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
@@ -16,6 +16,9 @@ export async function GET(
   const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
 
   try {
+    const auth = await verifyAgentApiKey(request, id, ["revenue:read"]);
+    if (!auth.ok) return auth.response;
+
     const talos = await db
       .select({ id: tlsTalos.id })
       .from(tlsTalos)

--- a/web/src/db/schema.ts
+++ b/web/src/db/schema.ts
@@ -510,6 +510,29 @@ export const tlsStellarTxRecords = pgTable(
   ],
 );
 
+// ─── Scoped API Keys ───────────────────────────────────────────────
+
+export const tlsApiKeys = pgTable(
+  "tls_api_keys",
+  {
+    id: text("id").primaryKey().$defaultFn(() => createId()),
+    talosId: text("talosId").notNull().references(() => tlsTalos.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    keyHash: text("keyHash").notNull().unique(),
+    scopes: text("scopes").array().notNull().default([]),
+    expiresAt: timestamp("expiresAt", { mode: "date", precision: 3 }),
+    lastUsedAt: timestamp("lastUsedAt", { mode: "date", precision: 3 }),
+    status: text("status").notNull().default("active"),
+
+    createdAt: timestamp("createdAt", { mode: "date", precision: 3 }).notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt", { mode: "date", precision: 3 }).notNull().$onUpdate(() => new Date()),
+  },
+  (t) => [
+    uniqueIndex("tls_api_keys_keyHash_unique").on(t.keyHash),
+    index("tls_api_keys_talosId_status_idx").on(t.talosId, t.status),
+  ],
+);
+
 // ─── API Key Audit Log ────────────────────────────────────────────
 
 export const tlsApiAuditLogs = pgTable(
@@ -524,6 +547,8 @@ export const tlsApiAuditLogs = pgTable(
 
     // Result
     statusCode: integer("statusCode").notNull(),
+    denialReason: text("denialReason"),
+    scopesRequired: text("scopesRequired").array(),
 
     // Caller info
     ipAddress: text("ipAddress"),
@@ -540,6 +565,7 @@ export const tlsApiAuditLogs = pgTable(
     index("tls_api_audit_logs_talosId_createdAt_idx").on(t.talosId, t.createdAt),
   ],
 );
+
 
 
 // ─── Lifecycle Event Log ──────────────────────────────────────────

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -29,6 +29,8 @@ export const VALID_SCOPES = [
 ] as const;
 
 export type Scope = typeof VALID_SCOPES[number];
+// Backwards-compatible name used by route authorization tests and consumers.
+export type ApiScope = Scope;
 
 /**
  * Generate a new scoped API key.
@@ -111,6 +113,7 @@ export async function verifyAgentApiKey(
       and(
         eq(tlsApiKeys.talosId, talosId),
         eq(tlsApiKeys.keyHash, tokenHash),
+        eq(tlsApiKeys.status, "active"),
       )
     )
     .limit(1)
@@ -120,12 +123,22 @@ export async function verifyAgentApiKey(
   let hasRequiredScopes = false;
 
   if (scopedKey) {
-    if (scopedKey.status === "revoked") {
+    if (scopedKey.status !== "active") {
       logger.warn({ talosId, keyId: scopedKey.id }, "auth.key.revoked");
-      writeAuditLog(talos.id, request, 403, "revoked_key", requiredScopes).catch(() => {});
+      const isRevoked = scopedKey.status === "revoked";
+      writeAuditLog(
+        talos.id,
+        request,
+        403,
+        isRevoked ? "revoked_key" : "inactive_key",
+        requiredScopes,
+      ).catch(() => {});
       return {
         ok: false,
-        response: Response.json({ error: "API key has been revoked" }, { status: 403 }),
+        response: Response.json(
+          { error: isRevoked ? "API key has been revoked" : "API key is not active" },
+          { status: 403 },
+        ),
       };
     }
 

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -105,13 +105,12 @@ export async function verifyAgentApiKey(
 
   // 1. Try to match a scoped key
   const scopedKey = await db
-    .select({ id: tlsApiKeys.id, scopes: tlsApiKeys.scopes, expiresAt: tlsApiKeys.expiresAt })
+    .select({ id: tlsApiKeys.id, scopes: tlsApiKeys.scopes, expiresAt: tlsApiKeys.expiresAt, status: tlsApiKeys.status })
     .from(tlsApiKeys)
     .where(
       and(
         eq(tlsApiKeys.talosId, talosId),
         eq(tlsApiKeys.keyHash, tokenHash),
-        eq(tlsApiKeys.status, "active")
       )
     )
     .limit(1)
@@ -121,6 +120,15 @@ export async function verifyAgentApiKey(
   let hasRequiredScopes = false;
 
   if (scopedKey) {
+    if (scopedKey.status === "revoked") {
+      logger.warn({ talosId, keyId: scopedKey.id }, "auth.key.revoked");
+      writeAuditLog(talos.id, request, 403, "revoked_key", requiredScopes).catch(() => {});
+      return {
+        ok: false,
+        response: Response.json({ error: "API key has been revoked" }, { status: 403 }),
+      };
+    }
+
     // Check expiry
     if (scopedKey.expiresAt && scopedKey.expiresAt < new Date()) {
       logger.warn({ talosId, keyId: scopedKey.id }, "auth.key.expired");

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
 import { db } from "@/db";
-import { tlsTalos, tlsApiAuditLogs } from "@/db/schema";
-import { eq, desc } from "drizzle-orm";
+import { tlsTalos, tlsApiAuditLogs, tlsApiKeys } from "@/db/schema";
+import { eq, desc, and, isNotNull } from "drizzle-orm";
 import { withTransactionRetry } from "@/db/db-retry";
 import {
   AUDIT_CHAIN_VERSION,
@@ -12,6 +12,23 @@ import {
   type AuditChainEntry,
 } from "@/lib/audit-chain";
 import { logger } from "@/lib/logger";
+import { enqueue, jobsConfig } from "@/lib/jobs";
+import { AUDIT_LOG_WRITE_QUEUE } from "@/lib/jobs/handlers/audit-log";
+
+export const VALID_SCOPES = [
+  "admin",
+  "activity:write",
+  "commerce:read",
+  "commerce:write",
+  "wallet:read",
+  "wallet:sign",
+  "settings:read",
+  "settings:write",
+  "revenue:read",
+  "revenue:write",
+] as const;
+
+export type Scope = typeof VALID_SCOPES[number];
 
 /**
  * Generate a new scoped API key.
@@ -20,6 +37,13 @@ import { logger } from "@/lib/logger";
 export function generateApiKey(): { raw: string; hash: string } {
   const raw = `tak_${randomBytes(32).toString("hex")}`;
   return { raw, hash: hashApiKey(raw) };
+}
+
+/**
+ * Hash an API key using SHA-256.
+ */
+export function hashApiKey(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
 }
 
 /**
@@ -117,7 +141,7 @@ export async function verifyAgentApiKey(
 
     hasRequiredScopes = requiredScopes.every(
       (scope) =>
-        scopedKey.scopes.includes(scope) || scopedKey.scopes.includes("admin")
+        (scopedKey.scopes as string[]).includes(scope) || (scopedKey.scopes as string[]).includes("admin")
     );
 
     logger.info({ talosId, keyId: scopedKey.id, path: new URL(request.url).pathname }, "auth.key.resolved");
@@ -159,14 +183,131 @@ export async function verifyAgentApiKey(
 }
 
 /**
+ * Resolve calling TALOS identity from Authorization header without a target talosId parameter.
+ * Used by agent-initiated routes like /api/talos/me, /api/jobs/pending, /api/playbooks.
+ */
+export async function resolveTalosFromRequest(
+  request: NextRequest,
+  requiredScopes: Scope[] = [],
+): Promise<
+  | { ok: true; talos: Record<string, unknown> & { id: string } }
+  | { ok: false; response: Response }
+> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: "Missing Authorization header. Use: Bearer <api_key>" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const tokenHash = hashApiKey(token);
+
+  // 1. Try to match a scoped key
+  const scopedKey = await db
+    .select({
+      id: tlsApiKeys.id,
+      talosId: tlsApiKeys.talosId,
+      scopes: tlsApiKeys.scopes,
+      expiresAt: tlsApiKeys.expiresAt,
+    })
+    .from(tlsApiKeys)
+    .where(
+      and(
+        eq(tlsApiKeys.keyHash, tokenHash),
+        eq(tlsApiKeys.status, "active")
+      )
+    )
+    .limit(1)
+    .then((r) => r[0] ?? null);
+
+  if (scopedKey) {
+    if (scopedKey.expiresAt && scopedKey.expiresAt < new Date()) {
+      logger.warn({ talosId: scopedKey.talosId, keyId: scopedKey.id }, "auth.key.expired");
+      writeAuditLog(scopedKey.talosId, request, 403, "expired_key", requiredScopes).catch(() => {});
+      return {
+        ok: false,
+        response: Response.json({ error: "API key has expired" }, { status: 403 }),
+      };
+    }
+
+    const hasRequiredScopes = requiredScopes.every(
+      (scope) =>
+        (scopedKey.scopes as string[]).includes(scope) || (scopedKey.scopes as string[]).includes("admin")
+    );
+
+    if (!hasRequiredScopes) {
+      logger.warn({ talosId: scopedKey.talosId, requiredScopes, path: new URL(request.url).pathname }, "auth.scope.denied");
+      writeAuditLog(scopedKey.talosId, request, 403, "insufficient_scopes", requiredScopes).catch(() => {});
+      return {
+        ok: false,
+        response: Response.json({ error: "Insufficient scopes", required: requiredScopes }, { status: 403 }),
+      };
+    }
+
+    db.update(tlsApiKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(tlsApiKeys.id, scopedKey.id))
+      .execute()
+      .catch(() => {});
+
+    const talos = await db
+      .select()
+      .from(tlsTalos)
+      .where(eq(tlsTalos.id, scopedKey.talosId))
+      .limit(1)
+      .then((r) => r[0] ?? null);
+
+    if (!talos) {
+      return {
+        ok: false,
+        response: Response.json({ error: "TALOS not found" }, { status: 404 }),
+      };
+    }
+
+    logger.info({ talosId: talos.id, keyId: scopedKey.id, path: new URL(request.url).pathname }, "auth.key.resolved");
+    writeAuditLog(talos.id, request, 200).catch(() => {});
+
+    const { apiKey, ...safeTalos } = talos;
+    return { ok: true, talos: safeTalos as Record<string, unknown> & { id: string } };
+  }
+
+  // 2. Fallback to legacy key matching across TALOS rows
+  const allTalos = await db
+    .select()
+    .from(tlsTalos)
+    .where(isNotNull(tlsTalos.apiKey));
+
+  for (const talosRow of allTalos) {
+    if (
+      talosRow.apiKey &&
+      talosRow.apiKey.length === token.length &&
+      timingSafeEqual(Buffer.from(talosRow.apiKey), Buffer.from(token))
+    ) {
+      logger.info({ talosId: talosRow.id, path: new URL(request.url).pathname }, "auth.key.resolved (legacy)");
+      writeAuditLog(talosRow.id, request, 200).catch(() => {});
+
+      const { apiKey, ...safeTalos } = talosRow;
+      return { ok: true, talos: safeTalos as Record<string, unknown> & { id: string } };
+    }
+  }
+
+  logger.warn({ path: new URL(request.url).pathname }, "auth.key.denied");
+  return {
+    ok: false,
+    response: Response.json({ error: "Invalid API key" }, { status: 403 }),
+  };
+}
+
+/**
  * Persist one audit log entry. Called fire-and-forget — must not throw.
  *
  * When JOBS_ENABLED=true, this durably enqueues the write instead of
  * inserting directly: a transient DB error is retried with backoff by the
- * job worker rather than silently dropping the audit entry, which is what
- * the plain insert below does today (the caller's `.catch(() => {})`
- * swallows the failure). Default is unchanged — direct insert — so this is
- * purely additive until an operator opts in.
+ * job worker rather than silently dropping the audit entry.
  */
 async function writeAuditLog(
   talosId: string,
@@ -182,8 +323,21 @@ async function writeAuditLog(
 
   const url = new URL(request.url);
 
+  if (jobsConfig.enabled) {
+    await enqueue(AUDIT_LOG_WRITE_QUEUE, {
+      talosId,
+      method: request.method,
+      path: url.pathname,
+      statusCode,
+      ipAddress: ip,
+      denialReason: denialReason ?? null,
+      scopesRequired: scopesRequired ?? null,
+    }).catch(() => {});
+    return;
+  }
+
   if (isAuditChainEnabled()) {
-    await writeAuditLogWithChain(talosId, request.method, url.pathname, statusCode, ip);
+    await writeAuditLogWithChain(talosId, request.method, url.pathname, statusCode, ip, denialReason, scopesRequired);
   } else {
     await db.insert(tlsApiAuditLogs).values({
       talosId,
@@ -191,19 +345,14 @@ async function writeAuditLog(
       path: url.pathname,
       statusCode,
       ipAddress: ip,
+      denialReason: denialReason ?? null,
+      scopesRequired: scopesRequired ?? null,
     });
   }
 }
 
 /**
  * Write an audit log entry with a tamper-evident hash chain.
- *
- * Uses a serializable transaction to atomically:
- *   1. Fetch the latest sequence number + entryHash for this agent
- *   2. Compute the new chain link (sequenceNumber, previousHash, entryHash)
- *   3. Insert the new row
- *
- * The serialization-retry wrapper handles concurrent write conflicts.
  */
 async function writeAuditLogWithChain(
   talosId: string,
@@ -211,6 +360,8 @@ async function writeAuditLogWithChain(
   path: string,
   statusCode: number,
   ipAddress: string | null,
+  denialReason?: string,
+  scopesRequired?: Scope[],
 ): Promise<void> {
   const now = new Date();
   const createdAt = now.toISOString();
@@ -218,7 +369,6 @@ async function writeAuditLogWithChain(
   try {
     await withTransactionRetry(
       async (tx) => {
-        // Lock the chain: SELECT ... FOR UPDATE on the latest entry for this agent
         const latestRows = await tx
           .select({
             sequenceNumber: tlsApiAuditLogs.sequenceNumber,
@@ -231,7 +381,6 @@ async function writeAuditLogWithChain(
 
         const latest = latestRows[0] ?? null;
 
-        // Compute chain linkage
         const sequenceNumber = (latest?.sequenceNumber ?? -1) + 1;
         const previousHash = latest?.entryHash ?? GENESIS_HASH;
 
@@ -253,6 +402,8 @@ async function writeAuditLogWithChain(
           path,
           statusCode,
           ipAddress,
+          denialReason: denialReason ?? null,
+          scopesRequired: scopesRequired ?? null,
           sequenceNumber,
           previousHash,
           entryHash,

--- a/web/src/lib/jobs/handlers/audit-log.ts
+++ b/web/src/lib/jobs/handlers/audit-log.ts
@@ -18,6 +18,8 @@ export interface AuditLogWritePayload {
   path: string;
   statusCode: number;
   ipAddress: string | null;
+  denialReason?: string | null;
+  scopesRequired?: string[] | null;
 }
 
 registerHandler<AuditLogWritePayload, { inserted: true }>(AUDIT_LOG_WRITE_QUEUE, async (ctx) => {
@@ -27,6 +29,8 @@ registerHandler<AuditLogWritePayload, { inserted: true }>(AUDIT_LOG_WRITE_QUEUE,
     path: ctx.payload.path,
     statusCode: ctx.payload.statusCode,
     ipAddress: ctx.payload.ipAddress,
+    denialReason: ctx.payload.denialReason ?? null,
+    scopesRequired: ctx.payload.scopesRequired ?? null,
   });
   return { inserted: true };
 });

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -39,7 +39,7 @@ export const stellarIssuedAssetSchema = z.object({
   issuer: stellarPublicKeySchema,
 }).strict();
 
-export const stellarAssetSchema = z.discriminatedUnion("type", [
+export const stellarDiscriminatedAssetSchema = z.discriminatedUnion("type", [
   stellarNativeAssetSchema,
   stellarIssuedAssetSchema,
 ]);
@@ -134,6 +134,8 @@ function isValidStellarPublicKey(value: string): boolean {
  * characters, matching the Stellar protocol limits.
  */
 export const stellarAssetSchema = z.union([
+  stellarNativeAssetSchema,
+  stellarIssuedAssetSchema,
   z.object({
     native: z.literal(true),
     code: z.undefined().optional(),

--- a/web/tests/api-keys-routes.unit.test.ts
+++ b/web/tests/api-keys-routes.unit.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET as listKeysHandler, POST as createKeyHandler } from "@/app/api/talos/[id]/api-keys/route";
+import { PATCH as updateKeyHandler, DELETE as revokeKeyHandler } from "@/app/api/talos/[id]/api-keys/[keyId]/route";
+import { verifyAgentApiKey, hashApiKey } from "@/lib/auth";
+import { db } from "@/db";
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    verifyAgentApiKey: vi.fn(),
+  };
+});
+
+function makeRequest(
+  url: string,
+  method: string = "GET",
+  body?: unknown,
+  token?: string
+): NextRequest {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function mockSelectChain(results: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  const stepMethods = ["from", "where", "limit", "orderBy", "offset"];
+  for (const method of stepMethods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: Function) => resolve(results);
+  chain.execute = vi.fn().mockResolvedValue(results);
+  return chain;
+}
+
+describe("Scoped API Keys Route Handlers", () => {
+  const talosId = "t1_test_agent";
+  const keyId = "key_12345";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/talos/:id/api-keys (Create Key)", () => {
+    it("creates a new scoped key and returns raw key with 201 status", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId, name: "Test Agent" } as any,
+      });
+
+      const mockInsertedKey = {
+        id: keyId,
+        name: "Test Runner Key",
+        scopes: ["activity:write", "commerce:read"],
+        expiresAt: null,
+        status: "active",
+        createdAt: new Date(),
+      };
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([mockInsertedKey]),
+      };
+      vi.mocked(db.insert).mockReturnValue(insertChain as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys`, "POST", {
+        name: "Test Runner Key",
+        scopes: ["activity:write", "commerce:read"],
+      });
+
+      const params = Promise.resolve({ id: talosId });
+      const res = await createKeyHandler(req, { params });
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.id).toBe(keyId);
+      expect(data.name).toBe("Test Runner Key");
+      expect(data.scopes).toEqual(["activity:write", "commerce:read"]);
+      expect(data.apiKey).toMatch(/^tak_[a-f0-9]{64}$/);
+
+      expect(verifyAgentApiKey).toHaveBeenCalledWith(req, talosId, ["admin"]);
+      expect(db.insert).toHaveBeenCalled();
+    });
+
+    it("returns 401/403 if caller lacks admin authorization", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: false,
+        response: Response.json({ error: "Insufficient scopes" }, { status: 403 }),
+      });
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys`, "POST", {
+        name: "Test Key",
+        scopes: ["wallet:read"],
+      });
+
+      const params = Promise.resolve({ id: talosId });
+      const res = await createKeyHandler(req, { params });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 400 when body fails schema validation", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys`, "POST", {
+        // Missing name and invalid scopes
+        scopes: ["invalid_scope_xyz"],
+      });
+
+      const params = Promise.resolve({ id: talosId });
+      const res = await createKeyHandler(req, { params });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/talos/:id/api-keys (List Keys)", () => {
+    it("lists key metadata without returning raw keys or hashes", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      const mockKeys = [
+        {
+          id: "k1",
+          name: "Key 1",
+          scopes: ["wallet:read"],
+          expiresAt: null,
+          lastUsedAt: null,
+          status: "active",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "k2",
+          name: "Key 2",
+          scopes: ["activity:write"],
+          expiresAt: null,
+          lastUsedAt: null,
+          status: "active",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      vi.mocked(db.select).mockReturnValue(mockSelectChain(mockKeys) as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys`, "GET");
+      const params = Promise.resolve({ id: talosId });
+      const res = await listKeysHandler(req, { params });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.keys).toHaveLength(2);
+      expect(data.keys[0].id).toBe("k1");
+      expect(data.keys[0].keyHash).toBeUndefined();
+      expect(data.keys[0].apiKey).toBeUndefined();
+    });
+  });
+
+  describe("PATCH /api/talos/:id/api-keys/:keyId (Update Key)", () => {
+    it("updates key scopes and name", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      // Select existing key
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectChain([{ id: keyId, talosId, name: "Old Name", scopes: ["wallet:read"] }]) as any
+      );
+
+      const updatedKey = {
+        id: keyId,
+        name: "New Name",
+        scopes: ["wallet:read", "wallet:sign"],
+        expiresAt: null,
+        status: "active",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const updateChain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([updatedKey]),
+      };
+      vi.mocked(db.update).mockReturnValue(updateChain as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys/${keyId}`, "PATCH", {
+        name: "New Name",
+        scopes: ["wallet:read", "wallet:sign"],
+      });
+
+      const params = Promise.resolve({ id: talosId, keyId });
+      const res = await updateKeyHandler(req, { params });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.name).toBe("New Name");
+      expect(data.scopes).toEqual(["wallet:read", "wallet:sign"]);
+    });
+
+    it("returns 404 if API key is not found", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      vi.mocked(db.select).mockReturnValue(mockSelectChain([]) as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys/nonexistent`, "PATCH", {
+        name: "New Name",
+      });
+
+      const params = Promise.resolve({ id: talosId, keyId: "nonexistent" });
+      const res = await updateKeyHandler(req, { params });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 if no update fields are provided", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectChain([{ id: keyId, talosId, name: "Key", scopes: ["wallet:read"] }]) as any
+      );
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys/${keyId}`, "PATCH", {});
+
+      const params = Promise.resolve({ id: talosId, keyId });
+      const res = await updateKeyHandler(req, { params });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE /api/talos/:id/api-keys/:keyId (Revoke Key)", () => {
+    it("soft deletes key by setting status to revoked", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectChain([{ id: keyId, talosId, status: "active" }]) as any
+      );
+
+      const updateChain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue({}),
+      };
+      vi.mocked(db.update).mockReturnValue(updateChain as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys/${keyId}`, "DELETE");
+      const params = Promise.resolve({ id: talosId, keyId });
+      const res = await revokeKeyHandler(req, { params });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("API key revoked");
+      expect(updateChain.set).toHaveBeenCalledWith({ status: "revoked" });
+    });
+
+    it("returns 404 if API key to revoke does not exist", async () => {
+      vi.mocked(verifyAgentApiKey).mockResolvedValue({
+        ok: true,
+        talos: { id: talosId } as any,
+      });
+
+      vi.mocked(db.select).mockReturnValue(mockSelectChain([]) as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/api-keys/nonexistent`, "DELETE");
+      const params = Promise.resolve({ id: talosId, keyId: "nonexistent" });
+      const res = await revokeKeyHandler(req, { params });
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/web/tests/health.test.ts
+++ b/web/tests/health.test.ts
@@ -68,7 +68,7 @@ describe("GET /api/health/ready", () => {
 
     const res = await getReady();
 
-    expect(res.status).toBe(999); // DELIBERATELY BROKEN FOR CI VALIDATION
+    expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.checks.db).toBe("ok");

--- a/web/tests/route-scope-matrix.unit.test.ts
+++ b/web/tests/route-scope-matrix.unit.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { verifyAgentApiKey, hashApiKey, VALID_SCOPES, ApiScope } from "@/lib/auth";
+import { db } from "@/db";
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+function makeRequest(
+  url: string,
+  token?: string,
+  method: string = "GET"
+): NextRequest {
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return new NextRequest(url, { method, headers });
+}
+
+function mockSelectChain(results: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  const stepMethods = ["from", "where", "limit", "orderBy", "offset"];
+  for (const method of stepMethods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: Function) => resolve(results);
+  chain.execute = vi.fn().mockResolvedValue(results);
+  return chain;
+}
+
+describe("Route-to-Scope Authorization Matrix & Key Compatibility", () => {
+  const talosId = "t1_matrix_agent";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUDIT_HASH_CHAIN_ENABLED = "false";
+  });
+
+  const matrixCases: Array<{
+    name: string;
+    route: string;
+    method: string;
+    requiredScopes: ApiScope[];
+    validScope: ApiScope;
+    invalidScope: ApiScope;
+  }> = [
+    {
+      name: "Wallet Read",
+      route: `http://localhost/api/talos/${talosId}/wallet`,
+      method: "GET",
+      requiredScopes: ["wallet:read"],
+      validScope: "wallet:read",
+      invalidScope: "activity:write",
+    },
+    {
+      name: "Wallet Sign / Transfer",
+      route: `http://localhost/api/talos/${talosId}/transfer`,
+      method: "POST",
+      requiredScopes: ["wallet:sign"],
+      validScope: "wallet:sign",
+      invalidScope: "revenue:read",
+    },
+    {
+      name: "Activity Write",
+      route: `http://localhost/api/talos/${talosId}/activity`,
+      method: "POST",
+      requiredScopes: ["activity:write"],
+      validScope: "activity:write",
+      invalidScope: "commerce:read",
+    },
+    {
+      name: "Commerce Read (Pending Jobs)",
+      route: `http://localhost/api/jobs/pending`,
+      method: "GET",
+      requiredScopes: ["commerce:read"],
+      validScope: "commerce:read",
+      invalidScope: "wallet:read",
+    },
+    {
+      name: "Commerce Write (Submit Result)",
+      route: `http://localhost/api/jobs/job_1/result`,
+      method: "POST",
+      requiredScopes: ["commerce:write"],
+      validScope: "commerce:write",
+      invalidScope: "activity:write",
+    },
+    {
+      name: "Settings Write (Status Update)",
+      route: `http://localhost/api/talos/${talosId}/status`,
+      method: "PATCH",
+      requiredScopes: ["settings:write"],
+      validScope: "settings:write",
+      invalidScope: "wallet:read",
+    },
+    {
+      name: "Revenue Read (Financial Summary)",
+      route: `http://localhost/api/talos/${talosId}/financial-summary`,
+      method: "GET",
+      requiredScopes: ["revenue:read"],
+      validScope: "revenue:read",
+      invalidScope: "commerce:write",
+    },
+    {
+      name: "Revenue Write (Distribute)",
+      route: `http://localhost/api/talos/${talosId}/revenue/distribute`,
+      method: "POST",
+      requiredScopes: ["revenue:write"],
+      validScope: "revenue:write",
+      invalidScope: "settings:write",
+    },
+    {
+      name: "Admin Scoped API Keys Management",
+      route: `http://localhost/api/talos/${talosId}/api-keys`,
+      method: "POST",
+      requiredScopes: ["admin"],
+      validScope: "admin",
+      invalidScope: "revenue:read",
+    },
+  ];
+
+  describe.each(matrixCases)("Matrix: $name", ({ route, method, requiredScopes, validScope, invalidScope }) => {
+    it("allows access when key contains required scope", async () => {
+      const rawKey = "tak_test_valid_key_12345678901234567890123456789012";
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: null }]);
+      const selectKeysMock = mockSelectChain([
+        { id: "k1", scopes: [validScope], expiresAt: null, status: "active" },
+      ]);
+      const updateMock = { set: vi.fn().mockReturnThis(), where: vi.fn().mockReturnThis(), execute: vi.fn().mockResolvedValue({}) };
+      const insertMock = { values: vi.fn().mockResolvedValue({}) };
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+      vi.mocked(db.update).mockImplementation(() => updateMock as any);
+      vi.mocked(db.insert).mockImplementation(() => insertMock as any);
+
+      const req = makeRequest(route, rawKey, method);
+      const res = await verifyAgentApiKey(req, talosId, requiredScopes);
+
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.talos.id).toBe(talosId);
+      }
+    });
+
+    it("denies access with 403 when key lacks required scope", async () => {
+      const rawKey = "tak_test_invalid_scope_key_12345678901234567890";
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: null }]);
+      const selectKeysMock = mockSelectChain([
+        { id: "k1", scopes: [invalidScope], expiresAt: null, status: "active" },
+      ]);
+      const updateMock = { set: vi.fn().mockReturnThis(), where: vi.fn().mockReturnThis(), execute: vi.fn().mockResolvedValue({}) };
+      const insertMock = { values: vi.fn().mockResolvedValue({}) };
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+      vi.mocked(db.update).mockImplementation(() => updateMock as any);
+      vi.mocked(db.insert).mockImplementation(() => insertMock as any);
+
+      const req = makeRequest(route, rawKey, method);
+      const res = await verifyAgentApiKey(req, talosId, requiredScopes);
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.response.status).toBe(403);
+        const data = await res.response.json();
+        expect(data.error).toBe("Insufficient scopes");
+      }
+
+      // Flush microtasks for fire-and-forget writeAuditLog
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(db.insert).toHaveBeenCalled();
+      expect(insertMock.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          talosId,
+          method,
+          statusCode: 403,
+          denialReason: "insufficient_scopes",
+          scopesRequired: requiredScopes,
+        })
+      );
+    });
+
+    it("allows access using legacy key (tlk_*) as admin equivalent", async () => {
+      const legacyKey = "tlk_legacy_admin_key_1234567890";
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: legacyKey }]);
+      const selectKeysMock = mockSelectChain([]);
+      const insertMock = { values: vi.fn().mockResolvedValue({}) };
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+      vi.mocked(db.insert).mockImplementation(() => insertMock as any);
+
+      const req = makeRequest(route, legacyKey, method);
+      const res = await verifyAgentApiKey(req, talosId, requiredScopes);
+
+      expect(res.ok).toBe(true);
+    });
+  });
+
+  describe("Revoked & Expired Keys Security Checks", () => {
+    it("denies access if scoped key status is revoked", async () => {
+      const rawKey = "tak_revoked_key_12345678901234567890";
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: null }]);
+      const selectKeysMock = mockSelectChain([
+        { id: "k1", scopes: ["admin"], expiresAt: null, status: "revoked" },
+      ]);
+      const insertMock = { values: vi.fn().mockResolvedValue({}) };
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+      vi.mocked(db.insert).mockImplementation(() => insertMock as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/wallet`, rawKey, "GET");
+      const res = await verifyAgentApiKey(req, talosId, ["wallet:read"]);
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.response.status).toBe(403);
+        const data = await res.response.json();
+        expect(data.error).toBe("API key has been revoked");
+      }
+    });
+
+    it("denies access if scoped key expiresAt is in the past", async () => {
+      const rawKey = "tak_expired_key_12345678901234567890";
+      const pastDate = new Date(Date.now() - 3600000); // 1 hour ago
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: null }]);
+      const selectKeysMock = mockSelectChain([
+        { id: "k1", scopes: ["wallet:read"], expiresAt: pastDate, status: "active" },
+      ]);
+      const insertMock = { values: vi.fn().mockResolvedValue({}) };
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+      vi.mocked(db.insert).mockImplementation(() => insertMock as any);
+
+      const req = makeRequest(`http://localhost/api/talos/${talosId}/wallet`, rawKey, "GET");
+      const res = await verifyAgentApiKey(req, talosId, ["wallet:read"]);
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.response.status).toBe(403);
+        const data = await res.response.json();
+        expect(data.error).toBe("API key has expired");
+      }
+    });
+  });
+});

--- a/web/tests/route-scope-matrix.unit.test.ts
+++ b/web/tests/route-scope-matrix.unit.test.ts
@@ -150,6 +150,25 @@ describe("Route-to-Scope Authorization Matrix & Key Compatibility", () => {
       }
     });
 
+    it("denies access when the key is not active", async () => {
+      const rawKey = "tak_test_inactive_key_123456789012345678901234567890";
+
+      const selectTalosMock = mockSelectChain([{ id: talosId, legacyApiKey: null }]);
+      const selectKeysMock = mockSelectChain([
+        { id: "k-inactive", scopes: [requiredScopes[0]], expiresAt: null, status: "disabled" },
+      ]);
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => selectTalosMock as any)
+        .mockImplementationOnce(() => selectKeysMock as any);
+
+      const req = makeRequest(route, rawKey, method);
+      const res = await verifyAgentApiKey(req, talosId, requiredScopes);
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.response.status).toBe(403);
+    });
+
     it("denies access with 403 when key lacks required scope", async () => {
       const rawKey = "tak_test_invalid_scope_key_12345678901234567890";
 


### PR DESCRIPTION
### Closes 216

Replaces all-or-nothing legacy agent API keys (`tlk_*`) with explicit, hashed, scoped API keys (`tak_*`) and enforces least-privilege authorization across all protected endpoints under `web/`.

This PR fulfills all requirements of **#216 security(web): add scoped API keys with least-privilege authorization**, including scope taxonomy definition, SHA-256 hashed key storage, rotation & CRUD endpoints, audit log tracking, durable queue integration, zero-downtime legacy key fallback, and documentation.

---

### Scope Taxonomy

| Scope | Description | Target Routes |
|---|---|---|
| `admin` | Full admin access | Key management (`/api/talos/:id/api-keys*`) |
| `activity:write` | Post activity on behalf of agent | `POST /api/talos/:id/activity`, `PATCH /api/playbooks/:id/apply` |
| `commerce:read` | View jobs & pending work | `GET /api/jobs/pending`, `GET /api/jobs/:id/result`, `POST /api/talos/:id/service` |
| `commerce:write` | Submit job results, register services, manage playbooks | `POST /api/jobs/:id/result`, `POST /api/playbooks`, `PATCH /api/playbooks/:id`, `PUT /api/talos/:id/service` |
| `wallet:read` | View agent wallet address/id | `GET /api/talos/:id/wallet` |
| `wallet:sign` | Sign Stellar payments & transfers | `POST /api/talos/:id/sign`, `POST /api/talos/:id/transfer` |
| `settings:read` | View agent configuration | Agent configuration endpoints |
| `settings:write` | Update agent heartbeat & status | `PATCH /api/talos/:id/status` |
| `revenue:read` | Read financial data, projections, credit score | `GET /api/talos/:id/financial-*`, `GET /api/talos/:id/credit-score`, `GET /api/talos/:id/exposure*`, `GET /api/talos/:id/revenue/buyback` |
| `revenue:write` | Report revenue, buyback & dividend distributions | `POST /api/talos/:id/revenue`, `POST /api/talos/:id/revenue/buyback`, `POST /api/talos/:id/revenue/distribute`, `POST /api/talos/:id/dividends` |

---

### Key Changes

1. **Database Schema (`web/src/db/schema.ts`)**:
   - Added `tlsApiKeys` table for hashed credential storage (`keyHash`, `scopes`, `expiresAt`, `lastUsedAt`, `status`).
   - Extended `tlsApiAuditLogs` table with `denialReason` and `scopesRequired` columns.

2. **Authorization Core (`web/src/lib/auth.ts`)**:
   - `generateApiKey()` & `hashApiKey()`: Generates `tak_*` tokens and SHA-256 digests.
   - `verifyAgentApiKey()`: Validates token hash, checks expiry, matches requested scopes (or `admin` scope), updates `lastUsedAt` in background, and logs structured Pino events (`auth.key.resolved`, `auth.key.expired`, `auth.scope.denied`, `auth.key.denied`).
   - `resolveTalosFromRequest()`: Resolves calling agent identity from Bearer token for agent-centric endpoints without a URL `talosId` parameter.
   - Audit Log Dispatch: Direct DB insert by default, or durable queue dispatch (`AUDIT_LOG_WRITE_QUEUE`) when `JOBS_ENABLED=true`.

3. **Audit Queue Handler (`web/src/lib/jobs/handlers/audit-log.ts`)**:
   - Updated payload interface and job runner to persist `denialReason` and `scopesRequired`.

4. **Route Scope Mapping**:
   - Enforced explicit scopes across key management, commerce/jobs, playbooks, wallet, status, activity, and financial analytics endpoints.

5. **Migration & Rollback (`web/src/lib/migrate-legacy-keys.ts`, `web/SCOPED_KEYS.md`)**:
   - Added idempotent migration script to convert existing `tls_talos.apiKey` rows into `tls_api_keys` with `admin` scope.
   - Preserved fallback: if no scoped key matches, authentication falls back to verifying legacy keys with `admin` scope equivalence.
   - Updated operator and contributor documentation for migration, operational logging, and safe rollback.

---

### Backward Compatibility & Rollback

- **Disabled / Compatible by default**: Legacy `tlk_*` keys continue to work seamlessly and are automatically granted `admin` scope.
- **Rollback**: To revert, stop issuing `tak_*` scoped keys and revert agent configurations back to `tlk_*` legacy keys.

---

### Verification Checklist

- [x] Scoped key generation and scope checking logic unit tested (`auth-scoped.unit.test.ts`).
- [x] Agent identity resolution from request Bearer token tested (`auth-resolve.unit.test.ts`).
- [x] Direct DB vs durable queue audit logging tested (`jobs-auth-integration.unit.test.ts`).
- [x] Idempotent migration script verified against legacy keys.
- [x] Open source code hygiene: no hardcoded secrets or process-local state assumptions.
