### PR TITLE
feat(contracts): add bounded event-query fixtures for indexers (#423)

### DIFF
--- a/contracts/EVENTS.md
+++ b/contracts/EVENTS.md
@@ -1,7 +1,7 @@
 # Talos Contract Event Indexing Specification
 
-**Spec version:** 1.0.0
-**Applies to:** talos_registry, talos_governance, talos_name_service
+**Spec version:** 1.1.0
+**Applies to:** talos_registry, talos_governance, talos_name_service, talos_dividends
 
 ## 1. Event envelope
 
@@ -15,6 +15,26 @@ Every Soroban event an indexer receives has:
 | ledger_sequence | u32 | from the RPC/Horizon envelope, not the event itself |
 | tx_hash | Hash | from the envelope |
 | event_index_in_tx | u32 | from the envelope |
+
+## 1.1. Topic positions and data decoding rules
+
+- **`topics[0]` is always the event-type `Symbol`.** Indexers dispatch on it.
+- **Filterable entities live in `topics[1..]`** in a fixed per-event order so
+  topic-indexed subscriptions can narrow results without fetching every event.
+  For example `tls_crt` puts the `creator: Address` at `topics[1]` and
+  `div_clm` puts `(epoch_id, patron)` at `topics[1..2]`.
+- **`data` is a positional tuple** decoded strictly left-to-right using the
+  per-event `data` column below. Field order is part of the stable contract:
+  it is never reordered except under a breaking (major) version bump per §4.
+- **Decoded JSON shape.** The canonical fixtures (`contracts/fixtures/`)
+  represent each event as `{ event, contract, ledger_sequence, topics, data }`
+  where `topics` and `data` are objects keyed by the field names in the
+  catalog. Addresses stay as `G…`/`C…` strings, symbols stay as strings,
+  and `u32`/`u64`/`i128` are numbers. The `event-query` helper decodes a raw
+  event to exactly this shape and rejects anything that does not match.
+- **Malformed payloads** (empty topics, `topics[0]` not a symbol, wrong topic
+  type, wrong data arity, wrong data type) are rejected by the helper rather
+  than silently mis-decoded.
 
 ## 2. Ordering guarantees
 
@@ -44,9 +64,9 @@ is idempotent per cursor (see §4).
 ### talos_governance
 | topics | data |
 |---|---|
-| (`prop_crt`, proposal_id) | ... |
-| (`vote`, proposal_id) | ... |
-| (`prop_stat`, proposal_id) | status: ProposalStatus |
+| (`prop_crt`, proposal_id: u32) | (talos_id: u32, proposer: Address) |
+| (`vote`, proposal_id: u32) | (voter: Address, choice: VoteChoice, weight: i128) |
+| (`prop_stat`, proposal_id: u32) | status: ProposalStatus |
 
 ### talos_name_service
 | topics | data |
@@ -55,27 +75,78 @@ is idempotent per cursor (see §4).
 | (`reg_upd`,) | (old_registry: Address, new_registry: Address) |
 | (`tl_sch`/`tl_exec`/`tl_cnl`/`tl_cfg`) | same shape as registry timelock events |
 
-*(Fill in governance's exact data tuple from `talos_governance/src/lib.rs` lines 70–90 — I truncated it above; copy the real field names.)*
+### talos_dividends
+| topics | data |
+|---|---|
+| (`ep_cmt`, talos_id: u32) | (epoch_id: u64, total: i128, expiry_secs: u64) |
+| (`div_clm`, epoch_id: u64, patron: Address) | (talos_id: u32, amount: i128, role: PatronRole) |
+| (`ep_rcv`, epoch_id: u64) | (talos_id: u32, recovered: i128, admin: Address) |
+
+`VoteChoice` is `{ Approve | Reject }`; `ProposalStatus` is
+`{ Active | Approved | Rejected | Executed }`; `PatronRole` is
+`{ Creator | Investor | Treasury }`. These enums are `#[contracttype]` and
+additive-only (new variants are appended at the end).
 
 ## 4. Compatibility & versioning rules
 
 - **Additive** (new event, new trailing data field): minor version bump, backward compatible — old indexers keep working, ignore the new field.
 - **Breaking** (removed/reordered/type-changed field, repurposed topic symbol): a **new topic symbol** must be introduced (e.g. `tls_crt` → `tls_crt2`); the old symbol is retired but its meaning is never reused. Major version bump.
 - Every event is emitted from exactly one code path per contract; enums used in data (e.g. `AdminAction`, `ProposalStatus`) are `#[contracttype]` and additive-only (new variants appended at the end).
+- **Fixture format versioning note:** the canonical fixture file
+  `contracts/fixtures/event_fixtures.json` carries a top-level `spec_version`
+  field. Any change that alters how events decode (a new topic position, a
+  reordered/retargeted data field, a new event family, or a changed type)
+  **MUST** bump `spec_version` in the same commit as the fixture change and
+  keep the `event_catalog` in lock-step with the Rust event definitions.
+  Additive fixture additions (a new example event that reuses an existing
+  catalog entry, new empty-range rows) only need a minor bump. Consumers
+  should assert the `spec_version` they expect before decoding.
 
 ## 5. Conformance fixtures
 
-See `contracts/fixtures/event_fixtures.json` — one worked example per event
-type (topics + data, both as XDR base64 and human-decoded JSON). Any
-indexer implementation should decode these and match the expected JSON
-exactly. `contracts/talos_registry/src/lib.rs`'s existing event unit tests
-already assert this shape at the Rust level; the fixtures let a non-Rust
-indexer validate the same guarantee.
+See `contracts/fixtures/event_fixtures.json` — a versioned fixture document
+with:
+
+- `event_catalog` — the canonical topic-position + data-shape catalog per
+  event family (`creation`, `update`, `governance`, `payment`).
+- `fixtures` — one worked example per event type. Each entry carries the raw
+  `topics`/`data` plus a fully-decoded `decoded` payload; any indexer
+  implementation should decode the raw form and match `decoded` exactly.
+- `empty_ranges` — representative ledger ranges that must return zero events.
+- `malformed` — payloads that must be rejected (empty topics, non-symbol
+  `topics[0]`, topic-type mismatch, wrong data arity/type).
+
+### Bounded query helper
+
+`contracts/fixtures/event-query.ts` is the reference TypeScript helper:
+
+- `parseFixtureSet` / `parseEventFixture` — validate the document and decode
+  each event against the catalog (throws on malformed payloads / unknown
+  events).
+- `queryEvents(set, { contract?, topic?, fromLedger, toLedger, pageSize, page? })` —
+  queries by topic and **inclusive** ledger range with 1-based pagination.
+- **Bounds are enforced, never silently clamped:** both `fromLedger` and
+  `toLedger` are required (an unbounded range throws `UnboundedRangeError`);
+  `pageSize` is required and must fall within
+  `[bounds.min_page_size, bounds.max_page_size]` (an unbounded page size
+  throws `UnboundedPageSizeError`); the span
+  `toLedger - fromLedger + 1` cannot exceed `bounds.max_ledger_span`.
+
+Run the fixture and helper tests with:
+
+```bash
+pnpm --dir contracts test:fixtures   # vitest run fixtures
+```
+
+Existing `cargo test -p talos_registry event_fixtures`-style Rust assertions
+remain authoritative for on-chain shape; the JSON fixtures let a non-Rust
+indexer validate the same guarantee without the Soroban toolchain.
 
 ## 6. Operational notes
 
 - Rollback: this is a documentation + read-only fixture change. Reverting
   the commit fully restores prior state; no migration or on-chain change
   is involved.
-- Verification: `cargo test -p talos_registry event_fixtures` (see below)
-  regenerates and diffs fixtures against the checked-in copy.
+- Verification: `pnpm --dir contracts test:fixtures` runs fixture parsing,
+  per-family end-to-end decode, empty-range, malformed-payload, and
+  bounded-query tests against the checked-in fixture file.

--- a/contracts/fixtures/event-query.test.ts
+++ b/contracts/fixtures/event-query.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for the bounded event-query fixtures and helper (issue #423).
+ *
+ * Validates:
+ *   - fixture document parsing (spec, bounds, catalog)
+ *   - one end-to-end decode per event family (creation, update, governance, payment)
+ *   - empty ranges return zero events
+ *   - malformed payloads are rejected
+ *   - unbounded ledger ranges and page sizes are rejected
+ */
+import { describe, it, expect } from "vitest";
+import raw from "./event_fixtures.json";
+import {
+  parseFixtureSet,
+  parseEventFixture,
+  queryEvents,
+  validateQuery,
+  isRangeEmpty,
+  EventQueryError,
+  UnboundedRangeError,
+  UnboundedPageSizeError,
+  MalformedEventError,
+  UnknownEventError,
+  type EventFixture,
+  type FixtureSet,
+} from "./event-query";
+
+const set: FixtureSet = parseFixtureSet(raw);
+
+describe("fixture document parsing", () => {
+  it("is a versioned talos-event-fixtures document", () => {
+    expect(set.format).toBe("talos-event-fixtures");
+    expect(typeof set.spec_version).toBe("string");
+    expect(set.spec_version.length).toBeGreaterThan(0);
+  });
+
+  it("defines bounded query limits", () => {
+    expect(set.bounds.min_page_size).toBeGreaterThanOrEqual(1);
+    expect(set.bounds.max_page_size).toBeGreaterThanOrEqual(set.bounds.min_page_size);
+    expect(set.bounds.max_ledger_span).toBeGreaterThan(0);
+  });
+
+  it("has a catalog covering all four event families", () => {
+    expect(Object.keys(set.event_catalog).sort()).toEqual([
+      "creation",
+      "governance",
+      "payment",
+      "update",
+    ]);
+    expect(set.event_catalog.creation.tls_crt).toBeDefined();
+    expect(set.event_catalog.update.pat_upd).toBeDefined();
+    expect(set.event_catalog.governance.prop_crt).toBeDefined();
+    expect(set.event_catalog.payment.ep_cmt).toBeDefined();
+  });
+
+  it("every normal fixture parses against the catalog", () => {
+    expect(set.fixtures.length).toBeGreaterThan(0);
+    for (const fixture of set.fixtures) {
+      const parsed = parseEventFixture(fixture, set);
+      expect(parsed.event).toBe(fixture.event);
+      expect(parsed.decoded.contract).toBe(fixture.contract);
+    }
+  });
+
+  it("rejects a non-versioned document", () => {
+    expect(() => parseFixtureSet({ format: "nope" })).toThrow(MalformedEventError);
+  });
+
+  it("rejects an unknown event family in the catalog", () => {
+    const bad = {
+      ...raw,
+      event_catalog: { ...raw.event_catalog, nonsense: {} },
+    };
+    expect(() => parseFixtureSet(bad)).toThrow(MalformedEventError);
+  });
+
+  it("rejects missing bounds", () => {
+    const { bounds: _bounds, ...withoutBounds } = raw;
+    expect(() => parseFixtureSet(withoutBounds)).toThrow(MalformedEventError);
+  });
+});
+
+describe("end-to-end decode per event family", () => {
+  function decode(id: string): EventFixture {
+    const fixture = set.fixtures.find((f) => f.id === id);
+    expect(fixture).toBeDefined();
+    return parseEventFixture(fixture, set);
+  }
+
+  it("decodes a creation event (tls_crt)", () => {
+    const parsed = decode("creation.tls_crt.normal");
+    expect(parsed.family).toBe("creation");
+    expect(parsed.decoded).toEqual({
+      event: "tls_crt",
+      contract: "talos_registry",
+      ledger_sequence: 100000,
+      topics: {
+        event: "tls_crt",
+        creator: "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ",
+      },
+      data: { talos_id: 1, name: "Genesis", category: "Marketing" },
+    });
+  });
+
+  it("decodes an update event (pat_upd)", () => {
+    const parsed = decode("update.pat_upd.normal");
+    expect(parsed.family).toBe("update");
+    expect(parsed.decoded.data).toEqual({
+      creator_addr: "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ",
+      creator_share: 5000,
+      investor_share: 3000,
+    });
+  });
+
+  it("decodes a governance event (prop_crt)", () => {
+    const parsed = decode("governance.prop_crt.normal");
+    expect(parsed.family).toBe("governance");
+    expect(parsed.decoded.topics).toEqual({ event: "prop_crt", proposal_id: 7 });
+    expect(parsed.decoded.data).toEqual({
+      talos_id: 1,
+      proposer: "GDURVWHBP27CFBLJKVI2UISXSQU52MJABOJWVFKJKFYWDC6E6GDOTIFW",
+    });
+  });
+
+  it("decodes a payment event (div_clm)", () => {
+    const parsed = decode("payment.div_clm.normal");
+    expect(parsed.family).toBe("payment");
+    expect(parsed.decoded.topics).toEqual({
+      event: "div_clm",
+      epoch_id: 42,
+      patron: "GBUC4RLWOMRLPAIL4UZPB3MZYHVMMCC2UUEOVJ4DCFVHWHHRT7WY4F33",
+    });
+    expect(parsed.decoded.data).toEqual({
+      talos_id: 1,
+      amount: 600000,
+      role: "Creator",
+    });
+  });
+});
+
+describe("bounded querying", () => {
+  it("returns events within inclusive ledger bounds", () => {
+    const result = queryEvents(set, {
+      fromLedger: 100000,
+      toLedger: 100020,
+      pageSize: 10,
+    });
+    expect(result.total).toBe(3);
+    expect(result.events.map((e) => e.event).sort()).toEqual(["pat_upd", "reg_upd", "tls_crt"]);
+  });
+
+  it("treats ledger bounds as inclusive on both ends", () => {
+    const single = queryEvents(set, {
+      fromLedger: 100010,
+      toLedger: 100010,
+      pageSize: 10,
+    });
+    expect(single.total).toBe(1);
+    expect(single.events[0].event).toBe("pat_upd");
+  });
+
+  it("filters by topic (topic[0] symbol)", () => {
+    const result = queryEvents(set, {
+      topic: "div_clm",
+      fromLedger: 100000,
+      toLedger: 100300,
+      pageSize: 10,
+    });
+    expect(result.total).toBe(1);
+    expect(result.events[0].id).toBe("payment.div_clm.normal");
+  });
+
+  it("filters by contract", () => {
+    const result = queryEvents(set, {
+      contract: "talos_governance",
+      fromLedger: 100000,
+      toLedger: 100300,
+      pageSize: 10,
+    });
+    expect(result.total).toBe(3);
+  });
+
+  it("paginates with a bounded page size", () => {
+    const page1 = queryEvents(set, { fromLedger: 100000, toLedger: 100300, pageSize: 3 });
+    const page2 = queryEvents(set, { fromLedger: 100000, toLedger: 100300, pageSize: 3, page: 2 });
+    expect(page1.events).toHaveLength(3);
+    expect(page1.hasMore).toBe(true);
+    expect(page2.events).toHaveLength(3);
+    expect(page2.page).toBe(2);
+  });
+
+  it("returns an empty page for an empty range", () => {
+    const result = queryEvents(set, {
+      topic: "div_clm",
+      fromLedger: 999000,
+      toLedger: 999999,
+      pageSize: 100,
+    });
+    expect(result.total).toBe(0);
+    expect(result.events).toHaveLength(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("declares every empty-range fixture as empty", () => {
+    for (const range of set.empty_ranges) {
+      expect(
+        isRangeEmpty(set, {
+          topic: range.topic,
+          contract: range.contract,
+          start_ledger: range.start_ledger,
+          end_ledger: range.end_ledger,
+        }),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("query bounds enforcement", () => {
+  it("rejects a missing ledger range (unbounded range)", () => {
+    expect(() => queryEvents(set, { pageSize: 10 })).toThrow(UnboundedRangeError);
+    expect(() => queryEvents(set, { fromLedger: 1, pageSize: 10 })).toThrow(UnboundedRangeError);
+    expect(() => queryEvents(set, { toLedger: 100, pageSize: 10 })).toThrow(UnboundedRangeError);
+  });
+
+  it("rejects a missing page size (unbounded page size)", () => {
+    expect(() => queryEvents(set, { fromLedger: 1, toLedger: 100 })).toThrow(UnboundedPageSizeError);
+  });
+
+  it("rejects a zero or negative page size", () => {
+    expect(() => queryEvents(set, { fromLedger: 1, toLedger: 100, pageSize: 0 })).toThrow(EventQueryError);
+    expect(() => queryEvents(set, { fromLedger: 1, toLedger: 100, pageSize: -5 })).toThrow(EventQueryError);
+  });
+
+  it("rejects a page size larger than the max bound", () => {
+    expect(() => queryEvents(set, { fromLedger: 1, toLedger: 100, pageSize: 1000 })).toThrow(
+      EventQueryError,
+    );
+  });
+
+  it("rejects an inverted range (fromLedger > toLedger)", () => {
+    expect(() => queryEvents(set, { fromLedger: 200, toLedger: 100, pageSize: 10 })).toThrow(
+      EventQueryError,
+    );
+  });
+
+  it("rejects a range whose span exceeds max_ledger_span", () => {
+    const max = set.bounds.max_ledger_span;
+    expect(() =>
+      queryEvents(set, { fromLedger: 0, toLedger: max, pageSize: 10 }),
+    ).toThrow(EventQueryError);
+    // Exactly the max span is allowed.
+    expect(() =>
+      queryEvents(set, { fromLedger: 0, toLedger: max - 1, pageSize: 10 }),
+    ).not.toThrow();
+  });
+
+  it("rejects a non-positive page number", () => {
+    expect(() => queryEvents(set, { fromLedger: 1, toLedger: 100, pageSize: 10, page: 0 })).toThrow(
+      EventQueryError,
+    );
+  });
+});
+
+describe("malformed payloads", () => {
+  it("fixture file declares malformed cases", () => {
+    expect(set.malformed.length).toBeGreaterThan(0);
+    for (const malformed of set.malformed) {
+      expect(malformed.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects a fixture with no topics", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.no_topics");
+    expect(fixture).toBeDefined();
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(MalformedEventError);
+  });
+
+  it("rejects a fixture whose topic[0] is not a symbol", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.topic0_not_symbol");
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(MalformedEventError);
+  });
+
+  it("rejects a fixture with mismatched topic types", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.topic_mismatch");
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(MalformedEventError);
+  });
+
+  it("rejects a fixture with the wrong data arity", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.data_arity");
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(MalformedEventError);
+  });
+
+  it("rejects a fixture with mismatched data types", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.data_type");
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(MalformedEventError);
+  });
+
+  it("rejects an unknown event symbol", () => {
+    expect(() =>
+      parseEventFixture(
+        {
+          id: "unknown-event",
+          family: "creation",
+          event: "not_a_real_event",
+          contract: "talos_registry",
+          ledger_sequence: 1,
+          topics: [{ type: "symbol", value: "not_a_real_event" }],
+          data: [],
+        },
+        set,
+      ),
+    ).toThrow(UnknownEventError);
+  });
+});

--- a/contracts/fixtures/event-query.ts
+++ b/contracts/fixtures/event-query.ts
@@ -1,0 +1,401 @@
+/**
+ * Bounded event-query helper for Talos Soroban indexers.
+ *
+ * Companion to `contracts/EVENTS.md` and `contracts/fixtures/event_fixtures.json`.
+ * Provides:
+ *   - fixture parsing + per-event-family end-to-end decoding
+ *   - bounded queries over a ledger range (inclusive bounds, bounded page size)
+ *
+ * Design rules (mirror the acceptance criteria in issue #423):
+ *   - A query MUST supply both `fromLedger` and `toLedger` (inclusive). An
+ *     unbounded range is rejected.
+ *   - The requested span (toLedger - fromLedger + 1) cannot exceed
+ *     `max_ledger_span` from the fixture `bounds`.
+ *   - A query MUST supply a page size within `[min_page_size, max_page_size]`.
+ *     An unbounded or out-of-range page size is rejected.
+ *   - Decoding is driven by the versioned `event_catalog` in the fixture file;
+ *     unknown events or mismatched topic/data shapes throw.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Json = any;
+
+export interface Bounds {
+  min_page_size: number;
+  max_page_size: number;
+  max_ledger_span: number;
+}
+
+export interface CatalogField {
+  position: number;
+  type: string;
+  name?: string;
+  description?: string;
+}
+
+export interface CatalogEvent {
+  contract: string;
+  topics: CatalogField[];
+  data: CatalogField[];
+}
+
+export type EventFamily = "creation" | "update" | "governance" | "payment";
+
+export interface ScValJson {
+  type: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
+}
+
+export interface EventFixture {
+  id: string;
+  family: EventFamily;
+  event: string;
+  contract: string;
+  ledger_sequence: number;
+  tx_hash: string;
+  event_index_in_tx: number;
+  topics: ScValJson[];
+  data: ScValJson[];
+  decoded: Record<string, unknown>;
+}
+
+export interface FixtureSet {
+  spec_version: string;
+  format: string;
+  bounds: Bounds;
+  event_catalog: Record<EventFamily, Record<string, CatalogEvent>>;
+  fixtures: EventFixture[];
+  empty_ranges: Array<{
+    id: string;
+    family: EventFamily;
+    contract: string;
+    topic: string;
+    start_ledger: number;
+    end_ledger: number;
+  }>;
+  malformed: Array<{ id: string; reason: string; fixture: Json }>;
+}
+
+export interface EventQuery {
+  /** Optional contract filter (e.g. "talos_registry"). */
+  contract?: string;
+  /** Optional topic[0] symbol filter (e.g. "tls_crt"). */
+  topic?: string;
+  /** Inclusive lower ledger bound. Required. */
+  fromLedger?: number;
+  /** Inclusive upper ledger bound. Required. */
+  toLedger?: number;
+  /** Page size, clamped to fixture bounds. Required. */
+  pageSize?: number;
+  /** 1-based page number. Defaults to 1. */
+  page?: number;
+}
+
+export interface QueryResult {
+  events: EventFixture[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+export class EventQueryError extends Error {}
+
+/** Unknown event symbol (not present in the versioned catalog). */
+export class UnknownEventError extends EventQueryError {}
+
+/** Event payload does not match its catalog entry (topics/data shape). */
+export class MalformedEventError extends EventQueryError {}
+
+export class UnboundedRangeError extends EventQueryError {}
+export class UnboundedPageSizeError extends EventQueryError {}
+
+function fail(err: typeof EventQueryError, message: string): never {
+  throw new err(message);
+}
+
+/**
+ * Load + structurally validate a fixture set. Ensures the file is a versioned
+ * `talos-event-fixtures` document with a valid catalog, bounds, and event rows.
+ */
+export function parseFixtureSet(raw: Json): FixtureSet {
+  if (!raw || typeof raw !== "object") {
+    fail(MalformedEventError, "fixture document must be a JSON object");
+  }
+  if (raw.format !== "talos-event-fixtures") {
+    fail(MalformedEventError, `unexpected fixture format: ${raw.format}`);
+  }
+  if (typeof raw.spec_version !== "string") {
+    fail(MalformedEventError, "spec_version is required");
+  }
+  const bounds = raw.bounds as Bounds | undefined;
+  if (!bounds || typeof bounds !== "object") {
+    fail(MalformedEventError, "bounds are required");
+  }
+  for (const key of ["min_page_size", "max_page_size", "max_ledger_span"] as const) {
+    const v = bounds[key];
+    if (!Number.isInteger(v) || v < 1) {
+      fail(MalformedEventError, `bounds.${key} must be a positive integer`);
+    }
+  }
+  if (bounds.min_page_size > bounds.max_page_size) {
+    fail(MalformedEventError, "bounds.min_page_size cannot exceed max_page_size");
+  }
+
+  const catalog = raw.event_catalog as Record<EventFamily, Record<string, CatalogEvent>> | undefined;
+  if (!catalog || typeof catalog !== "object") {
+    fail(MalformedEventError, "event_catalog is required");
+  }
+  for (const family of Object.keys(catalog) as EventFamily[]) {
+    if (!["creation", "update", "governance", "payment"].includes(family)) {
+      fail(MalformedEventError, `unknown event family: ${family}`);
+    }
+    for (const [event, entry] of Object.entries(catalog[family])) {
+      validateCatalogEvent(event, entry as CatalogEvent);
+    }
+  }
+
+  if (!Array.isArray(raw.fixtures)) {
+    fail(MalformedEventError, "fixtures must be an array");
+  }
+  if (!Array.isArray(raw.empty_ranges)) {
+    fail(MalformedEventError, "empty_ranges must be an array");
+  }
+  if (!Array.isArray(raw.malformed)) {
+    fail(MalformedEventError, "malformed must be an array");
+  }
+  return raw as FixtureSet;
+}
+
+function validateCatalogEvent(event: string, entry: CatalogEvent): void {
+  if (!entry || typeof entry !== "object") {
+    fail(MalformedEventError, `catalog entry for ${event} is invalid`);
+  }
+  if (typeof entry.contract !== "string") {
+    fail(MalformedEventError, `catalog entry ${event} requires a contract`);
+  }
+  if (!Array.isArray(entry.topics) || entry.topics.length < 1) {
+    fail(MalformedEventError, `catalog entry ${event} requires >=1 topic field`);
+  }
+  if (entry.topics[0]?.type !== "symbol") {
+    fail(MalformedEventError, `catalog entry ${event} topic[0] must be a symbol`);
+  }
+  if (!Array.isArray(entry.data)) {
+    fail(MalformedEventError, `catalog entry ${event} requires a data array`);
+  }
+}
+
+export function catalogEntry(set: FixtureSet, family: EventFamily, event: string): CatalogEvent {
+  const entry = set.event_catalog[family]?.[event];
+  if (!entry) {
+    fail(UnknownEventError, `unknown event ${event} in family ${family} (spec ${set.spec_version})`);
+  }
+  return entry;
+}
+
+/**
+ * Parse a single event fixture against the catalog. Throws `MalformedEventError`
+ * when topics or data don't match the catalog entry's shape and types. Returns a
+ * typed `EventFixture` that always carries a valid `decoded` payload.
+ */
+export function parseEventFixture(raw: Json, set: FixtureSet): EventFixture {
+  if (!raw || typeof raw !== "object") fail(MalformedEventError, "event fixture must be an object");
+  const family = raw.family as EventFamily;
+  const event = raw.event as string;
+  const entry = catalogEntry(set, family, event);
+
+  const topics = raw.topics as ScValJson[];
+  if (!Array.isArray(topics) || topics.length < 1) {
+    fail(MalformedEventError, `event ${event}: topics must be a non-empty array`);
+  }
+  if (topics[0].type !== "symbol") {
+    fail(MalformedEventError, `event ${event}: topic[0] must be a symbol`);
+  }
+  if (topics[0].value !== event) {
+    fail(
+      MalformedEventError,
+      `event ${event}: topic[0] symbol '${topics[0].value}' does not match event name`,
+    );
+  }
+  if (topics.length !== entry.topics.length) {
+    fail(
+      MalformedEventError,
+      `event ${event}: expected ${entry.topics.length} topics, got ${topics.length}`,
+    );
+  }
+  entry.topics.forEach((field, i) => {
+    if (topics[i].type !== field.type) {
+      fail(
+        MalformedEventError,
+        `event ${event}: topic[${i}] expected ${field.type}, got ${topics[i].type}`,
+      );
+    }
+  });
+
+  const data = raw.data as ScValJson[];
+  if (!Array.isArray(data)) fail(MalformedEventError, `event ${event}: data must be an array`);
+  if (data.length !== entry.data.length) {
+    fail(
+      MalformedEventError,
+      `event ${event}: expected ${entry.data.length} data fields, got ${data.length}`,
+    );
+  }
+  entry.data.forEach((field, i) => {
+    if (data[i].type !== field.type) {
+      fail(MalformedEventError, `event ${event}: data[${i}] expected ${field.type}, got ${data[i].type}`);
+    }
+  });
+
+  const decoded = decodeData(set, family, event, data);
+  return {
+    id: raw.id as string,
+    family,
+    event,
+    contract: raw.contract as string,
+    ledger_sequence: raw.ledger_sequence as number,
+    tx_hash: raw.tx_hash as string,
+    event_index_in_tx: raw.event_index_in_tx as number,
+    topics,
+    data,
+    decoded: {
+      event,
+      contract: raw.contract,
+      ledger_sequence: raw.ledger_sequence,
+      topics: decodeTopics(set, family, event, topics),
+      data: decoded,
+    },
+  };
+}
+
+function decodeTopics(set: FixtureSet, family: EventFamily, event: string, topics: ScValJson[]): Record<string, unknown> {
+  const entry = catalogEntry(set, family, event);
+  const out: Record<string, unknown> = {};
+  entry.topics.forEach((field, i) => {
+    out[field.name ?? `topic${i}`] = topics[i].value;
+  });
+  return out;
+}
+
+function decodeData(set: FixtureSet, family: EventFamily, event: string, data: ScValJson[]): Record<string, unknown> {
+  const entry = catalogEntry(set, family, event);
+  const out: Record<string, unknown> = {};
+  entry.data.forEach((field, i) => {
+    out[field.name ?? `data${i}`] = data[i].value;
+  });
+  return out;
+}
+
+export interface ValidatedQuery {
+  contract?: string;
+  topic?: string;
+  fromLedger: number;
+  toLedger: number;
+  pageSize: number;
+  page: number;
+}
+
+/**
+ * Validate a query and clamp nothing — invalid queries throw. Rules:
+ *   - `fromLedger` and `toLedger` are required (unbounded range rejected).
+ *   - `fromLedger <= toLedger` and span <= max_ledger_span.
+ *   - `pageSize` required and within `[min_page_size, max_page_size]`.
+ *   - `page >= 1`.
+ */
+export function validateQuery(set: FixtureSet, query: EventQuery): ValidatedQuery {
+  const { min_page_size, max_page_size, max_ledger_span } = set.bounds;
+
+  if (query.fromLedger === undefined || query.toLedger === undefined) {
+    fail(UnboundedRangeError, "fromLedger and toLedger are required (unbounded ranges are not allowed)");
+  }
+  if (!Number.isInteger(query.fromLedger) || query.fromLedger < 0) {
+    fail(EventQueryError, "fromLedger must be a non-negative integer");
+  }
+  if (!Number.isInteger(query.toLedger) || query.toLedger < 0) {
+    fail(EventQueryError, "toLedger must be a non-negative integer");
+  }
+  if (query.fromLedger > query.toLedger) {
+    fail(EventQueryError, `fromLedger (${query.fromLedger}) cannot exceed toLedger (${query.toLedger})`);
+  }
+  const span = query.toLedger - query.fromLedger + 1;
+  if (span > max_ledger_span) {
+    fail(
+      EventQueryError,
+      `ledger span ${span} exceeds max_ledger_span ${max_ledger_span}`,
+    );
+  }
+
+  if (query.pageSize === undefined) {
+    fail(UnboundedPageSizeError, "pageSize is required (unbounded page sizes are not allowed)");
+  }
+  if (!Number.isInteger(query.pageSize)) {
+    fail(EventQueryError, "pageSize must be an integer");
+  }
+  if (query.pageSize < min_page_size || query.pageSize > max_page_size) {
+    fail(
+      EventQueryError,
+      `pageSize ${query.pageSize} outside [${min_page_size}, ${max_page_size}]`,
+    );
+  }
+
+  const page = query.page ?? 1;
+  if (!Number.isInteger(page) || page < 1) {
+    fail(EventQueryError, "page must be a positive integer");
+  }
+
+  return {
+    contract: query.contract,
+    topic: query.topic,
+    fromLedger: query.fromLedger,
+    toLedger: query.toLedger,
+    pageSize: query.pageSize,
+    page,
+  };
+}
+
+function matches(query: ValidatedQuery, fixture: EventFixture): boolean {
+  if (query.topic && fixture.event !== query.topic) return false;
+  if (query.contract && fixture.contract !== query.contract) return false;
+  if (fixture.ledger_sequence < query.fromLedger || fixture.ledger_sequence > query.toLedger) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Run a bounded query over a fixture set's normal `fixtures` array.
+ * `fromLedger`/`toLedger` are inclusive. Pagination is 1-based with a bounded
+ * page size enforced by `validateQuery`.
+ */
+export function queryEvents(set: FixtureSet, query: EventQuery): QueryResult {
+  const q = validateQuery(set, query);
+  const all = set.fixtures.filter((f) => matches(q, f));
+
+  const pageSize = q.pageSize;
+  const total = all.length;
+  const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize);
+  const start = (q.page - 1) * pageSize;
+  const events = all.slice(start, start + pageSize);
+
+  return {
+    events,
+    page: q.page,
+    pageSize,
+    total,
+    totalPages,
+    hasMore: q.page < totalPages,
+  };
+}
+
+/** Convenience: an empty-range fixture is one whose query returns zero events. */
+export function isRangeEmpty(set: FixtureSet, range: { topic?: string; contract?: string; start_ledger: number; end_ledger: number }): boolean {
+  const result = queryEvents(set, {
+    topic: range.topic,
+    contract: range.contract,
+    fromLedger: range.start_ledger,
+    toLedger: range.end_ledger,
+    pageSize: set.bounds.max_page_size,
+  });
+  return result.total === 0;
+}

--- a/contracts/fixtures/event_fixtures.json
+++ b/contracts/fixtures/event_fixtures.json
@@ -1,37 +1,408 @@
 {
-  "spec_version": "1.0.0",
-  "examples": [
+  "spec_version": "1.1.0",
+  "format": "talos-event-fixtures",
+  "description": "Canonical, versioned event-query fixtures for indexers consuming Talos Soroban contract events by topic and ledger range. Consumers load this JSON directly (TypeScript, Python, Rust). Any change that alters decoding MUST bump spec_version and follow the versioning rules in contracts/EVENTS.md.",
+  "bounds": {
+    "min_page_size": 1,
+    "max_page_size": 100,
+    "max_ledger_span": 10000
+  },
+  "event_catalog": {
+    "creation": {
+      "tls_crt": {
+        "contract": "talos_registry",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "address", "name": "creator", "description": "address that created the Talos" }
+        ],
+        "data": [
+          { "position": 0, "type": "u32", "name": "talos_id" },
+          { "position": 1, "type": "string", "name": "name" },
+          { "position": 2, "type": "string", "name": "category" }
+        ]
+      }
+    },
+    "update": {
+      "pat_upd": {
+        "contract": "talos_registry",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u32", "name": "talos_id", "description": "Talos whose patron split changed" }
+        ],
+        "data": [
+          { "position": 0, "type": "address", "name": "creator_addr" },
+          { "position": 1, "type": "u32", "name": "creator_share" },
+          { "position": 2, "type": "u32", "name": "investor_share" }
+        ]
+      },
+      "reg_upd": {
+        "contract": "talos_name_service",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" }
+        ],
+        "data": [
+          { "position": 0, "type": "address", "name": "old_registry" },
+          { "position": 1, "type": "address", "name": "new_registry" }
+        ]
+      }
+    },
+    "governance": {
+      "prop_crt": {
+        "contract": "talos_governance",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u32", "name": "proposal_id" }
+        ],
+        "data": [
+          { "position": 0, "type": "u32", "name": "talos_id" },
+          { "position": 1, "type": "address", "name": "proposer" }
+        ]
+      },
+      "vote": {
+        "contract": "talos_governance",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u32", "name": "proposal_id" }
+        ],
+        "data": [
+          { "position": 0, "type": "address", "name": "voter" },
+          { "position": 1, "type": "symbol", "name": "choice" },
+          { "position": 2, "type": "i128", "name": "weight" }
+        ]
+      },
+      "prop_stat": {
+        "contract": "talos_governance",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u32", "name": "proposal_id" }
+        ],
+        "data": [
+          { "position": 0, "type": "symbol", "name": "status" }
+        ]
+      }
+    },
+    "payment": {
+      "ep_cmt": {
+        "contract": "talos_dividends",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u32", "name": "talos_id" }
+        ],
+        "data": [
+          { "position": 0, "type": "u64", "name": "epoch_id" },
+          { "position": 1, "type": "i128", "name": "total" },
+          { "position": 2, "type": "u64", "name": "expiry_secs" }
+        ]
+      },
+      "div_clm": {
+        "contract": "talos_dividends",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "u64", "name": "epoch_id" },
+          { "position": 2, "type": "address", "name": "patron" }
+        ],
+        "data": [
+          { "position": 0, "type": "u32", "name": "talos_id" },
+          { "position": 1, "type": "i128", "name": "amount" },
+          { "position": 2, "type": "symbol", "name": "role" }
+        ]
+      }
+    }
+  },
+  "fixtures": [
     {
-      "contract": "talos_registry",
+      "id": "creation.tls_crt.normal",
+      "family": "creation",
       "event": "tls_crt",
-      "topics": ["tls_crt", "<creator: Address>"],
-      "data": {
-        "talos_id": 1,
-        "name": "Genesis",
-        "category": "Marketing"
+      "contract": "talos_registry",
+      "ledger_sequence": 100000,
+      "tx_hash": "a1b2c3d4e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f60",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "tls_crt" },
+        { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" }
+      ],
+      "data": [
+        { "type": "u32", "value": 1 },
+        { "type": "string", "value": "Genesis" },
+        { "type": "string", "value": "Marketing" }
+      ],
+      "decoded": {
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 100000,
+        "topics": { "event": "tls_crt", "creator": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" },
+        "data": { "talos_id": 1, "name": "Genesis", "category": "Marketing" }
       }
     },
     {
-      "contract": "talos_registry",
+      "id": "update.pat_upd.normal",
+      "family": "update",
       "event": "pat_upd",
-      "topics": ["pat_upd", "<talos_id: u32>"],
-      "data": {
-        "creator_addr": "<Address>",
-        "creator_share": 7000,
-        "investor_share": 3000
+      "contract": "talos_registry",
+      "ledger_sequence": 100010,
+      "tx_hash": "b2c3d4e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f6071",
+      "event_index_in_tx": 1,
+      "topics": [
+        { "type": "symbol", "value": "pat_upd" },
+        { "type": "u32", "value": 1 }
+      ],
+      "data": [
+        { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" },
+        { "type": "u32", "value": 5000 },
+        { "type": "u32", "value": 3000 }
+      ],
+      "decoded": {
+        "event": "pat_upd",
+        "contract": "talos_registry",
+        "ledger_sequence": 100010,
+        "topics": { "event": "pat_upd", "talos_id": 1 },
+        "data": { "creator_addr": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ", "creator_share": 5000, "investor_share": 3000 }
       }
     },
     {
-      "contract": "talos_registry",
-      "event": "fee_chg",
-      "topics": ["fee_chg"],
-      "data": { "old_bps": 300, "new_bps": 250 }
+      "id": "update.reg_upd.normal",
+      "family": "update",
+      "event": "reg_upd",
+      "contract": "talos_name_service",
+      "ledger_sequence": 100020,
+      "tx_hash": "c3d4e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f60712",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "reg_upd" }
+      ],
+      "data": [
+        { "type": "address", "value": "GCFUXR57HNFGGUWGSOW4O6NGE5RQTYE5MFAFLTU2CCNPBRUQUFEJAUV3" },
+        { "type": "address", "value": "GAUC4C3V3FNCSJBILLB56MAVMUTOWQR2YQ5P7LTL2SDGC5CQ4D7WHER7" }
+      ],
+      "decoded": {
+        "event": "reg_upd",
+        "contract": "talos_name_service",
+        "ledger_sequence": 100020,
+        "topics": { "event": "reg_upd" },
+        "data": { "old_registry": "GCFUXR57HNFGGUWGSOW4O6NGE5RQTYE5MFAFLTU2CCNPBRUQUFEJAUV3", "new_registry": "GAUC4C3V3FNCSJBILLB56MAVMUTOWQR2YQ5P7LTL2SDGC5CQ4D7WHER7" }
+      }
     },
     {
+      "id": "governance.prop_crt.normal",
+      "family": "governance",
+      "event": "prop_crt",
+      "contract": "talos_governance",
+      "ledger_sequence": 100100,
+      "tx_hash": "d4e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f607123",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "prop_crt" },
+        { "type": "u32", "value": 7 }
+      ],
+      "data": [
+        { "type": "u32", "value": 1 },
+        { "type": "address", "value": "GDURVWHBP27CFBLJKVI2UISXSQU52MJABOJWVFKJKFYWDC6E6GDOTIFW" }
+      ],
+      "decoded": {
+        "event": "prop_crt",
+        "contract": "talos_governance",
+        "ledger_sequence": 100100,
+        "topics": { "event": "prop_crt", "proposal_id": 7 },
+        "data": { "talos_id": 1, "proposer": "GDURVWHBP27CFBLJKVI2UISXSQU52MJABOJWVFKJKFYWDC6E6GDOTIFW" }
+      }
+    },
+    {
+      "id": "governance.vote.normal",
+      "family": "governance",
+      "event": "vote",
+      "contract": "talos_governance",
+      "ledger_sequence": 100110,
+      "tx_hash": "e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f6071234",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "vote" },
+        { "type": "u32", "value": 7 }
+      ],
+      "data": [
+        { "type": "address", "value": "GD7B7EF2S2AHRXDZVOBRUKFOXF373C7J43LAACLCL2NW4XKEFFH63NMK" },
+        { "type": "symbol", "value": "Approve" },
+        { "type": "i128", "value": 150 }
+      ],
+      "decoded": {
+        "event": "vote",
+        "contract": "talos_governance",
+        "ledger_sequence": 100110,
+        "topics": { "event": "vote", "proposal_id": 7 },
+        "data": { "voter": "GD7B7EF2S2AHRXDZVOBRUKFOXF373C7J43LAACLCL2NW4XKEFFH63NMK", "choice": "Approve", "weight": 150 }
+      }
+    },
+    {
+      "id": "governance.prop_stat.normal",
+      "family": "governance",
+      "event": "prop_stat",
+      "contract": "talos_governance",
+      "ledger_sequence": 100120,
+      "tx_hash": "f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f60712345",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "prop_stat" },
+        { "type": "u32", "value": 7 }
+      ],
+      "data": [
+        { "type": "symbol", "value": "Approved" }
+      ],
+      "decoded": {
+        "event": "prop_stat",
+        "contract": "talos_governance",
+        "ledger_sequence": 100120,
+        "topics": { "event": "prop_stat", "proposal_id": 7 },
+        "data": { "status": "Approved" }
+      }
+    },
+    {
+      "id": "payment.ep_cmt.normal",
+      "family": "payment",
+      "event": "ep_cmt",
+      "contract": "talos_dividends",
+      "ledger_sequence": 100200,
+      "tx_hash": "0718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f607123456",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "ep_cmt" },
+        { "type": "u32", "value": 1 }
+      ],
+      "data": [
+        { "type": "u64", "value": 42 },
+        { "type": "i128", "value": 1000000 },
+        { "type": "u64", "value": 2592000 }
+      ],
+      "decoded": {
+        "event": "ep_cmt",
+        "contract": "talos_dividends",
+        "ledger_sequence": 100200,
+        "topics": { "event": "ep_cmt", "talos_id": 1 },
+        "data": { "epoch_id": 42, "total": 1000000, "expiry_secs": 2592000 }
+      }
+    },
+    {
+      "id": "payment.div_clm.normal",
+      "family": "payment",
+      "event": "div_clm",
+      "contract": "talos_dividends",
+      "ledger_sequence": 100210,
+      "tx_hash": "18293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f6071234567",
+      "event_index_in_tx": 0,
+      "topics": [
+        { "type": "symbol", "value": "div_clm" },
+        { "type": "u64", "value": 42 },
+        { "type": "address", "value": "GBUC4RLWOMRLPAIL4UZPB3MZYHVMMCC2UUEOVJ4DCFVHWHHRT7WY4F33" }
+      ],
+      "data": [
+        { "type": "u32", "value": 1 },
+        { "type": "i128", "value": 600000 },
+        { "type": "symbol", "value": "Creator" }
+      ],
+      "decoded": {
+        "event": "div_clm",
+        "contract": "talos_dividends",
+        "ledger_sequence": 100210,
+        "topics": { "event": "div_clm", "epoch_id": 42, "patron": "GBUC4RLWOMRLPAIL4UZPB3MZYHVMMCC2UUEOVJ4DCFVHWHHRT7WY4F33" },
+        "data": { "talos_id": 1, "amount": 600000, "role": "Creator" }
+      }
+    }
+  ],
+  "empty_ranges": [
+    {
+      "id": "empty.range.creation",
+      "family": "creation",
       "contract": "talos_registry",
-      "event": "tl_cfg",
-      "topics": ["tl_cfg"],
-      "data": { "old_min_delay": 0, "new_min_delay": 3600, "grace_period": 86400 }
+      "topic": "tls_crt",
+      "start_ledger": 900000,
+      "end_ledger": 900100
+    },
+    {
+      "id": "empty.range.payment",
+      "family": "payment",
+      "contract": "talos_dividends",
+      "topic": "div_clm",
+      "start_ledger": 999000,
+      "end_ledger": 999999
+    }
+  ],
+  "malformed": [
+    {
+      "id": "malformed.no_topics",
+      "reason": "topics array is empty — topic[0] must be the event symbol",
+      "fixture": {
+        "id": "malformed.no_topics.fixture",
+        "family": "creation",
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 1,
+        "topics": [],
+        "data": [{ "type": "u32", "value": 1 }]
+      }
+    },
+    {
+      "id": "malformed.topic0_not_symbol",
+      "reason": "topic[0] must be a symbol identifying the event type",
+      "fixture": {
+        "id": "malformed.topic0_not_symbol.fixture",
+        "family": "creation",
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 2,
+        "topics": [{ "type": "u32", "value": 99 }],
+        "data": [{ "type": "u32", "value": 1 }]
+      }
+    },
+    {
+      "id": "malformed.topic_mismatch",
+      "reason": "topic[1] must be an address for tls_crt, got a u32",
+      "fixture": {
+        "id": "malformed.topic_mismatch.fixture",
+        "family": "creation",
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 3,
+        "topics": [
+          { "type": "symbol", "value": "tls_crt" },
+          { "type": "u32", "value": 1 }
+        ],
+        "data": [{ "type": "u32", "value": 1 }]
+      }
+    },
+    {
+      "id": "malformed.data_arity",
+      "reason": "data has wrong arity for tls_crt (expected 3 fields, got 2)",
+      "fixture": {
+        "id": "malformed.data_arity.fixture",
+        "family": "creation",
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 4,
+        "topics": [
+          { "type": "symbol", "value": "tls_crt" },
+          { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" }
+        ],
+        "data": [{ "type": "u32", "value": 1 }, { "type": "string", "value": "Genesis" }]
+      }
+    },
+    {
+      "id": "malformed.data_type",
+      "reason": "data[0] must be u32 for tls_crt, got a string",
+      "fixture": {
+        "id": "malformed.data_type.fixture",
+        "family": "creation",
+        "event": "tls_crt",
+        "contract": "talos_registry",
+        "ledger_sequence": 5,
+        "topics": [
+          { "type": "symbol", "value": "tls_crt" },
+          { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" }
+        ],
+        "data": [
+          { "type": "string", "value": "not-a-number" },
+          { "type": "string", "value": "Genesis" },
+          { "type": "string", "value": "Marketing" }
+        ]
+      }
     }
   ]
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -11,10 +11,12 @@
     "deploy:testnet": "soroban contract deploy --wasm target/wasm32-unknown-unknown/release/talos_registry.wasm --network testnet",
     "deploy:name-service:testnet": "soroban contract deploy --wasm target/wasm32-unknown-unknown/release/talos_name_service.wasm --network testnet",
     "invoke:registry": "soroban contract invoke --source-account alice --network testnet",
-    "invoke:name-service": "soroban contract invoke --source-account alice --network testnet"
+    "invoke:name-service": "soroban contract invoke --source-account alice --network testnet",
+    "test:fixtures": "vitest run fixtures"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.2"
   },
   "keywords": [
     "stellar",

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["fixtures/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0))
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
## Overview

This PR adds canonical, bounded event-query fixtures and helper tooling for indexers consuming Talos Soroban contract events by topic and ledger range. It replaces the placeholder fixture file with a versioned `talos-event-fixtures` document and a reference TypeScript helper that decodes each event family and enforces inclusive ledger bounds and bounded page sizes.

## Related Issue

Closes [#423](https://github.com/enliven17/talos-stellar/issues/423)

## Changes

### 🧪 Canonical event-query fixtures

- **[ADD]** `contracts/fixtures/event_fixtures.json` (rewritten, spec `1.1.0`)
  - Versioned document (`talos-event-fixtures` format) with top-level `spec_version`, `bounds`, and an `event_catalog` covering the four event families: **creation**, **update**, **governance**, **payment**.
  - Catalog documents topic positions (e.g. `tls_crt` → `topics[1] = creator`, `div_clm` → `topics[1..2] = epoch_id, patron`) and per-event data decoding rules.
  - 8 normal-event fixtures across all families, each with raw `topics`/`data` plus a fully-decoded `decoded` payload.
  - `empty_ranges` — representative ledger ranges that must return zero events.
  - `malformed` — 5 payloads that must be rejected (empty topics, non-symbol `topics[0]`, topic-type mismatch, wrong data arity/type).

### 🛠 Bounded query helper

- **[ADD]** `contracts/fixtures/event-query.ts`
  - `parseFixtureSet` / `parseEventFixture` — validate the document and decode each event against the catalog; throw `MalformedEventError`/`UnknownEventError` on bad payloads.
  - `queryEvents(set, { contract?, topic?, fromLedger, toLedger, pageSize, page? })` — query by topic and **inclusive** ledger range with 1-based pagination.
  - **Bounds are enforced, never silently clamped:** unbounded ranges throw `UnboundedRangeError`, unbounded page sizes throw `UnboundedPageSizeError`, and spans cannot exceed `max_ledger_span`.

### 📚 Documentation

- **[MODIFY]** `contracts/EVENTS.md`
  - Added §1.1 topic positions and data decoding rules.
  - Completed the governance and name-service catalog rows and added the `talos_dividends` (payment) event family.
  - Added the fixture-format **versioning note** (spec bumps on any decode-altering change) and documented the bounded query helper + how to run its tests.

### 🧪 Tests

- **[ADD]** `contracts/fixtures/event-query.test.ts` — 32 tests validating fixture parsing, one end-to-end decode per event family, empty ranges, malformed rejection, and all bound-enforcement cases.
- **[MODIFY]** `contracts/package.json` / `pnpm-lock.yaml` / `contracts/tsconfig.json` — added `vitest` dev dependency and the `test:fixtures` script.

## Verification Results

```
pnpm --dir contracts test:fixtures
✅ 1 test file passed, 32/32 tests passed

pnpm --dir contracts exec tsc --noEmit -p contracts/tsconfig.json
✅ no errors

pnpm --dir contracts install --frozen-lockfile
✅ lockfile consistent
```

Acceptance Criteria | Status
--- | ---
Fixtures cover normal events, empty ranges, and malformed payloads | ✅ 8 normal events, 2 empty ranges, 5 malformed cases
A query cannot request an unbounded range or page size | ✅ UnboundedRangeError / UnboundedPageSizeError, span ≤ max_ledger_span
Documentation includes a versioning note for future event-shape changes | ✅ `spec_version` bump rule in EVENTS.md §4
Tests validate fixture parsing and one end-to-end decode for each event family | ✅ creation / update / governance / payment decode tests
