### PR TITLE
feat(agent): add adapter retry budgets and circuit breakers

### DIFF
--- a/packages/prime-agent/src/talos_agent/__init__.py
+++ b/packages/prime-agent/src/talos_agent/__init__.py
@@ -11,6 +11,7 @@ from talos_agent.circuit_breaker import (
     CircuitState,
     ProviderCircuitBreaker,
     cb_registry,
+    execute_with_retry,
 )
 
 __version__ = "0.1.0"
@@ -24,4 +25,5 @@ __all__ = [
     "CircuitState",
     "ProviderCircuitBreaker",
     "cb_registry",
+    "execute_with_retry",
 ]

--- a/packages/prime-agent/src/talos_agent/adapters/capability.py
+++ b/packages/prime-agent/src/talos_agent/adapters/capability.py
@@ -22,6 +22,12 @@ from urllib.parse import unquote, urlsplit
 import httpx
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitBreakerOpen,
+    CircuitBreakerRegistry,
+    execute_with_retry,
+)
 from talos_agent.observability import log
 
 _IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
@@ -815,6 +821,7 @@ class AdapterSandbox:
         manifests: Mapping[str, AdapterCapabilityManifest],
         db: object,
         secret_resolver: Callable[[str], str],
+        retry_configs: Mapping[str, Mapping[str, Any]] | None = None,
     ) -> None:
         self._manifests = dict(manifests)
         self._store = AdapterInvocationStore(db)
@@ -824,6 +831,8 @@ class AdapterSandbox:
             for name, manifest in self._manifests.items()
         }
         self._owner_id = str(uuid.uuid4())
+        self._retry_configs = dict(retry_configs or {})
+        self._breakers = CircuitBreakerRegistry()
 
     def manifest(self, adapter_id: str) -> AdapterCapabilityManifest:
         normalized = adapter_id.lower()
@@ -854,6 +863,10 @@ class AdapterSandbox:
             store=self._store,
             semaphore=self._semaphores[adapter_id],
             owner_id=self._owner_id,
+            breaker=self._breakers.get_or_create(
+                adapter_id,
+                CircuitBreakerConfig.from_mapping(self._retry_configs.get(adapter_id)),
+            ),
         )
 
 
@@ -868,12 +881,14 @@ class SandboxedAdapter(BaseSocialAdapter):
         store: AdapterInvocationStore,
         semaphore: asyncio.Semaphore,
         owner_id: str,
+        breaker: Any,
     ) -> None:
         self.__adapter = adapter
         self.__manifest = manifest
         self.__store = store
         self.__semaphore = semaphore
         self.__owner_id = owner_id
+        self.__breaker = breaker
         self.channel_name = adapter.channel_name
 
     def get_capabilities(self) -> ChannelCapabilities:
@@ -967,9 +982,19 @@ class SandboxedAdapter(BaseSocialAdapter):
             )
             acquired = True
             method = getattr(self.__adapter, operation)
-            result = await asyncio.wait_for(
-                method(*args, **kwargs),
-                timeout=max(0.001, deadline - time.monotonic()),
+
+            async def invoke() -> Any:
+                return await asyncio.wait_for(
+                    method(*args, **kwargs),
+                    timeout=max(0.001, deadline - time.monotonic()),
+                )
+
+            result = await execute_with_retry(
+                invoke,
+                self.__breaker,
+                is_failure=lambda value: (
+                    isinstance(value, PublishResult) and value.status == "failed"
+                ),
             )
             output_bytes, output_items = _output_shape(
                 result.to_dict() if isinstance(result, PublishResult) else result

--- a/packages/prime-agent/src/talos_agent/circuit_breaker.py
+++ b/packages/prime-agent/src/talos_agent/circuit_breaker.py
@@ -41,14 +41,19 @@ Usage
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, ClassVar, TypeVar
+
+from talos_agent.observability import log as structured_log
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 # ── Exceptions ────────────────────────────────────────────────────────────────
@@ -108,9 +113,39 @@ class CircuitBreakerConfig:
     window_size: float = 60.0
     """Rolling window size in seconds for failure counting."""
 
+    retry_budget: int = 3
+    """Number of retries permitted for one adapter invocation."""
+
+    backoff_initial: float = 1.0
+    """Initial exponential backoff delay in seconds."""
+
+    backoff_max: float = 30.0
+    """Maximum exponential backoff delay in seconds."""
+
     # ── Pre-built defaults for known providers ────────────────────────────
 
     PROVIDER_DEFAULTS: ClassVar[dict[str, CircuitBreakerConfig]] = {}
+
+    def __post_init__(self) -> None:
+        if self.failure_threshold < 1 or self.half_open_max_probes < 1 or self.success_threshold < 1:
+            raise ValueError("circuit thresholds and probe limits must be at least 1")
+        if self.recovery_timeout <= 0 or self.window_size <= 0:
+            raise ValueError("circuit timeouts must be greater than zero")
+        if self.retry_budget < 0:
+            raise ValueError("retry_budget must not be negative")
+        if self.backoff_initial <= 0 or self.backoff_max <= 0 or self.backoff_initial > self.backoff_max:
+            raise ValueError("backoff_initial must be positive and no greater than backoff_max")
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any] | None = None) -> CircuitBreakerConfig:
+        """Build a validated config from user-provided adapter settings."""
+        if values is None:
+            return cls()
+        allowed = {field for field in cls.__dataclass_fields__ if field != "PROVIDER_DEFAULTS"}
+        unknown = set(values) - allowed
+        if unknown:
+            raise ValueError(f"unknown circuit breaker settings: {', '.join(sorted(unknown))}")
+        return cls(**dict(values))
 
     @classmethod
     def for_provider(cls, provider: str) -> CircuitBreakerConfig:
@@ -254,6 +289,7 @@ class ProviderCircuitBreaker:
         self._total_failures: int = 0
         self._total_rejected: int = 0
         self._total_probes: int = 0
+        self._lock = asyncio.Lock()
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -267,29 +303,25 @@ class ProviderCircuitBreaker:
         * If OPEN and recovery_timeout has elapsed, transitions to HALF_OPEN.
         * If HALF_OPEN, increments the probe counter.
         """
-        now = time.monotonic()
-
-        if self.state == CircuitState.CLOSED:
-            return True
-
-        if self.state == CircuitState.OPEN:
-            elapsed = now - self._last_state_change
-            if elapsed >= self.config.recovery_timeout:
-                self._transition_to(CircuitState.HALF_OPEN, now)
-                self._half_open_probes_used = 1
+        async with self._lock:
+            now = time.monotonic()
+            if self.state == CircuitState.CLOSED:
+                return True
+            if self.state == CircuitState.OPEN:
+                elapsed = now - self._last_state_change
+                if elapsed >= self.config.recovery_timeout:
+                    self._transition_to(CircuitState.HALF_OPEN, now)
+                    self._half_open_probes_used = 1
+                    self._total_probes += 1
+                    return True
+                self._total_rejected += 1
+                return False
+            if self._half_open_probes_used < self.config.half_open_max_probes:
+                self._half_open_probes_used += 1
                 self._total_probes += 1
                 return True
             self._total_rejected += 1
             return False
-
-        # HALF_OPEN — allow up to half_open_max_probes probes.
-        if self._half_open_probes_used < self.config.half_open_max_probes:
-            self._half_open_probes_used += 1
-            self._total_probes += 1
-            return True
-
-        self._total_rejected += 1
-        return False
 
     async def record_success(self) -> None:
         """Record a successful request.
@@ -299,20 +331,15 @@ class ProviderCircuitBreaker:
           when success_threshold is reached.
         * If CLOSED, prunes the failure window.
         """
-        self._total_successes += 1
-
-        if self.state == CircuitState.HALF_OPEN:
-            self._consecutive_successes += 1
-            if self._consecutive_successes >= self.config.success_threshold:
-                logger.info(
-                    "Circuit breaker CLOSED for '%s' — recovery confirmed (%d consecutive successes)",
-                    self.provider,
-                    self._consecutive_successes,
-                )
-                self._transition_to(CircuitState.CLOSED)
-                self._failures.clear()
-        elif self.state == CircuitState.CLOSED:
-            self._prune_window()
+        async with self._lock:
+            self._total_successes += 1
+            if self.state == CircuitState.HALF_OPEN:
+                self._consecutive_successes += 1
+                if self._consecutive_successes >= self.config.success_threshold:
+                    self._transition_to(CircuitState.CLOSED)
+                    self._failures.clear()
+            elif self.state == CircuitState.CLOSED:
+                self._prune_window()
 
     async def record_failure(self) -> None:
         """Record a failed request.
@@ -322,27 +349,17 @@ class ProviderCircuitBreaker:
         * If HALF_OPEN, transitions back to OPEN.
         * If CLOSED and failure_threshold is met, transitions to OPEN.
         """
-        now = time.monotonic()
-        self._total_failures += 1
-        self._last_failure_time = now
-        self._failures.append(now)
-
-        if self.state == CircuitState.HALF_OPEN:
-            logger.warning(
-                "Circuit breaker HALF_OPEN → OPEN for '%s' — probe failed (back to recovery)",
-                self.provider,
-            )
-            self._transition_to(CircuitState.OPEN, now)
-        elif self.state == CircuitState.CLOSED:
-            self._prune_window()
-            if len(self._failures) >= self.config.failure_threshold:
-                logger.warning(
-                    "Circuit breaker OPEN for '%s' — %d failures in %.0fs window",
-                    self.provider,
-                    len(self._failures),
-                    self.config.window_size,
-                )
+        async with self._lock:
+            now = time.monotonic()
+            self._total_failures += 1
+            self._last_failure_time = now
+            self._failures.append(now)
+            if self.state == CircuitState.HALF_OPEN:
                 self._transition_to(CircuitState.OPEN, now)
+            elif self.state == CircuitState.CLOSED:
+                self._prune_window()
+                if len(self._failures) >= self.config.failure_threshold:
+                    self._transition_to(CircuitState.OPEN, now)
 
     def remaining_cooldown(self) -> float | None:
         """Seconds until OPEN → HALF_OPEN transition, or ``None``."""
@@ -380,14 +397,22 @@ class ProviderCircuitBreaker:
     def _transition_to(self, new_state: CircuitState, now: float | None = None) -> None:
         if self.state == new_state:
             return
+        previous_state = self.state
         logger.info(
             "Circuit breaker '%s': %s → %s",
             self.provider,
-            self.state.value,
-            new_state.value,
+            self.state.value.upper(),
+            new_state.value.upper(),
         )
         self.state = new_state
         self._last_state_change = now or time.monotonic()
+        structured_log.info(
+            "circuit_state_change",
+            adapter=self.provider,
+            previous_state=previous_state.value,
+            state=new_state.value,
+            reason="failure_threshold" if new_state == CircuitState.OPEN else "recovery",
+        )
 
         if new_state == CircuitState.OPEN:
             # When transitioning to OPEN from HALF_OPEN, reset consecutive
@@ -458,6 +483,46 @@ class CircuitBreakerRegistry:
 # Module-level singleton — imported by http.py and callers.
 cb_registry: CircuitBreakerRegistry = CircuitBreakerRegistry()
 
+
+async def execute_with_retry(
+    operation: Callable[[], Awaitable[T]],
+    breaker: ProviderCircuitBreaker,
+    *,
+    is_failure: Callable[[T], bool] | None = None,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> T:
+    """Run one adapter operation with its budget and exponential backoff.
+
+    The breaker is admitted once per logical operation. Only the final failed
+    operation consumes a failure, so internal retries do not open the circuit
+    prematurely.
+    """
+    if not await breaker.allow_request():
+        raise CircuitBreakerOpen(
+            breaker.provider, breaker.remaining_cooldown() or 0.0
+        )
+    failure_check = is_failure or (lambda result: False)
+    for attempt in range(breaker.config.retry_budget + 1):
+        try:
+            result = await operation()
+        except Exception:
+            if attempt >= breaker.config.retry_budget:
+                await breaker.record_failure()
+                raise
+        else:
+            if not failure_check(result):
+                await breaker.record_success()
+                return result
+            if attempt >= breaker.config.retry_budget:
+                await breaker.record_failure()
+                return result
+        delay = min(
+            breaker.config.backoff_initial * (2**attempt),
+            breaker.config.backoff_max,
+        )
+        await sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without result")
+
 __all__ = [
     "CircuitBreakerConfig",
     "CircuitBreakerError",
@@ -468,4 +533,5 @@ __all__ = [
     "ProviderCircuitBreaker",
     "_resolve_provider_from_url",
     "cb_registry",
+    "execute_with_retry",
 ]

--- a/packages/prime-agent/src/talos_agent/config.py
+++ b/packages/prime-agent/src/talos_agent/config.py
@@ -6,8 +6,10 @@ import json
 from decimal import Decimal
 from pathlib import Path
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from talos_agent.circuit_breaker import CircuitBreakerConfig
 
 APP_DIR = Path.home() / ".talos-agent"
 
@@ -196,6 +198,23 @@ class Settings(BaseSettings):
         le=1000000,
         validation_alias="TALOS_ADAPTER_MAX_INVOCATION_RECORDS",
     )
+    adapter_retry_configs: dict[str, dict] = Field(
+        default_factory=dict,
+        validation_alias="TALOS_ADAPTER_RETRY_CONFIGS",
+        description="Per-adapter retry and circuit breaker settings as JSON",
+    )
+
+    @field_validator("adapter_retry_configs")
+    @classmethod
+    def validate_adapter_retry_configs(cls, value: dict[str, dict]) -> dict[str, dict]:
+        for adapter, config in value.items():
+            if not isinstance(adapter, str) or not adapter or not isinstance(config, dict):
+                raise ValueError("adapter retry configs must map adapter names to objects")
+            try:
+                CircuitBreakerConfig.from_mapping(config)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"invalid retry config for adapter '{adapter}'") from exc
+        return {adapter.lower(): config for adapter, config in value.items()}
 
     # Policy engine (disabled by default — backward compatible)
     policy_engine_enabled: bool = Field(default=False, description="Enable the declarative policy engine for autonomous actions")

--- a/packages/prime-agent/src/talos_agent/tools/registry.py
+++ b/packages/prime-agent/src/talos_agent/tools/registry.py
@@ -305,6 +305,7 @@ def build_all_tools(
             manifests=manifests,
             db=db,
             secret_resolver=settings.secret_value,
+            retry_configs=settings.adapter_retry_configs,
         )
         adapter_registry = AdapterRegistry(sandbox)
         adapter_registry.register(

--- a/packages/prime-agent/tests/test_adapter_retry_budget.py
+++ b/packages/prime-agent/tests/test_adapter_retry_budget.py
@@ -1,0 +1,113 @@
+"""Tests for adapter retry budgets and circuit admission."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from talos_agent.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitState,
+    ProviderCircuitBreaker,
+    execute_with_retry,
+)
+from talos_agent.config import Settings
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_uses_exponential_backoff_and_records_final_failure():
+    breaker = ProviderCircuitBreaker(
+        "discord",
+        CircuitBreakerConfig(
+            retry_budget=2,
+            backoff_initial=0.25,
+            backoff_max=1.0,
+            failure_threshold=1,
+        ),
+    )
+    delays: list[float] = []
+    calls = 0
+
+    async def operation() -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("temporary failure")
+
+    async def record_delay(delay: float) -> None:
+        delays.append(delay)
+
+    with pytest.raises(RuntimeError):
+        await execute_with_retry(operation, breaker, sleep=record_delay)
+
+    assert calls == 3
+    assert delays == [0.25, 0.5]
+    assert breaker.state == CircuitState.OPEN
+    assert breaker.metrics().total_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_success_resets_budget_after_half_open_probe():
+    breaker = ProviderCircuitBreaker(
+        "telegram",
+        CircuitBreakerConfig(
+            failure_threshold=1,
+            recovery_timeout=0.01,
+            success_threshold=1,
+            retry_budget=1,
+        ),
+    )
+    await breaker.record_failure()
+    await asyncio.sleep(0.02)
+
+    assert await breaker.allow_request()
+    await breaker.record_success()
+    assert breaker.state == CircuitState.CLOSED
+    assert breaker.failures_in_window() == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_half_open_calls_are_limited_to_probes():
+    breaker = ProviderCircuitBreaker(
+        "x",
+        CircuitBreakerConfig(
+            failure_threshold=1,
+            recovery_timeout=0.01,
+            half_open_max_probes=2,
+        ),
+    )
+    await breaker.record_failure()
+    await asyncio.sleep(0.02)
+
+    allowed = await asyncio.gather(*(breaker.allow_request() for _ in range(8)))
+    assert sum(allowed) == 2
+    assert breaker.metrics().total_rejected == 6
+
+
+def test_config_validation_and_restart_defaults():
+    with pytest.raises(ValueError):
+        CircuitBreakerConfig(retry_budget=-1)
+    with pytest.raises(ValueError):
+        CircuitBreakerConfig(backoff_initial=2, backoff_max=1)
+
+    first = ProviderCircuitBreaker("new-adapter")
+    second = ProviderCircuitBreaker("new-adapter")
+    assert first.state == second.state == CircuitState.CLOSED
+    assert first.config == second.config == CircuitBreakerConfig()
+
+
+def test_settings_validate_per_adapter_retry_configuration():
+    settings = Settings(
+        _env_file=None,
+        adapter_retry_configs={
+            "Discord": {
+                "retry_budget": 4,
+                "backoff_initial": 0.5,
+                "backoff_max": 8,
+            }
+        },
+    )
+    assert settings.adapter_retry_configs["discord"]["retry_budget"] == 4
+
+    with pytest.raises(ValueError):
+        Settings(_env_file=None, adapter_retry_configs={"discord": {"retry_budget": -1}})


### PR DESCRIPTION
## Summary

Add per-adapter retry budgets and circuit breakers to prevent repeated external adapter failures from consuming the agent loop or delaying unrelated work.

## Changes

- Add configurable per-adapter retry budgets with exponential backoff and maximum delay limits.
- Add closed, open, and half-open circuit states with bounded concurrent probes.
- Reset failure state after successful recovery probes.
- Emit structured circuit state-change events.
- Preserve the existing adapter interface and integrate policy at the sandbox boundary.
- Validate retry and circuit configuration through the existing agent settings.

## Tests

- `pytest -q tests/test_adapter_retry_budget.py tests/test_circuit_breaker.py`
- Result: 65 passed
- Python compilation and `git diff --check` passed.

Closes #400