### PR TITLE
Add CI workflows for Python package and Web/SDK testing

### DIFF
--- a/.github/workflows/ci-python-package.yml
+++ b/.github/workflows/ci-python-package.yml
@@ -1,0 +1,48 @@
+name: Python Package CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/prime-agent/**'
+      - '.github/workflows/ci-python-package.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/prime-agent/**'
+      - '.github/workflows/ci-python-package.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-package:
+    name: Python Package (prime-agent)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/prime-agent
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: packages/prime-agent/uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras --all-groups
+
+      - name: Lint
+        run: uv run ruff check src tests
+
+      - name: Test
+        run: uv run pytest tests/ -v

--- a/.github/workflows/ci-web-sdk.yml
+++ b/.github/workflows/ci-web-sdk.yml
@@ -63,7 +63,6 @@ jobs:
       - name: SDK type check
         working-directory: packages/sdk
         run: pnpm build:esm
-        continue-on-error: true
 
       - name: SDK tests
         working-directory: packages/sdk

--- a/.github/workflows/ci-web-sdk.yml
+++ b/.github/workflows/ci-web-sdk.yml
@@ -1,0 +1,70 @@
+name: Web and SDK CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'packages/sdk/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - '.github/workflows/ci-web-sdk.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'packages/sdk/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - '.github/workflows/ci-web-sdk.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  web-sdk:
+    name: Web and SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Web type check
+        working-directory: web
+        run: pnpm build
+
+      - name: Web lint
+        working-directory: web
+        run: pnpm lint
+
+      - name: Web unit tests
+        working-directory: web
+        run: pnpm test:unit
+
+      - name: SDK type check
+        working-directory: packages/sdk
+        run: pnpm build:esm
+        continue-on-error: true
+
+      - name: SDK tests
+        working-directory: packages/sdk
+        run: pnpm test

--- a/docs/CI_LOCAL_COMMANDS.md
+++ b/docs/CI_LOCAL_COMMANDS.md
@@ -1,0 +1,101 @@
+# CI Local Commands
+
+This document provides the local commands that match each CI gate in the Python Package and Web/SDK CI workflows.
+
+## Python Package CI
+
+The CI workflow `ci-python-package.yml` runs the following checks on the `packages/prime-agent` directory:
+
+### Lint
+```bash
+cd packages/prime-agent
+uv sync --frozen --all-extras --all-groups
+uv run ruff check src tests
+```
+
+### Test
+```bash
+cd packages/prime-agent
+uv sync --frozen --all-extras --all-groups
+uv run pytest tests/ -v
+```
+
+### Run all Python checks locally
+```bash
+cd packages/prime-agent
+uv sync --frozen --all-extras --all-groups
+uv run ruff check src tests
+uv run pytest tests/ -v
+```
+
+## Web and SDK CI
+
+The CI workflow `ci-web-sdk.yml` runs the following checks on the `web` and `packages/sdk` directories:
+
+### Web type check
+```bash
+pnpm install --frozen-lockfile
+cd web
+pnpm build
+```
+
+### Web lint
+```bash
+pnpm install --frozen-lockfile
+cd web
+pnpm lint
+```
+
+### Web unit tests
+```bash
+pnpm install --frozen-lockfile
+cd web
+pnpm test:unit
+```
+
+### SDK type check
+```bash
+pnpm install --frozen-lockfile
+cd packages/sdk
+pnpm build:esm
+```
+
+### SDK tests
+```bash
+pnpm install --frozen-lockfile
+cd packages/sdk
+pnpm test
+```
+
+### Run all Web/SDK checks locally
+```bash
+pnpm install --frozen-lockfile
+
+# Web checks
+cd web
+pnpm build
+pnpm lint
+pnpm test:unit
+
+# SDK checks
+cd ../packages/sdk
+pnpm build:esm
+pnpm test
+```
+
+## Path Filters
+
+The CI workflows use path filters to ensure they only run when relevant changes are made:
+
+### Python Package CI (`ci-python-package.yml`)
+- `packages/prime-agent/**`
+- `.github/workflows/ci-python-package.yml`
+
+### Web and SDK CI (`ci-web-sdk.yml`)
+- `web/**`
+- `packages/sdk/**`
+- `pnpm-lock.yaml`
+- `package.json`
+- `.github/workflows/ci-web-sdk.yml`
+
+This ensures that unrelated changes don't trigger unnecessary CI runs.

--- a/packages/prime-agent/src/talos_agent/agent/loop.py
+++ b/packages/prime-agent/src/talos_agent/agent/loop.py
@@ -31,7 +31,6 @@ from talos_agent.agent.prompt import build_system_prompt
 from talos_agent.http import call_with_retry
 from talos_agent.routing import (
     FallbackChain,
-    ProviderRegistry,
     RoutingConstraints,
     RoutingPolicy,
     UsageTracker,
@@ -232,8 +231,6 @@ async def _routed_agent_loop(
             f"[dim]Router: {decision.provider_name}/{decision.model} "
             f"(score={decision.score:.2f})[/dim]"
         )
-
-        provider = registry.get(decision.provider_name)
 
         # Define the completion operation for fallback
         async def _complete(

--- a/packages/prime-agent/src/talos_agent/routing/policy.py
+++ b/packages/prime-agent/src/talos_agent/routing/policy.py
@@ -25,18 +25,13 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 from talos_agent.routing.provider import (
     ProviderCapabilities,
     ProviderMetadata,
     ProviderRegistry,
-    ProviderStatus,
     TaskType,
 )
-
-if TYPE_CHECKING:
-    from talos_agent.routing.provider import LLMProvider
 
 logger = logging.getLogger(__name__)
 

--- a/packages/prime-agent/src/talos_agent/routing/provider.py
+++ b/packages/prime-agent/src/talos_agent/routing/provider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Any

--- a/packages/prime-agent/src/talos_agent/routing/usage.py
+++ b/packages/prime-agent/src/talos_agent/routing/usage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Callable
 

--- a/packages/prime-agent/uv.lock
+++ b/packages/prime-agent/uv.lock
@@ -330,6 +330,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +549,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -552,6 +645,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37", size = 453256, upload-time = "2026-08-20T16:33:53.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/15/5162230af4912697f0fe406f6800f80760945babcff0e2c2fe6c84ef2d5d/protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44", size = 341436, upload-time = "2026-08-20T16:33:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/09/1670b2bfc9a45e807e520c3e9be36524db9ccc7dc05ea17af7681cabdc61/protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16", size = 354440, upload-time = "2026-08-20T16:33:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/acd02338235a3e7d03168c4303478347b7624fc8189ff4e7f0d2654bbe86/protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071", size = 440216, upload-time = "2026-08-20T16:33:57.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/12cb93270967a2affff5b3f720694700d4d87712a67afd05c8cb3f6fa52c/protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488", size = 453731, upload-time = "2026-08-20T16:33:58.951Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
 ]
 
 [[package]]
@@ -952,6 +1060,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -981,6 +1092,9 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "openai", specifier = ">=1.30" },
+    { name = "opentelemetry-api", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary
Add CI workflows to catch agent and web regressions before deployment.

## Changes
- **Python Package CI** (`ci-python-package.yml`): Lint and test for `packages/prime-agent`
- **Web/SDK CI** (`ci-web-sdk.yml`): Type-check, lint, and unit tests for web and SDK
- Both workflows include dependency caching and path filters for fast, targeted runs
- No production secrets required — all checks use public dependencies
- Added `docs/CI_LOCAL_COMMANDS.md` with local commands matching each CI gate

## Test plan
- Workflows run on pull requests and pushes to main
- Path filters ensure CI only runs for relevant changes
- Local commands documented for developers to reproduce CI checks locally

Closes #402 