### PR TITLE
Feat/contract fixture validation

### DIFF
--- a/contracts/fixtures/event-query.test.ts
+++ b/contracts/fixtures/event-query.test.ts
@@ -312,3 +312,36 @@ describe("malformed payloads", () => {
     ).toThrow(UnknownEventError);
   });
 });
+
+describe("malformed-fixture failure-path check", () => {
+  it("rejects fixture set with missing format", () => {
+    const bad = { ...raw };
+    delete (bad as any).format;
+    expect(() => parseFixtureSet(bad)).toThrow(MalformedEventError);
+  });
+
+  it("rejects fixture set with invalid bounds min/max page size", () => {
+    const bad = {
+      ...raw,
+      bounds: {
+        min_page_size: 10,
+        max_page_size: 5,
+        max_ledger_span: 100,
+      },
+    };
+    expect(() => parseFixtureSet(bad)).toThrow(MalformedEventError);
+  });
+
+  it("rejects an invalid event fixture with mismatched topic[0] symbol value", () => {
+    const badFixture = {
+      id: "bad.mismatched_symbol",
+      family: "creation",
+      event: "tls_crt",
+      contract: "talos_registry",
+      ledger_sequence: 100,
+      topics: [{ type: "symbol", value: "wrong_symbol_name" }],
+      data: [],
+    };
+    expect(() => parseEventFixture(badFixture, set)).toThrow(MalformedEventError);
+  });
+});

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -12,7 +12,7 @@
     "deploy:name-service:testnet": "soroban contract deploy --wasm target/wasm32-unknown-unknown/release/talos_name_service.wasm --network testnet",
     "invoke:registry": "soroban contract invoke --source-account alice --network testnet",
     "invoke:name-service": "soroban contract invoke --source-account alice --network testnet",
-    "test:fixtures": "vitest run fixtures"
+    "test:fixtures": "tsc --noEmit && vitest run fixtures"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "stack:up": "bash scripts/local-stack.sh up",
     "stack:down": "bash scripts/local-stack.sh down",
     "stack:logs": "bash scripts/local-stack.sh logs",
-    "stack:reset": "bash scripts/local-stack.sh reset"
+    "stack:reset": "bash scripts/local-stack.sh reset",
+    "test:fixtures": "pnpm --dir contracts test:fixtures"
   },
   "dependencies": {
     "next": "16.2.2"


### PR DESCRIPTION
closes #442 

Unified Validation Command: Configured a single script "test:fixtures" in contracts/package.json that chains TypeScript compilation check (tsc --noEmit) and Vitest test suite (vitest run fixtures).
Workspace-level Delegation: Added a root-level "test:fixtures" script in package.json to delegate the validation execution directly via pnpm --dir contracts test:fixtures.
Failure-Path Coverage: Expanded the unit tests in contracts/fixtures/event-query.test.ts to include a malformed-fixture failure-path check block. This asserts that malformed fixture documents (e.g. missing spec/format keys, invalid page boundaries, and mismatched topic[0] symbols) throw the expected validation errors.
Verification & Git Operations: Verified that both type-checking and tests pass, confirmed that failing checks exit with a non-zero exit code, and pushed the work to GitHub under the branch feat/contract-fixture-validation.