### PR TITLE
feat(agent): expose adapter health and degraded-state snapshots (#421)

### DIFF
--- a/packages/prime-agent/src/talos_agent/adapters/__init__.py
+++ b/packages/prime-agent/src/talos_agent/adapters/__init__.py
@@ -15,9 +15,12 @@ from talos_agent.adapters.health import (
     AdapterState,
     BrowserSessionProbe,
     DiscordProbe,
+    ErrorCategory,
     HealthReport,
     ProbeResult,
+    StellarPaymentProbe,
     TelegramProbe,
+    X402PaymentProbe,
     XProbe,
 )
 from talos_agent.adapters.registry import AdapterRegistry
@@ -50,12 +53,15 @@ __all__ = [
     "XAdapterConfig",
     # Health probes
     "AdapterState",
+    "ErrorCategory",
     "ProbeResult",
     "AdapterProbe",
     "DiscordProbe",
     "TelegramProbe",
     "XProbe",
     "BrowserSessionProbe",
+    "StellarPaymentProbe",
+    "X402PaymentProbe",
     "HealthReport",
     "AdapterHealthReporter",
     # Storage adapters and coordinator

--- a/packages/prime-agent/src/talos_agent/adapters/health.py
+++ b/packages/prime-agent/src/talos_agent/adapters/health.py
@@ -1,8 +1,9 @@
 """Adapter health probes — lightweight, side-effect-free readiness checks.
 
 Each probe inspects only the in-process state of an adapter (credentials
-present, browser session initialised, etc.).  No HTTP requests are made,
-no browser pages are loaded, and no tokens are consumed.
+present, browser session initialised, payment proxy ready, etc.). No HTTP
+requests are made, no browser pages are loaded, no blockchain transactions
+are submitted, and no tokens or funds are consumed.
 
 Usage
 -----
@@ -11,17 +12,32 @@ Run individual probes::
     from talos_agent.adapters.health import DiscordProbe
     result = await DiscordProbe(adapter).probe()
 
-Run aggregate over the whole registry::
+Run aggregate over social, browser, and payment adapters::
 
     from talos_agent.adapters.health import AdapterHealthReporter
-    report = await AdapterHealthReporter(registry, browser).report()
+    report = await AdapterHealthReporter(
+        registry=registry,
+        browser=browser,
+        stellar_kit=stellar,
+        x402_signer=signer,
+    ).report()
 
 Probe states
 ------------
-healthy   — adapter is fully configured and its session (if any) is live.
-disabled  — required credentials are absent; the adapter is intentionally off.
-degraded  — credentials are partially set or in an unexpected state.
+healthy   — adapter is fully configured and its session/proxy is live.
+disabled  — required credentials or configurations are absent; intentionally off.
+degraded  — credentials partially set, dependency unavailable, or probe failed.
 timeout   — the probe itself did not complete within PROBE_TIMEOUT_SECONDS.
+
+Error categories
+----------------
+none                   — no error (healthy or intentionally disabled).
+missing_credentials    — required secrets/tokens/channels are missing.
+invalid_credentials    — credentials provided are invalid or misconfigured.
+dependency_unavailable — external dependency (browser, horizon, web API) is not live.
+timeout                — health probe timed out before completing.
+internal_error         — probe raised an unexpected internal exception.
+network_error          — network or connection error encountered.
 """
 
 from __future__ import annotations
@@ -29,14 +45,36 @@ from __future__ import annotations
 import asyncio
 import datetime
 import enum
+import re
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 PROBE_TIMEOUT_SECONDS: float = 5.0
 
-# ── State ─────────────────────────────────────────────────────────────────────
+# ── Sanitization ─────────────────────────────────────────────────────────────
+
+_SENSITIVE_PATTERNS = [
+    re.compile(r"S[A-Z0-9]{55}"),  # Stellar secret seed
+    re.compile(r"sk-[A-Za-z0-9\-_]{20,}"),  # OpenAI/API secret key
+    re.compile(r"(https?://[^\s:@]+:[^\s:@]+@\S+)"),  # URL with basic auth creds
+    re.compile(r"(Bearer\s+)[A-Za-z0-9\-_.~+/]+=*", re.IGNORECASE),
+    re.compile(r"([a-zA-Z0-9_\-]{24,}\.[a-zA-Z0-9_\-]{6}\.[a-zA-Z0-9_\-]{27,})"),  # Discord bot token
+]
+
+
+def _sanitize_health_detail(text: str) -> str:
+    """Strip secrets, credentials, tokens, or signed payloads from details."""
+    if not text:
+        return ""
+    sanitized = str(text)
+    for pattern in _SENSITIVE_PATTERNS:
+        sanitized = pattern.sub("[REDACTED]", sanitized)
+    return sanitized
+
+
+# ── State & Categories ───────────────────────────────────────────────────────
 
 
 class AdapterState(str, enum.Enum):
@@ -48,6 +86,18 @@ class AdapterState(str, enum.Enum):
     TIMEOUT = "timeout"
 
 
+class ErrorCategory(str, enum.Enum):
+    """Error classification category for adapter health states."""
+
+    NONE = "none"
+    MISSING_CREDENTIALS = "missing_credentials"
+    INVALID_CREDENTIALS = "invalid_credentials"
+    DEPENDENCY_UNAVAILABLE = "dependency_unavailable"
+    TIMEOUT = "timeout"
+    INTERNAL_ERROR = "internal_error"
+    NETWORK_ERROR = "network_error"
+
+
 # ── Result ────────────────────────────────────────────────────────────────────
 
 
@@ -56,23 +106,32 @@ class ProbeResult:
     """Outcome of a single adapter health probe."""
 
     adapter: str
-    """Canonical adapter name, e.g. ``"Discord"``, ``"Telegram"``, ``"X"``."""
+    """Canonical adapter name, e.g. ``"Discord"``, ``"Telegram"``, ``"X"``, ``"StellarPayment"``."""
 
     state: AdapterState
     """Overall health state."""
 
     detail: str = ""
-    """Human-readable explanation — safe to expose in dashboards."""
+    """Human-readable explanation — safe to expose in dashboards and logs."""
+
+    error_category: ErrorCategory = ErrorCategory.NONE
+    """Typed category explaining the cause when state is not healthy."""
 
     checked_at: datetime.datetime = field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
+        cat = (
+            self.error_category.value
+            if isinstance(self.error_category, enum.Enum)
+            else str(self.error_category or "none")
+        )
         return {
             "adapter": self.adapter,
-            "state": self.state.value,
-            "detail": self.detail,
+            "state": self.state.value if isinstance(self.state, enum.Enum) else str(self.state),
+            "detail": _sanitize_health_detail(self.detail),
+            "error_category": cat,
             "checked_at": self.checked_at.isoformat(),
         }
 
@@ -85,7 +144,7 @@ class AdapterProbe(Protocol):
     """Common interface for all adapter health probes.
 
     Implementations MUST NOT make any external network calls, read files,
-    or trigger side effects.  They inspect only in-process state.
+    or trigger side effects. They inspect only in-process state.
     """
 
     async def probe(self) -> ProbeResult:
@@ -96,15 +155,18 @@ class AdapterProbe(Protocol):
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-async def _run_with_timeout(coro, timeout: float = PROBE_TIMEOUT_SECONDS) -> ProbeResult:
+async def _run_with_timeout(
+    coro, timeout: float = PROBE_TIMEOUT_SECONDS, adapter_name: str = "unknown"
+) -> ProbeResult:
     """Run *coro* and wrap a TimeoutError into a TIMEOUT ProbeResult."""
     try:
         return await asyncio.wait_for(coro, timeout=timeout)
     except asyncio.TimeoutError:
         return ProbeResult(
-            adapter="unknown",
+            adapter=adapter_name,
             state=AdapterState.TIMEOUT,
             detail=f"Probe did not complete within {timeout}s",
+            error_category=ErrorCategory.TIMEOUT,
         )
 
 
@@ -124,6 +186,7 @@ class DiscordProbe:
 
     async def probe(self) -> ProbeResult:
         a = self._adapter
+        adapter_name = getattr(a, "channel_name", "Discord")
         snapshot_fn = getattr(a, "health_snapshot", None)
         snapshot = snapshot_fn() if callable(snapshot_fn) else {}
         snapshot = snapshot if isinstance(snapshot, dict) else {}
@@ -145,36 +208,40 @@ class DiscordProbe:
 
         if has_webhook or (has_token and has_channel):
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.HEALTHY,
                 detail=(
                     "webhook configured"
                     if has_webhook
                     else "bot token + channel ID configured"
                 ),
+                error_category=ErrorCategory.NONE,
             )
 
         if has_token and not has_channel:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.DEGRADED,
                 detail="DISCORD_BOT_TOKEN set but DISCORD_CHANNEL_ID is missing",
+                error_category=ErrorCategory.MISSING_CREDENTIALS,
             )
 
         if has_channel and not has_token:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.DEGRADED,
                 detail="DISCORD_CHANNEL_ID set but DISCORD_BOT_TOKEN is missing",
+                error_category=ErrorCategory.MISSING_CREDENTIALS,
             )
 
         return ProbeResult(
-            adapter=a.channel_name,
+            adapter=adapter_name,
             state=AdapterState.DISABLED,
             detail=(
                 "No credentials found. "
                 "Set DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID."
             ),
+            error_category=ErrorCategory.NONE,
         )
 
 
@@ -194,6 +261,7 @@ class TelegramProbe:
 
     async def probe(self) -> ProbeResult:
         a = self._adapter
+        adapter_name = getattr(a, "channel_name", "Telegram")
         snapshot_fn = getattr(a, "health_snapshot", None)
         snapshot = snapshot_fn() if callable(snapshot_fn) else {}
         snapshot = snapshot if isinstance(snapshot, dict) else {}
@@ -210,32 +278,36 @@ class TelegramProbe:
 
         if has_token and has_chat:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.HEALTHY,
                 detail="bot token and chat ID configured",
+                error_category=ErrorCategory.NONE,
             )
 
         if has_token and not has_chat:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.DEGRADED,
                 detail="telegram_bot_token set but telegram_chat_id is missing",
+                error_category=ErrorCategory.MISSING_CREDENTIALS,
             )
 
         if has_chat and not has_token:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.DEGRADED,
                 detail="telegram_chat_id set but telegram_bot_token is missing",
+                error_category=ErrorCategory.MISSING_CREDENTIALS,
             )
 
         return ProbeResult(
-            adapter=a.channel_name,
+            adapter=adapter_name,
             state=AdapterState.DISABLED,
             detail=(
                 "No credentials found. "
                 "Set telegram_bot_token and telegram_chat_id."
             ),
+            error_category=ErrorCategory.NONE,
         )
 
 
@@ -255,6 +327,7 @@ class XProbe:
 
     async def probe(self) -> ProbeResult:
         a = self._adapter
+        adapter_name = getattr(a, "channel_name", "X")
         snapshot_fn = getattr(a, "health_snapshot", None)
         snapshot = snapshot_fn() if callable(snapshot_fn) else {}
         snapshot = snapshot if isinstance(snapshot, dict) else {}
@@ -282,26 +355,29 @@ class XProbe:
 
         if not has_creds:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.DISABLED,
                 detail="No X credentials found. Set X_USERNAME and X_PASSWORD.",
+                error_category=ErrorCategory.NONE,
             )
 
         if has_creds and browser_live:
             return ProbeResult(
-                adapter=a.channel_name,
+                adapter=adapter_name,
                 state=AdapterState.HEALTHY,
                 detail="credentials configured and browser session is live",
+                error_category=ErrorCategory.NONE,
             )
 
         # Credentials present but browser not yet ready
         return ProbeResult(
-            adapter=a.channel_name,
+            adapter=adapter_name,
             state=AdapterState.DEGRADED,
             detail=(
                 "X credentials configured but browser session is not initialised. "
                 "The adapter will become healthy once the browser starts."
             ),
+            error_category=ErrorCategory.DEPENDENCY_UNAVAILABLE,
         )
 
 
@@ -342,6 +418,7 @@ class BrowserSessionProbe:
                 adapter="BrowserSession",
                 state=AdapterState.DISABLED,
                 detail="No browser session instance provided.",
+                error_category=ErrorCategory.NONE,
             )
 
         stagehand = getattr(b, "_stagehand", None)
@@ -350,6 +427,7 @@ class BrowserSessionProbe:
                 adapter="BrowserSession",
                 state=AdapterState.DISABLED,
                 detail="Browser session not started (no Stagehand instance).",
+                error_category=ErrorCategory.NONE,
             )
 
         page = getattr(stagehand, "page", None)
@@ -358,12 +436,150 @@ class BrowserSessionProbe:
                 adapter="BrowserSession",
                 state=AdapterState.DEGRADED,
                 detail="Stagehand initialised but no page is open yet.",
+                error_category=ErrorCategory.DEPENDENCY_UNAVAILABLE,
             )
 
         return ProbeResult(
             adapter="BrowserSession",
             state=AdapterState.HEALTHY,
             detail="Stagehand session active with open page.",
+            error_category=ErrorCategory.NONE,
+        )
+
+
+# ── Payment probes (Stellar & x402) ──────────────────────────────────────────
+
+
+class StellarPaymentProbe:
+    """Probe Stellar payment proxy / StellarKit configuration and readiness.
+
+    healthy  — API client configured and proxy initialized.
+    degraded — API client configured but proxy not yet initialized.
+    disabled — No API client provided (Stellar payments disabled).
+    """
+
+    def __init__(self, stellar_kit) -> None:
+        self._stellar_kit = stellar_kit
+
+    async def probe(self) -> ProbeResult:
+        s = self._stellar_kit
+        if s is None:
+            return ProbeResult(
+                adapter="StellarPayment",
+                state=AdapterState.DISABLED,
+                detail="No Stellar payment instance provided.",
+                error_category=ErrorCategory.NONE,
+            )
+
+        snapshot_fn = getattr(s, "health_snapshot", None)
+        snapshot = snapshot_fn() if callable(snapshot_fn) else {}
+        snapshot = snapshot if isinstance(snapshot, dict) else {}
+
+        has_api = bool(
+            snapshot["has_api"]
+            if "has_api" in snapshot
+            else getattr(s, "_api", None) is not None
+        )
+        initialized = bool(
+            snapshot["initialized"]
+            if "initialized" in snapshot
+            else getattr(s, "_initialized", False)
+        )
+
+        if not has_api:
+            return ProbeResult(
+                adapter="StellarPayment",
+                state=AdapterState.DISABLED,
+                detail="Stellar payment proxy disabled (no API client configured).",
+                error_category=ErrorCategory.NONE,
+            )
+
+        if has_api and initialized:
+            return ProbeResult(
+                adapter="StellarPayment",
+                state=AdapterState.HEALTHY,
+                detail="Stellar payment proxy initialized and ready.",
+                error_category=ErrorCategory.NONE,
+            )
+
+        return ProbeResult(
+            adapter="StellarPayment",
+            state=AdapterState.DEGRADED,
+            detail="Stellar payment proxy configured but not initialized.",
+            error_category=ErrorCategory.DEPENDENCY_UNAVAILABLE,
+        )
+
+
+class X402PaymentProbe:
+    """Probe x402 signer payment adapter configuration and readiness.
+
+    healthy  — API client configured, initialized, and agent wallet available.
+    degraded — API client configured but signer not initialized.
+    disabled — No API client or no wallet assigned (signing disabled).
+    """
+
+    def __init__(self, signer) -> None:
+        self._signer = signer
+
+    async def probe(self) -> ProbeResult:
+        s = self._signer
+        if s is None:
+            return ProbeResult(
+                adapter="X402Signer",
+                state=AdapterState.DISABLED,
+                detail="No x402 signer instance provided.",
+                error_category=ErrorCategory.NONE,
+            )
+
+        snapshot_fn = getattr(s, "health_snapshot", None)
+        snapshot = snapshot_fn() if callable(snapshot_fn) else {}
+        snapshot = snapshot if isinstance(snapshot, dict) else {}
+
+        has_api = bool(
+            snapshot["has_api"]
+            if "has_api" in snapshot
+            else getattr(s, "_api", None) is not None
+        )
+        initialized = bool(
+            snapshot["initialized"]
+            if "initialized" in snapshot
+            else getattr(s, "_initialized", False)
+        )
+        has_wallet = bool(
+            snapshot["has_wallet"]
+            if "has_wallet" in snapshot
+            else bool(getattr(s, "_wallet_address", None))
+        )
+
+        if not has_api:
+            return ProbeResult(
+                adapter="X402Signer",
+                state=AdapterState.DISABLED,
+                detail="x402 payment signer disabled (no API client configured).",
+                error_category=ErrorCategory.NONE,
+            )
+
+        if has_api and initialized and has_wallet:
+            return ProbeResult(
+                adapter="X402Signer",
+                state=AdapterState.HEALTHY,
+                detail="x402 payment signer initialized with active agent wallet.",
+                error_category=ErrorCategory.NONE,
+            )
+
+        if has_api and initialized and not has_wallet:
+            return ProbeResult(
+                adapter="X402Signer",
+                state=AdapterState.DISABLED,
+                detail="x402 payment signing disabled (no agent wallet found).",
+                error_category=ErrorCategory.NONE,
+            )
+
+        return ProbeResult(
+            adapter="X402Signer",
+            state=AdapterState.DEGRADED,
+            detail="x402 payment signer configured but not initialized.",
+            error_category=ErrorCategory.DEPENDENCY_UNAVAILABLE,
         )
 
 
@@ -384,12 +600,29 @@ class HealthReport:
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
-            "overall": self.overall.value,
+            "overall": self.overall.value if isinstance(self.overall, enum.Enum) else str(self.overall),
             "adapters": [r.to_dict() for r in self.adapters],
             "checked_at": self.checked_at.isoformat(),
         }
+
+    @property
+    def has_degraded(self) -> bool:
+        """Return True if any probe reported degraded or timeout state."""
+        return any(
+            r.state in (AdapterState.DEGRADED, AdapterState.TIMEOUT)
+            for r in self.adapters
+        )
+
+    @property
+    def degraded_adapters(self) -> list[ProbeResult]:
+        """Return list of degraded or timed-out adapter probes."""
+        return [
+            r
+            for r in self.adapters
+            if r.state in (AdapterState.DEGRADED, AdapterState.TIMEOUT)
+        ]
 
 
 _STATE_SEVERITY: dict[AdapterState, int] = {
@@ -403,7 +636,41 @@ _STATE_SEVERITY: dict[AdapterState, int] = {
 def _worst(states: list[AdapterState]) -> AdapterState:
     if not states:
         return AdapterState.DISABLED
-    return max(states, key=lambda s: _STATE_SEVERITY[s])
+    return max(states, key=lambda s: _STATE_SEVERITY.get(s, 1))
+
+
+async def _safe_probe_coro(
+    probe_obj: AdapterProbe, timeout_sec: float, adapter_n: str
+) -> ProbeResult:
+    """Safely invoke probe_obj.probe() with timeout and error capture."""
+    try:
+        res = probe_obj.probe()
+        if asyncio.iscoroutine(res) or hasattr(res, "__await__"):
+            return await asyncio.wait_for(res, timeout=timeout_sec)
+        elif isinstance(res, ProbeResult):
+            return res
+        else:
+            return ProbeResult(
+                adapter=adapter_n,
+                state=AdapterState.HEALTHY,
+                detail=str(res),
+                error_category=ErrorCategory.NONE,
+            )
+    except asyncio.TimeoutError:
+        return ProbeResult(
+            adapter=adapter_n,
+            state=AdapterState.TIMEOUT,
+            detail=f"Probe did not complete within {timeout_sec}s",
+            error_category=ErrorCategory.TIMEOUT,
+        )
+    except Exception as exc:  # noqa: BLE001
+        err_type = type(exc).__name__
+        return ProbeResult(
+            adapter=adapter_n,
+            state=AdapterState.DEGRADED,
+            detail=_sanitize_health_detail(f"Probe raised an unexpected error: {err_type}"),
+            error_category=ErrorCategory.INTERNAL_ERROR,
+        )
 
 
 class AdapterHealthReporter:
@@ -412,50 +679,113 @@ class AdapterHealthReporter:
     Parameters
     ----------
     registry:
-        An :class:`~talos_agent.adapters.registry.AdapterRegistry` whose
+        Optional :class:`~talos_agent.adapters.registry.AdapterRegistry` whose
         registered adapters are probed.
     browser:
         Optional :class:`~talos_agent.browser.session.BrowserSession` to
         include as a standalone probe.
+    payments:
+        Optional payment adapter, list of payment adapters, or dict of payment probes.
+    stellar_kit:
+        Optional :class:`~talos_agent.payments.stellar_kit.StellarKit` instance.
+    x402_signer:
+        Optional :class:`~talos_agent.payments.x402_signer.X402Signer` instance.
     timeout:
         Per-probe timeout in seconds (default: :data:`PROBE_TIMEOUT_SECONDS`).
     """
 
-    def __init__(self, registry, browser=None, timeout: float = PROBE_TIMEOUT_SECONDS) -> None:
+    def __init__(
+        self,
+        registry=None,
+        browser=None,
+        payments=None,
+        stellar_kit=None,
+        x402_signer=None,
+        timeout: float = PROBE_TIMEOUT_SECONDS,
+    ) -> None:
         self._registry = registry
         self._browser = browser
+        self._payments = payments
+        self._stellar_kit = stellar_kit
+        self._x402_signer = x402_signer
         self._timeout = timeout
 
     async def report(self) -> HealthReport:
-        """Run all probes concurrently and return a :class:`HealthReport`."""
+        """Run all probes concurrently and return a :class:`HealthReport`.
+
+        Guarantees that a failing or hanging probe never crashes the report.
+        """
         probes: list[tuple[str, AdapterProbe]] = []
 
-        for adapter in self._registry._adapters.values():
-            name = adapter.channel_name.lower()
-            if name == "discord":
-                probes.append(("discord", DiscordProbe(adapter)))
-            elif name == "telegram":
-                probes.append(("telegram", TelegramProbe(adapter)))
-            elif name == "x":
-                probes.append(("x", XProbe(adapter)))
+        if self._registry is not None:
+            adapters_dict = getattr(self._registry, "_adapters", {})
+            for adapter in adapters_dict.values():
+                name = getattr(adapter, "channel_name", "").lower()
+                if name == "discord":
+                    probes.append(("Discord", DiscordProbe(adapter)))
+                elif name == "telegram":
+                    probes.append(("Telegram", TelegramProbe(adapter)))
+                elif name == "x":
+                    probes.append(("X", XProbe(adapter)))
+                elif hasattr(adapter, "probe") and callable(adapter.probe):
+                    probes.append((getattr(adapter, "channel_name", "custom"), adapter))
 
         if self._browser is not None:
-            probes.append(("browser", BrowserSessionProbe(self._browser)))
+            probes.append(("BrowserSession", BrowserSessionProbe(self._browser)))
+
+        # Process payment components
+        if self._stellar_kit is not None:
+            probes.append(("StellarPayment", StellarPaymentProbe(self._stellar_kit)))
+
+        if self._x402_signer is not None:
+            probes.append(("X402Signer", X402PaymentProbe(self._x402_signer)))
+
+        if self._payments is not None:
+            if isinstance(self._payments, (list, tuple, set)):
+                for p in self._payments:
+                    p_name = type(p).__name__
+                    if "Stellar" in p_name:
+                        probes.append(("StellarPayment", StellarPaymentProbe(p)))
+                    elif "402" in p_name or "Signer" in p_name:
+                        probes.append(("X402Signer", X402PaymentProbe(p)))
+                    elif hasattr(p, "probe") and callable(p.probe):
+                        probes.append((getattr(p, "channel_name", p_name), p))
+            elif isinstance(self._payments, dict):
+                for p_key, p_val in self._payments.items():
+                    if hasattr(p_val, "probe") and callable(p_val.probe):
+                        probes.append((p_key, p_val))
+                    elif "stellar" in p_key.lower():
+                        probes.append((p_key, StellarPaymentProbe(p_val)))
+                    elif "x402" in p_key.lower() or "signer" in p_key.lower():
+                        probes.append((p_key, X402PaymentProbe(p_val)))
+            else:
+                p = self._payments
+                p_name = type(p).__name__
+                if "Stellar" in p_name:
+                    probes.append(("StellarPayment", StellarPaymentProbe(p)))
+                elif "402" in p_name or "Signer" in p_name:
+                    probes.append(("X402Signer", X402PaymentProbe(p)))
+                elif hasattr(p, "probe") and callable(p.probe):
+                    probes.append((getattr(p, "channel_name", p_name), p))
 
         results: list[ProbeResult] = []
         if probes:
             coros = [
-                _run_with_timeout(probe.probe(), timeout=self._timeout)
-                for _, probe in probes
+                _safe_probe_coro(probe, self._timeout, name)
+                for name, probe in probes
             ]
             raw = await asyncio.gather(*coros, return_exceptions=True)
             for (name, _), outcome in zip(probes, raw):
                 if isinstance(outcome, BaseException):
+                    err_type = type(outcome).__name__
                     results.append(
                         ProbeResult(
                             adapter=name,
                             state=AdapterState.DEGRADED,
-                            detail=f"Probe raised an unexpected exception: {outcome}",
+                            detail=_sanitize_health_detail(
+                                f"Probe raised an unexpected error: {err_type}"
+                            ),
+                            error_category=ErrorCategory.INTERNAL_ERROR,
                         )
                     )
                 else:

--- a/packages/prime-agent/src/talos_agent/cli.py
+++ b/packages/prime-agent/src/talos_agent/cli.py
@@ -594,7 +594,8 @@ def telemetry(json_output: bool):
         console.print("[bold]Adapter Health[/bold]")
         for a in report.adapters:
             color = {"healthy": "green", "disabled": "dim", "degraded": "yellow", "timeout": "red"}.get(a.state, "dim")
-            console.print(f"  {a.name}: [{color}]{a.state}[/{color}] — {a.detail}")
+            cat_str = f" [{a.error_category}]" if a.error_category and a.error_category != "none" else ""
+            console.print(f"  {a.name}: [{color}]{a.state}[/{color}]{cat_str} — {a.detail}")
         console.print()
 
     console.print("[bold]Content Performance (7d)[/bold]")
@@ -609,3 +610,84 @@ def telemetry(json_output: bool):
     console.print(f"  Escalations: {report.policy_escalate_count}")
 
     db.close()
+
+
+@main.command(name="diagnostics")
+@click.option("--json", "json_output", is_flag=True, help="Output raw JSON instead of a formatted summary.")
+def diagnostics(json_output: bool):
+    """Run health probes across social, browser, and payment adapters.
+
+    Evaluates in-process readiness, credentials, and dependency states
+    without performing side effects, external HTTP calls, or transactions.
+    """
+    import asyncio
+    import json
+    from talos_agent.config import Settings
+    from talos_agent.adapters.health import AdapterHealthReporter
+    from talos_agent.adapters.discord import DiscordAdapter
+    from talos_agent.adapters.telegram import TelegramAdapter
+    from talos_agent.adapters.x import XAdapter
+    from talos_agent.adapters.registry import AdapterRegistry
+    from talos_agent.payments.stellar_kit import StellarKit
+    from talos_agent.payments.x402_signer import X402Signer
+    from talos_agent.api_client import TalosAPIClient
+
+    settings = Settings()
+    registry = AdapterRegistry()
+
+    # Register social adapters safely
+    try:
+        registry.register(DiscordAdapter(settings))
+    except Exception:
+        pass
+    try:
+        registry.register(TelegramAdapter(settings))
+    except Exception:
+        pass
+    try:
+        registry.register(XAdapter(None, settings))
+    except Exception:
+        pass
+
+    # Payment components
+    api_client = None
+    if settings.talos_api_url and settings.talos_api_key and settings.talos_id:
+        try:
+            api_client = TalosAPIClient(settings)
+        except Exception:
+            pass
+
+    stellar_kit = StellarKit(api_client) if api_client else None
+    x402_signer = X402Signer(api_client) if api_client else None
+
+    reporter = AdapterHealthReporter(
+        registry=registry,
+        browser=None,
+        stellar_kit=stellar_kit,
+        x402_signer=x402_signer,
+    )
+
+    report = asyncio.run(reporter.report())
+
+    if json_output:
+        console.print(json.dumps(report.to_dict(), indent=2))
+        return
+
+    overall_color = {
+        "healthy": "green",
+        "disabled": "dim",
+        "degraded": "yellow",
+        "timeout": "red",
+    }.get(report.overall.value, "dim")
+
+    console.print(f"[bold]Adapter Health & Diagnostics:[/bold] [{overall_color}]{report.overall.value.upper()}[/{overall_color}]")
+    console.print(f"  Checked at: {report.checked_at.isoformat()}")
+    console.print()
+
+    for a in report.adapters:
+        color = {"healthy": "green", "disabled": "dim", "degraded": "yellow", "timeout": "red"}.get(a.state.value, "dim")
+        cat_str = f" [{a.error_category.value}]" if a.error_category.value != "none" else ""
+        console.print(f"  [bold]{a.adapter}[/bold]: [{color}]{a.state.value}[/{color}]{cat_str}")
+        if a.detail:
+            console.print(f"    Detail: {a.detail}")
+    console.print()

--- a/packages/prime-agent/src/talos_agent/payments/stellar_kit.py
+++ b/packages/prime-agent/src/talos_agent/payments/stellar_kit.py
@@ -41,6 +41,13 @@ class StellarKit:
     def available(self) -> bool:
         return self._initialized
 
+    def health_snapshot(self) -> dict[str, bool]:
+        """Return in-process readiness snapshot for health probes (side-effect free)."""
+        return {
+            "has_api": self._api is not None,
+            "initialized": bool(self._initialized),
+        }
+
     async def get_balance(self, account_id: str = "") -> dict[str, Any]:
         """Query XLM balance via Horizon (public API)."""
         try:

--- a/packages/prime-agent/src/talos_agent/payments/x402_signer.py
+++ b/packages/prime-agent/src/talos_agent/payments/x402_signer.py
@@ -54,6 +54,14 @@ class X402Signer:
     def address(self) -> str | None:
         return self._wallet_address
 
+    def health_snapshot(self) -> dict[str, bool]:
+        """Return in-process readiness snapshot for health probes (side-effect free)."""
+        return {
+            "has_api": self._api is not None,
+            "initialized": bool(self._initialized),
+            "has_wallet": bool(self._wallet_address),
+        }
+
     async def sign_payment(
         self,
         payee: str,

--- a/packages/prime-agent/src/talos_agent/scheduler.py
+++ b/packages/prime-agent/src/talos_agent/scheduler.py
@@ -1,4 +1,4 @@
-﻿"""Main async scheduler — orchestrates all agent tasks."""
+"""Main async scheduler — orchestrates all agent tasks."""
 
 from __future__ import annotations
 
@@ -526,6 +526,35 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
     # Initialize StellarKit for balance checks
     stellar = StellarKit(api)
     await stellar.initialize()
+
+    # ── Adapter health snapshot (#421) ──────────────────────────────────
+    from talos_agent.adapters.health import AdapterHealthReporter
+    from talos_agent.tools.publishing import _adapter_registry
+
+    adapter_health_reporter = AdapterHealthReporter(
+        registry=_adapter_registry,
+        browser=browser,
+        stellar_kit=stellar,
+    )
+    try:
+        startup_health = await adapter_health_reporter.report()
+        log.info(
+            "adapter_health_startup_snapshot",
+            overall=startup_health.overall.value,
+            adapters=[a.to_dict() for a in startup_health.adapters],
+        )
+        if startup_health.has_degraded:
+            degraded_names = [
+                f"{a.adapter} ({a.error_category.value})"
+                for a in startup_health.degraded_adapters
+            ]
+            console.print(
+                f"[yellow]Adapter health warning: degraded adapter(s): {', '.join(degraded_names)}[/yellow]"
+            )
+        else:
+            console.print(f"[green]Adapter health check: {startup_health.overall.value.upper()}[/green]")
+    except Exception as _health_exc:
+        logger.debug("Initial adapter health check failed (non-fatal): %s", _health_exc)
 
     # ── Post-restore reconciliation (#296) ──────────────────────────────────
     # Reconcile backoff state, schedule timestamps, fencing tokens, and
@@ -1130,6 +1159,12 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                     cb_registry=cb_registry,
                     policy_engine=policy_engine if policy_engine.enabled else None,
                 )
+                try:
+                    health_report = await adapter_health_reporter.report()
+                    collector.add_adapter_health(report, health_report.adapters)
+                except Exception as _ah_exc:
+                    logger.debug("Telemetry adapter health probe failed: %s", _ah_exc)
+
                 log.info(
                     "telemetry_snapshot",
                     tasks=[
@@ -1145,6 +1180,10 @@ async def run(settings: Settings, agent_slot: int = 0) -> None:
                     circuit_breakers=[
                         {"provider": c.get("provider"), "state": c.get("state")}
                         for c in report.circuit_breakers
+                    ],
+                    adapters=[
+                        {"name": a.name, "state": a.state, "error_category": a.error_category}
+                        for a in report.adapters
                     ],
                     policy_evaluations=report.policy_evaluation_count,
                 )

--- a/packages/prime-agent/src/talos_agent/telemetry.py
+++ b/packages/prime-agent/src/talos_agent/telemetry.py
@@ -91,6 +91,8 @@ class AdapterTelemetry:
     name: str
     state: str
     detail: str = ""
+    error_category: str = ""
+    checked_at: str = ""
 
 
 @dataclass
@@ -359,10 +361,17 @@ class TelemetryCollector:
             name = d.get("adapter", "unknown")
             if _is_sensitive_key(name):
                 name = "[REDACTED]"
+            raw_cat = d.get("error_category", "")
+            cat_str = raw_cat.value if hasattr(raw_cat, "value") else str(raw_cat or "")
+            checked_at = d.get("checked_at", "")
+            if hasattr(checked_at, "isoformat"):
+                checked_at = checked_at.isoformat()
             report.adapters.append(
                 AdapterTelemetry(
                     name=name,
                     state=_redact_if_sensitive("state", d.get("state", "unknown")),  # type: ignore[arg-type]
                     detail=_redact_if_sensitive("detail", d.get("detail", "")),  # type: ignore[arg-type]
+                    error_category=_redact_if_sensitive("error_category", cat_str),
+                    checked_at=str(checked_at),
                 )
             )

--- a/packages/prime-agent/tests/test_adapter_health.py
+++ b/packages/prime-agent/tests/test_adapter_health.py
@@ -2,13 +2,16 @@
 
 Coverage
 --------
-DiscordProbe:   healthy (webhook), healthy (bot), degraded (partial creds), disabled
-TelegramProbe:  healthy, degraded (token only), degraded (chat only), disabled
-XProbe:         healthy, degraded (creds but no browser), disabled
+DiscordProbe:        healthy (webhook), healthy (bot), degraded (partial creds), disabled
+TelegramProbe:       healthy, degraded (token only), degraded (chat only), disabled
+XProbe:              healthy, degraded (creds but no browser), disabled
 BrowserSessionProbe: healthy, degraded (no page), disabled (no stagehand), disabled (None)
-AdapterHealthReporter: aggregate states, timeout path, concurrent execution
-ProbeResult / HealthReport: to_dict(), checked_at present, state ordering
-AdapterState:   _worst() ordering
+StellarPaymentProbe: healthy, degraded (uninitialized), disabled (no api), disabled (None)
+X402PaymentProbe:    healthy, disabled (no wallet), degraded (uninitialized), disabled (no api)
+AdapterHealthReporter: combined snapshot across social/browser/payment, timeout path, exception resilience
+ProbeResult / HealthReport: to_dict(), error_category, checked_at present, state ordering
+Sanitization:        redaction of Stellar secret seeds, Discord tokens, API keys, Bearer tokens
+CLI diagnostics:     formatted output and json output
 """
 
 from __future__ import annotations
@@ -17,21 +20,25 @@ import asyncio
 from unittest.mock import MagicMock
 
 import pytest
-
+from click.testing import CliRunner
 from talos_agent.adapters.health import (
     AdapterHealthReporter,
     AdapterState,
     BrowserSessionProbe,
     DiscordProbe,
+    ErrorCategory,
     HealthReport,
     ProbeResult,
+    StellarPaymentProbe,
     TelegramProbe,
+    X402PaymentProbe,
     XProbe,
     _browser_is_live,
+    _sanitize_health_detail,
     _worst,
 )
 from talos_agent.adapters.registry import AdapterRegistry
-
+from talos_agent.cli import main
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -89,6 +96,27 @@ def _browser_no_stagehand():
     return browser
 
 
+def _stellar_kit(has_api=True, initialized=True):
+    kit = MagicMock()
+    kit._api = MagicMock() if has_api else None
+    kit._initialized = initialized
+    kit.health_snapshot = lambda: {"has_api": has_api, "initialized": initialized}
+    return kit
+
+
+def _x402_signer(has_api=True, initialized=True, has_wallet=True, wallet_address="GD5J..."):
+    signer = MagicMock()
+    signer._api = MagicMock() if has_api else None
+    signer._initialized = initialized
+    signer._wallet_address = wallet_address if has_wallet else None
+    signer.health_snapshot = lambda: {
+        "has_api": has_api,
+        "initialized": initialized,
+        "has_wallet": has_wallet,
+    }
+    return signer
+
+
 # ─── DiscordProbe ─────────────────────────────────────────────────────────────
 
 
@@ -97,30 +125,35 @@ class TestDiscordProbe:
     async def test_healthy_via_webhook(self):
         result = await DiscordProbe(_discord(webhook="https://discord.com/api/webhooks/x/y")).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert "webhook" in result.detail
 
     @pytest.mark.asyncio
     async def test_healthy_via_bot_token_and_channel(self):
         result = await DiscordProbe(_discord(bot_token="tok", channel_id="123")).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert "bot token" in result.detail
 
     @pytest.mark.asyncio
     async def test_degraded_token_without_channel(self):
         result = await DiscordProbe(_discord(bot_token="tok")).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.MISSING_CREDENTIALS
         assert "DISCORD_CHANNEL_ID" in result.detail
 
     @pytest.mark.asyncio
     async def test_degraded_channel_without_token(self):
         result = await DiscordProbe(_discord(channel_id="123")).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.MISSING_CREDENTIALS
         assert "DISCORD_BOT_TOKEN" in result.detail
 
     @pytest.mark.asyncio
     async def test_disabled_no_credentials(self):
         result = await DiscordProbe(_discord()).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
         assert result.adapter == "Discord"
 
     @pytest.mark.asyncio
@@ -130,6 +163,7 @@ class TestDiscordProbe:
             _discord(webhook="https://discord.com/api/webhooks/x/y", bot_token="tok", channel_id="123")
         ).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert "webhook" in result.detail
 
 
@@ -141,28 +175,33 @@ class TestTelegramProbe:
     async def test_healthy_both_credentials(self):
         result = await TelegramProbe(_telegram(bot_token="abc", chat_id="@chan")).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert result.adapter == "Telegram"
 
     @pytest.mark.asyncio
     async def test_degraded_token_only(self):
         result = await TelegramProbe(_telegram(bot_token="abc")).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.MISSING_CREDENTIALS
         assert "telegram_chat_id" in result.detail
 
     @pytest.mark.asyncio
     async def test_degraded_chat_only(self):
         result = await TelegramProbe(_telegram(chat_id="@chan")).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.MISSING_CREDENTIALS
         assert "telegram_bot_token" in result.detail
 
     @pytest.mark.asyncio
     async def test_disabled_no_credentials(self):
         result = await TelegramProbe(_telegram()).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
 
     @pytest.mark.asyncio
     async def test_healthy_detail_mentions_both(self):
         result = await TelegramProbe(_telegram(bot_token="t", chat_id="c")).probe()
+        assert result.error_category == ErrorCategory.NONE
         assert "bot token" in result.detail and "chat ID" in result.detail
 
 
@@ -176,12 +215,14 @@ class TestXProbe:
             _x_adapter(username="user", password="pass", browser=_live_browser())
         ).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert result.adapter == "X"
 
     @pytest.mark.asyncio
     async def test_degraded_creds_but_no_browser(self):
         result = await XProbe(_x_adapter(username="user", password="pass")).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.DEPENDENCY_UNAVAILABLE
         assert "browser session is not initialised" in result.detail
 
     @pytest.mark.asyncio
@@ -190,11 +231,13 @@ class TestXProbe:
             _x_adapter(username="user", password="pass", browser=_stagehand_no_page())
         ).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.DEPENDENCY_UNAVAILABLE
 
     @pytest.mark.asyncio
     async def test_disabled_no_credentials(self):
         result = await XProbe(_x_adapter()).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
         assert "X_USERNAME" in result.detail
 
     @pytest.mark.asyncio
@@ -202,6 +245,7 @@ class TestXProbe:
         # Only username — no password → disabled (not enough for login)
         result = await XProbe(_x_adapter(username="user")).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
 
 
 # ─── BrowserSessionProbe ─────────────────────────────────────────────────────
@@ -212,23 +256,100 @@ class TestBrowserSessionProbe:
     async def test_healthy_stagehand_with_page(self):
         result = await BrowserSessionProbe(_live_browser()).probe()
         assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
         assert result.adapter == "BrowserSession"
 
     @pytest.mark.asyncio
     async def test_degraded_stagehand_no_page(self):
         result = await BrowserSessionProbe(_stagehand_no_page()).probe()
         assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.DEPENDENCY_UNAVAILABLE
         assert "no page" in result.detail.lower()
 
     @pytest.mark.asyncio
     async def test_disabled_browser_no_stagehand(self):
         result = await BrowserSessionProbe(_browser_no_stagehand()).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
 
     @pytest.mark.asyncio
     async def test_disabled_none_browser(self):
         result = await BrowserSessionProbe(None).probe()
         assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
+
+
+# ─── StellarPaymentProbe ─────────────────────────────────────────────────────
+
+
+class TestStellarPaymentProbe:
+    @pytest.mark.asyncio
+    async def test_healthy_initialized_with_api(self):
+        result = await StellarPaymentProbe(_stellar_kit(has_api=True, initialized=True)).probe()
+        assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
+        assert result.adapter == "StellarPayment"
+        assert "initialized" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_degraded_uninitialized(self):
+        result = await StellarPaymentProbe(_stellar_kit(has_api=True, initialized=False)).probe()
+        assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.DEPENDENCY_UNAVAILABLE
+        assert "not initialized" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_api_client(self):
+        result = await StellarPaymentProbe(_stellar_kit(has_api=False)).probe()
+        assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
+        assert "disabled" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_disabled_none_instance(self):
+        result = await StellarPaymentProbe(None).probe()
+        assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
+
+
+# ─── X402PaymentProbe ────────────────────────────────────────────────────────
+
+
+class TestX402PaymentProbe:
+    @pytest.mark.asyncio
+    async def test_healthy_initialized_with_wallet(self):
+        result = await X402PaymentProbe(_x402_signer(has_api=True, initialized=True, has_wallet=True)).probe()
+        assert result.state == AdapterState.HEALTHY
+        assert result.error_category == ErrorCategory.NONE
+        assert result.adapter == "X402Signer"
+        # Secret check: ensure no private key or raw address is exposed in detail
+        assert "GD5J" not in result.detail
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_wallet(self):
+        result = await X402PaymentProbe(_x402_signer(has_api=True, initialized=True, has_wallet=False)).probe()
+        assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
+        assert "no agent wallet" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_degraded_uninitialized(self):
+        result = await X402PaymentProbe(_x402_signer(has_api=True, initialized=False)).probe()
+        assert result.state == AdapterState.DEGRADED
+        assert result.error_category == ErrorCategory.DEPENDENCY_UNAVAILABLE
+        assert "not initialized" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_api_client(self):
+        result = await X402PaymentProbe(_x402_signer(has_api=False)).probe()
+        assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
+
+    @pytest.mark.asyncio
+    async def test_disabled_none_instance(self):
+        result = await X402PaymentProbe(None).probe()
+        assert result.state == AdapterState.DISABLED
+        assert result.error_category == ErrorCategory.NONE
 
 
 # ─── _browser_is_live ─────────────────────────────────────────────────────────
@@ -255,15 +376,56 @@ class TestBrowserIsLive:
         assert _browser_is_live(_live_browser()) is True
 
 
+# ─── Sanitization ────────────────────────────────────────────────────────────
+
+
+class TestSanitization:
+    def test_redacts_stellar_secret_seed(self):
+        secret = "S" + "B" * 55
+        raw = f"Error with secret key {secret} in stellar connection"
+        sanitized = _sanitize_health_detail(raw)
+        assert secret not in sanitized
+        assert "[REDACTED]" in sanitized
+
+    def test_redacts_bearer_token(self):
+        token_body = "eyJhbGci" + "OiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        raw = f"Authorization failed with Bearer {token_body}"
+        sanitized = _sanitize_health_detail(raw)
+        assert token_body not in sanitized
+        assert "[REDACTED]" in sanitized
+
+    def test_redacts_discord_token(self):
+        token = "A" * 24 + "." + "B" * 6 + "." + "C" * 27
+        raw = f"Discord auth failed for token {token}"
+        sanitized = _sanitize_health_detail(raw)
+        assert token not in sanitized
+
+    def test_redacts_openai_key(self):
+        key = "sk-" + "a" * 32
+        raw = f"API key {key} invalid"
+        sanitized = _sanitize_health_detail(raw)
+        assert key not in sanitized
+        assert "[REDACTED]" in sanitized
+
+    def test_empty_string_safe(self):
+        assert _sanitize_health_detail("") == ""
+
+
 # ─── ProbeResult / HealthReport ───────────────────────────────────────────────
 
 
 class TestProbeResult:
     def test_to_dict_keys(self):
-        r = ProbeResult(adapter="Discord", state=AdapterState.HEALTHY, detail="ok")
+        r = ProbeResult(
+            adapter="Discord",
+            state=AdapterState.HEALTHY,
+            detail="ok",
+            error_category=ErrorCategory.NONE,
+        )
         d = r.to_dict()
-        assert set(d.keys()) == {"adapter", "state", "detail", "checked_at"}
+        assert set(d.keys()) == {"adapter", "state", "detail", "error_category", "checked_at"}
         assert d["state"] == "healthy"
+        assert d["error_category"] == "none"
 
     def test_checked_at_is_utc(self):
         r = ProbeResult(adapter="X", state=AdapterState.DISABLED)
@@ -272,6 +434,7 @@ class TestProbeResult:
     def test_default_detail_empty(self):
         r = ProbeResult(adapter="Telegram", state=AdapterState.DEGRADED)
         assert r.detail == ""
+        assert r.error_category == ErrorCategory.NONE
 
 
 class TestHealthReport:
@@ -279,8 +442,18 @@ class TestHealthReport:
         return HealthReport(
             overall=AdapterState.DEGRADED,
             adapters=[
-                ProbeResult(adapter="Discord", state=AdapterState.HEALTHY, detail="ok"),
-                ProbeResult(adapter="Telegram", state=AdapterState.DEGRADED, detail="partial"),
+                ProbeResult(
+                    adapter="Discord",
+                    state=AdapterState.HEALTHY,
+                    detail="ok",
+                    error_category=ErrorCategory.NONE,
+                ),
+                ProbeResult(
+                    adapter="Telegram",
+                    state=AdapterState.DEGRADED,
+                    detail="partial",
+                    error_category=ErrorCategory.MISSING_CREDENTIALS,
+                ),
             ],
         )
 
@@ -289,12 +462,19 @@ class TestHealthReport:
         assert d["overall"] == "degraded"
         assert len(d["adapters"]) == 2
         assert "checked_at" in d
+        assert d["adapters"][1]["error_category"] == "missing_credentials"
 
     def test_adapter_names_in_report(self):
         d = self._sample_report().to_dict()
         names = [a["adapter"] for a in d["adapters"]]
         assert "Discord" in names
         assert "Telegram" in names
+
+    def test_has_degraded_and_degraded_adapters(self):
+        report = self._sample_report()
+        assert report.has_degraded is True
+        assert len(report.degraded_adapters) == 1
+        assert report.degraded_adapters[0].adapter == "Telegram"
 
 
 # ─── _worst() ────────────────────────────────────────────────────────────────
@@ -345,6 +525,7 @@ class TestAdapterHealthReporter:
         assert report.overall == AdapterState.HEALTHY
         assert len(report.adapters) == 1
         assert report.adapters[0].state == AdapterState.HEALTHY
+        assert report.adapters[0].error_category == ErrorCategory.NONE
 
     @pytest.mark.asyncio
     async def test_aggregate_picks_worst_state(self):
@@ -375,51 +556,54 @@ class TestAdapterHealthReporter:
         assert report.adapters[0].state == AdapterState.HEALTHY
 
     @pytest.mark.asyncio
+    async def test_payment_adapters_included(self):
+        stellar = _stellar_kit(has_api=True, initialized=True)
+        signer = _x402_signer(has_api=True, initialized=True, has_wallet=True)
+        reporter = AdapterHealthReporter(stellar_kit=stellar, x402_signer=signer)
+        report = await reporter.report()
+        assert report.overall == AdapterState.HEALTHY
+        names = [a.adapter for a in report.adapters]
+        assert "StellarPayment" in names
+        assert "X402Signer" in names
+
+    @pytest.mark.asyncio
+    async def test_exception_in_one_probe_does_not_crash_report(self):
+        """When an adapter probe raises an unhandled exception, it is caught as DEGRADED."""
+        class CrashingAdapter:
+            channel_name = "Crashing"
+            def probe(self):
+                raise RuntimeError("database disk malfunction")
+
+        discord = _discord(webhook="https://discord.com/api/webhooks/x/y")
+        registry = _make_registry(discord, CrashingAdapter())
+        reporter = AdapterHealthReporter(registry)
+        report = await reporter.report()
+        assert report.overall == AdapterState.DEGRADED
+        adapters_by_name = {a.adapter: a for a in report.adapters}
+        assert adapters_by_name["Discord"].state == AdapterState.HEALTHY
+        assert adapters_by_name["Crashing"].state == AdapterState.DEGRADED
+        assert adapters_by_name["Crashing"].error_category == ErrorCategory.INTERNAL_ERROR
+        assert "RuntimeError" in adapters_by_name["Crashing"].detail
+
+    @pytest.mark.asyncio
     async def test_timeout_probe_returns_timeout_state(self):
         """A probe that hangs beyond the timeout is reported as TIMEOUT."""
 
-        class HangingProbe:
-            async def probe(self) -> ProbeResult:
-                await asyncio.sleep(99)  # never finishes in test
-                return ProbeResult(adapter="X", state=AdapterState.HEALTHY)
+        class HangingProbeAdapter:
+            channel_name = "Hanging"
 
-        # Patch the probe factory: make XAdapter produce a hanging probe
-        x_settings = MagicMock()
-        x_settings.x_username = "user"
-        x_settings.x_password = "pass"
-        x_adapter = MagicMock()
-        x_adapter.channel_name = "X"
-        x_adapter._settings = x_settings
-        x_adapter._browser = None
+            async def probe(self) -> ProbeResult:
+                await asyncio.sleep(99)
+                return ProbeResult(adapter="Hanging", state=AdapterState.HEALTHY)
 
         registry = AdapterRegistry()
-        registry.register(x_adapter)
-
-        # Use a very short timeout so the test doesn't actually wait 5 s
+        registry.register(HangingProbeAdapter())
         reporter = AdapterHealthReporter(registry, timeout=0.05)
+        report = await reporter.report()
 
-        # Monkey-patch the probe for "x" to a hanging one
-        async def patched_report():
-            reporter._registry._adapters["x"] = x_adapter
-            # Replace probe resolution inside reporter
-            probes = [("x", HangingProbe())]
-            from talos_agent.adapters.health import _run_with_timeout
-            coros = [_run_with_timeout(p.probe(), timeout=0.05) for _, p in probes]
-            raw = await asyncio.gather(*coros, return_exceptions=True)
-            results = []
-            for outcome in raw:
-                if isinstance(outcome, BaseException):
-                    results.append(
-                        ProbeResult(adapter="x", state=AdapterState.DEGRADED, detail=str(outcome))
-                    )
-                else:
-                    results.append(outcome)
-            from talos_agent.adapters.health import _worst, HealthReport
-            return HealthReport(overall=_worst([r.state for r in results]), adapters=results)
-
-        report = await patched_report()
         assert report.overall == AdapterState.TIMEOUT
         assert report.adapters[0].state == AdapterState.TIMEOUT
+        assert report.adapters[0].error_category == ErrorCategory.TIMEOUT
 
     @pytest.mark.asyncio
     async def test_report_to_dict_includes_overall_and_adapters(self):
@@ -431,6 +615,7 @@ class TestAdapterHealthReporter:
         assert "overall" in d
         assert "adapters" in d
         assert "checked_at" in d
+        assert d["adapters"][0]["error_category"] == "none"
 
     @pytest.mark.asyncio
     async def test_multiple_adapters_all_healthy(self):
@@ -441,3 +626,22 @@ class TestAdapterHealthReporter:
         report = await reporter.report()
         assert report.overall == AdapterState.HEALTHY
         assert len(report.adapters) == 2
+
+
+# ─── CLI Diagnostics Command Tests ───────────────────────────────────────────
+
+
+class TestDiagnosticsCLI:
+    def test_diagnostics_command_runs(self, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(main, ["diagnostics"])
+        assert result.exit_code == 0
+        assert "Adapter Health & Diagnostics" in result.output
+
+    def test_diagnostics_json_output(self, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(main, ["diagnostics", "--json"])
+        assert result.exit_code == 0
+        assert '"overall":' in result.output
+        assert '"adapters":' in result.output
+        assert '"error_category":' in result.output


### PR DESCRIPTION
## Summary

Addresses #421 by exposing comprehensive, privacy-safe, side-effect-free adapter health and degraded-state snapshots across all agent subsystems:
- **Social Channel Probes**: Discord, Telegram, and X probes now return typed `ErrorCategory` (`MISSING_CREDENTIALS`, `DEPENDENCY_UNAVAILABLE`, `TIMEOUT`, `INTERNAL_ERROR`, `NONE`) and sanitize detail strings.
- **Payment Component Probes**: Added `StellarPaymentProbe` (for `StellarKit`) and `X402PaymentProbe` (for `X402Signer`) to report in-process readiness without live network requests, signing operations, or secret exposure.
- **Sanitization & Redaction**: Regex-based redaction (`_sanitize_health_detail`) strips secret seeds (`S...`), OpenAI keys (`sk-...`), Discord bot tokens, basic auth credentials, and Bearer tokens from health messages and outputs.
- **Fault-Tolerant Concurrent Probing**: `AdapterHealthReporter` concurrent execution shields probe exceptions using an exception barrier so that a failing adapter probe never crashes the scheduler or the combined health report.
- **Telemetry & Scheduler Integration**: Enhanced `AdapterTelemetry` and `TelemetryCollector.add_adapter_health` with `error_category` and `checked_at`. Attached startup and periodic telemetry health snapshots in `scheduler.py`.
- **CLI Diagnostics**: Added `talos-agent diagnostics` command supporting formatted human-readable output and machine-readable `--json` output.

## Changes

- `packages/prime-agent/src/talos_agent/adapters/health.py`: Added `ErrorCategory`, `_sanitize_health_detail`, `StellarPaymentProbe`, `X402PaymentProbe`, exception shielding in `AdapterHealthReporter.report()`, and updated probes.
- `packages/prime-agent/src/talos_agent/adapters/__init__.py`: Exported `ErrorCategory`, `StellarPaymentProbe`, `X402PaymentProbe`.
- `packages/prime-agent/src/talos_agent/payments/stellar_kit.py`: Added `health_snapshot()` method.
- `packages/prime-agent/src/talos_agent/payments/x402_signer.py`: Added `health_snapshot()` method.
- `packages/prime-agent/src/talos_agent/telemetry.py`: Added `error_category` and `checked_at` fields to `AdapterTelemetry` and populated them in `add_adapter_health()`.
- `packages/prime-agent/src/talos_agent/scheduler.py`: Added startup adapter health snapshot and periodic adapter health probing in `telemetry_log_task`.
- `packages/prime-agent/src/talos_agent/cli.py`: Added `diagnostics` command (`--json`) and updated adapter health display in `telemetry` command.
- `packages/prime-agent/tests/test_adapter_health.py`: Comprehensive test suite covering healthy, degraded, disabled, timeout, exception-resilience, secret redaction, and CLI command execution.

## Verification

- Ran full pytest suite (129 tests passed cleanly).
- Verified CLI `diagnostics` and `diagnostics --json` commands.
- Verified ruff checks pass with no errors.

Closes #421.