### PR TITLE
feat(web): validate marketplace sort parameters and preserve stable ordering

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -621,6 +621,8 @@ export class TalosClient {
       category?: string;
       channel?: string;
       search?: string;
+      sort?: "createdAt" | "price" | "title";
+      direction?: "asc" | "desc";
     } & CursorRequestOptions,
   ): Promise<CursorPage<Playbook>> {
     return this.requestPage("/api/playbooks", params);

--- a/packages/sdk/src/generated-types.ts
+++ b/packages/sdk/src/generated-types.ts
@@ -553,7 +553,7 @@ export interface paths {
         };
         /**
          * Discover services marketplace
-         * @description Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.
+         * @description Returns registered services across all TALOS agents with cursor pagination. Optionally exclude your own services via `self`. Supports `sort` (`createdAt` or `price`) and `direction` (`asc` or `desc`, default `desc`). When omitted, results are ordered deterministically by `createdAt` descending with `id` as a tiebreaker. Cursor pagination is only compatible with the default `createdAt` descending sort.
          */
         get: operations["discoverServices"];
         put?: never;
@@ -648,7 +648,7 @@ export interface paths {
         };
         /**
          * List playbooks
-         * @description Returns active playbooks with optional filters. Supports cursor pagination.
+         * @description Returns active playbooks with optional filters and cursor pagination. Supports `sort` (`createdAt`, `price`, or `title`) and `direction` (`asc` or `desc`, default `desc`). When omitted, results are ordered deterministically by `createdAt` descending with `id` as a tiebreaker. Cursor pagination is only compatible with the default `createdAt` descending sort.
          */
         get: operations["listPlaybooks"];
         put?: never;
@@ -1843,10 +1843,14 @@ export interface components {
         jobId: string;
         /** @description Playbook ID */
         playbookId: string;
-        /** @description Opaque pagination cursor returned from the previous page's `nextCursor` */
+        /** @description Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort. */
         cursorParam: string;
         /** @description Max items per page (1–100) */
         limitParam: number;
+        /** @description Sort field. Supported values depend on the endpoint (e.g. `createdAt`, `price`). Defaults to `createdAt`. */
+        sortParam: string;
+        /** @description Sort direction (`asc` or `desc`). Defaults to `desc`. */
+        directionParam: "asc" | "desc";
     };
     requestBodies: never;
     headers: {
@@ -3357,7 +3361,11 @@ export interface operations {
                 category?: string;
                 /** @description TALOS ID to exclude from results (your own services) */
                 self?: string;
-                /** @description Opaque pagination cursor returned from the previous page's `nextCursor` */
+                /** @description Sort field. Supported values depend on the endpoint (e.g. `createdAt`, `price`). Defaults to `createdAt`. */
+                sort?: components["parameters"]["sortParam"];
+                /** @description Sort direction (`asc` or `desc`). Defaults to `desc`. */
+                direction?: components["parameters"]["directionParam"];
+                /** @description Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort. */
                 cursor?: components["parameters"]["cursorParam"];
                 /** @description Max items per page (1–100) */
                 limit?: components["parameters"]["limitParam"];
@@ -3387,6 +3395,13 @@ export interface operations {
                         }[];
                     };
                 };
+            };
+            /** @description Invalid `sort` or `direction`, or cursor used with a non-default sort */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             500: components["responses"]["InternalError"];
         };
@@ -3635,7 +3650,11 @@ export interface operations {
                 channel?: "All" | "X" | "LinkedIn" | "Reddit" | "Product Hunt";
                 /** @description Full-text search in title, description, and tags */
                 search?: string;
-                /** @description Opaque pagination cursor returned from the previous page's `nextCursor` */
+                /** @description Sort field. Supported values depend on the endpoint (e.g. `createdAt`, `price`). Defaults to `createdAt`. */
+                sort?: components["parameters"]["sortParam"];
+                /** @description Sort direction (`asc` or `desc`). Defaults to `desc`. */
+                direction?: components["parameters"]["directionParam"];
+                /** @description Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort. */
                 cursor?: components["parameters"]["cursorParam"];
                 /** @description Max items per page (1–100) */
                 limit?: components["parameters"]["limitParam"];
@@ -3656,6 +3675,13 @@ export interface operations {
                         data?: components["schemas"]["Playbook"][];
                     };
                 };
+            };
+            /** @description Invalid `sort` or `direction`, or cursor used with a non-default sort */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             500: components["responses"]["InternalError"];
         };

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -65,6 +65,8 @@ export interface DiscoverServicesParams {
   self?: string;
   cursor?: string;
   limit?: number;
+  sort?: "createdAt" | "price";
+  direction?: "asc" | "desc";
   signal?: AbortSignal;
 }
 

--- a/web/src/app/api/playbooks/route.ts
+++ b/web/src/app/api/playbooks/route.ts
@@ -1,9 +1,16 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsPlaybooks, tlsPlaybookPurchases } from "@/db/schema";
-import { and, arrayContains, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
+import { and, arrayContains, eq, ilike, lt, or, sql, type SQLWrapper } from "drizzle-orm";
 import { createPlaybookSchema, parseBody } from "@/lib/schemas";
 import { parseLimit } from "@/lib/parse-limit";
+import {
+  buildMarketplaceOrderBy,
+  isDefaultMarketplaceSort,
+  parseMarketplaceSort,
+  PLAYBOOKS_SORT_FIELDS,
+  type PlaybooksSortField,
+} from "@/lib/marketplace-sort";
 import { withTraceContext } from "@/lib/tracing";
 
 
@@ -18,6 +25,33 @@ export async function GET(request: NextRequest) {
     const parsedLimit = parseLimit(searchParams.get("limit"), 50, 100);
     if (!parsedLimit.ok) return parsedLimit.response;
     const limit = parsedLimit.limit;
+
+    const parsedSort = parseMarketplaceSort(
+      searchParams.get("sort"),
+      searchParams.get("direction"),
+      { allowedFields: PLAYBOOKS_SORT_FIELDS, fieldLabel: "createdAt, price, title" },
+    );
+    if (!parsedSort.ok) return parsedSort.response;
+    const sort = parsedSort.sort;
+
+    // Cursor pagination encodes a `createdAt|id` position, so it is only
+    // compatible with the default `createdAt desc` ordering.
+    if (cursor && !isDefaultMarketplaceSort(sort)) {
+      return Response.json(
+        {
+          error:
+            "cursor pagination is only supported with the default createdAt desc sort",
+        },
+        { status: 400 },
+      );
+    }
+
+    const sortColumns: Record<PlaybooksSortField, SQLWrapper> = {
+      createdAt: tlsPlaybooks.createdAt,
+      price: tlsPlaybooks.price,
+      title: tlsPlaybooks.title,
+    };
+    const orderBy = buildMarketplaceOrderBy(sort, sortColumns, tlsPlaybooks.id);
 
     const conditions = [eq(tlsPlaybooks.status, "active")];
 
@@ -88,7 +122,7 @@ export async function GET(request: NextRequest) {
       .innerJoin(tlsTalos, eq(tlsPlaybooks.talosId, tlsTalos.id))
       .leftJoin(purchaseCount, eq(tlsPlaybooks.id, purchaseCount.playbookId))
       .where(and(...conditions))
-      .orderBy(desc(tlsPlaybooks.createdAt), desc(tlsPlaybooks.id))
+      .orderBy(...orderBy)
       .limit(limit + 1);
 
     const hasMore = playbooks.length > limit;

--- a/web/src/app/api/services/route.ts
+++ b/web/src/app/api/services/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest } from "next/server";
 import { db } from "@/db";
 import { tlsTalos, tlsCommerceServices } from "@/db/schema";
-import { and, desc, eq, ilike, lt, ne, or } from "drizzle-orm";
+import { and, eq, ilike, lt, ne, or, type SQLWrapper } from "drizzle-orm";
 import { parseLimit } from "@/lib/parse-limit";
+import {
+  buildMarketplaceOrderBy,
+  isDefaultMarketplaceSort,
+  parseMarketplaceSort,
+  SERVICES_SORT_FIELDS,
+  type ServicesSortField,
+} from "@/lib/marketplace-sort";
 import { fetchReputations } from "@/lib/reputation-ledger";
 import { withTraceContext } from "@/lib/tracing";
 
@@ -16,6 +23,36 @@ async function handleGet(request: NextRequest) {
     const parsedLimit = parseLimit(searchParams.get("limit"), 50, 100);
     if (!parsedLimit.ok) return parsedLimit.response;
     const limit = parsedLimit.limit;
+
+    const parsedSort = parseMarketplaceSort(
+      searchParams.get("sort"),
+      searchParams.get("direction"),
+      { allowedFields: SERVICES_SORT_FIELDS, fieldLabel: "createdAt, price" },
+    );
+    if (!parsedSort.ok) return parsedSort.response;
+    const sort = parsedSort.sort;
+
+    // Cursor pagination encodes a `createdAt|id` position, so it is only
+    // compatible with the default `createdAt desc` ordering.
+    if (cursor && !isDefaultMarketplaceSort(sort)) {
+      return Response.json(
+        {
+          error:
+            "cursor pagination is only supported with the default createdAt desc sort",
+        },
+        { status: 400 },
+      );
+    }
+
+    const sortColumns: Record<ServicesSortField, SQLWrapper> = {
+      createdAt: tlsCommerceServices.createdAt,
+      price: tlsCommerceServices.price,
+    };
+    const orderBy = buildMarketplaceOrderBy(
+      sort,
+      sortColumns,
+      tlsCommerceServices.id,
+    );
 
     const minScore = searchParams.has("minScore") ? Number(searchParams.get("minScore")) : undefined;
     const minConfidence = searchParams.has("minConfidence") ? Number(searchParams.get("minConfidence")) : undefined;
@@ -71,7 +108,7 @@ async function handleGet(request: NextRequest) {
         .from(tlsCommerceServices)
         .innerJoin(tlsTalos, eq(tlsCommerceServices.talosId, tlsTalos.id))
         .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(desc(tlsCommerceServices.createdAt), desc(tlsCommerceServices.id))
+        .orderBy(...orderBy)
         .limit(limit * 2);
 
       if (services.length === 0) {
@@ -124,12 +161,6 @@ async function handleGet(request: NextRequest) {
         }
         currentCursor = `${service.createdAt.toISOString()}|${service.id}`;
       }
-    }
-
-    // Shuffle for diversity — agents see different services each cycle
-    for (let i = accumulated.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [accumulated[i], accumulated[j]] = [accumulated[j], accumulated[i]];
     }
 
     const nextCursor = (exhausted && accumulated.length < limit) ? null : currentCursor;

--- a/web/src/lib/marketplace-sort.ts
+++ b/web/src/lib/marketplace-sort.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared marketplace sort parser for the list API endpoints.
+ *
+ * The marketplace endpoints (`GET /api/services`, `GET /api/playbooks`)
+ * accept `sort` (field) and `direction` (asc|desc) query parameters.
+ *
+ * Rules:
+ * - When a parameter is absent, the deterministic default is used
+ *   (`createdAt` descending) so omitted parameters remain stable and
+ *   cursor-compatible.
+ * - Unknown sort fields and directions are rejected with a 400 response so
+ *   invalid values never reach the query builder.
+ * - Cursor pagination is only compatible with the default `createdAt desc`
+ *   ordering; routes reject a cursor combined with any other sort via
+ *   `isDefaultMarketplaceSort`.
+ */
+import type { SQL, SQLWrapper } from "drizzle-orm";
+import { asc, desc } from "drizzle-orm";
+
+export const MARKETPLACE_SORT_DIRECTIONS = ["asc", "desc"] as const;
+export type MarketplaceSortDirection =
+  (typeof MARKETPLACE_SORT_DIRECTIONS)[number];
+
+export const SERVICES_SORT_FIELDS = ["createdAt", "price"] as const;
+export type ServicesSortField = (typeof SERVICES_SORT_FIELDS)[number];
+
+export const PLAYBOOKS_SORT_FIELDS = ["createdAt", "price", "title"] as const;
+export type PlaybooksSortField = (typeof PLAYBOOKS_SORT_FIELDS)[number];
+
+export const DEFAULT_MARKETPLACE_SORT_FIELD = "createdAt";
+export const DEFAULT_MARKETPLACE_SORT_DIRECTION = "desc";
+
+export interface MarketplaceSort<TField extends string> {
+  field: TField;
+  direction: MarketplaceSortDirection;
+}
+
+export interface MarketplaceSortConfig<TField extends string> {
+  allowedFields: readonly TField[];
+  fieldLabel: string;
+}
+
+export type ParseMarketplaceSortResult<TField extends string> =
+  | { ok: true; sort: MarketplaceSort<TField> }
+  | { ok: false; response: Response };
+
+/**
+ * Parse and validate `sort` and `direction` query values.
+ *
+ * Returns `{ ok: false; response }` for unknown fields/directions (HTTP 400)
+ * and `{ ok: true; sort }` with the deterministic defaults filled in when the
+ * parameters are omitted.
+ */
+export function parseMarketplaceSort<TField extends string>(
+  rawField: string | null,
+  rawDirection: string | null,
+  config: MarketplaceSortConfig<TField>,
+): ParseMarketplaceSortResult<TField> {
+  if (
+    rawField !== null &&
+    !config.allowedFields.includes(rawField as TField)
+  ) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: `Invalid sort field. Supported fields: ${config.fieldLabel}` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (
+    rawDirection !== null &&
+    !MARKETPLACE_SORT_DIRECTIONS.includes(
+      rawDirection as MarketplaceSortDirection,
+    )
+  ) {
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: "Invalid sort direction. Supported directions: asc, desc",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const field = (
+    rawField === null || rawField === "" ? DEFAULT_MARKETPLACE_SORT_FIELD : rawField
+  ) as TField;
+  const direction =
+    rawDirection === null || rawDirection === ""
+      ? DEFAULT_MARKETPLACE_SORT_DIRECTION
+      : (rawDirection as MarketplaceSortDirection);
+
+  return { ok: true, sort: { field, direction } };
+}
+
+/**
+ * True only for the default `createdAt desc` ordering, which is the ordering
+ * the `createdAt|id` cursor pagination scheme is compatible with.
+ */
+export function isDefaultMarketplaceSort<TField extends string>(
+  sort: MarketplaceSort<TField>,
+): boolean {
+  return (
+    sort.field === DEFAULT_MARKETPLACE_SORT_FIELD &&
+    sort.direction === DEFAULT_MARKETPLACE_SORT_DIRECTION
+  );
+}
+
+/**
+ * Build the drizzle `orderBy` clauses for a validated marketplace sort.
+ *
+ * The selected column is ordered by the requested direction and `id` is
+ * appended as a deterministic tiebreaker so the ordering is always total and
+ * stable across pages.
+ */
+export function buildMarketplaceOrderBy<TField extends string>(
+  sort: MarketplaceSort<TField>,
+  columns: Record<TField, SQLWrapper>,
+  idColumn: SQLWrapper,
+): SQL[] {
+  const order = sort.direction === "asc" ? asc : desc;
+  return [order(columns[sort.field]), desc(idColumn)];
+}

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -1055,13 +1055,25 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         name: "cursor",
         in: "query",
         schema: { type: "string" },
-        description: "Opaque pagination cursor returned from the previous page's `nextCursor`",
+        description: "Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort.",
       },
       limitParam: {
         name: "limit",
         in: "query",
         schema: { type: "integer", minimum: 1, maximum: 100, default: 50 },
         description: "Max items per page (1–100)",
+      },
+      sortParam: {
+        name: "sort",
+        in: "query",
+        schema: { type: "string" },
+        description: "Sort field. Supported values depend on the endpoint (e.g. `createdAt`, `price`). Defaults to `createdAt`.",
+      },
+      directionParam: {
+        name: "direction",
+        in: "query",
+        schema: { type: "string", enum: ["asc", "desc"], default: "desc" },
+        description: "Sort direction (`asc` or `desc`). Defaults to `desc`.",
       },
       minScoreParam: {
         name: "minScore",
@@ -2394,7 +2406,9 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
       get: {
         tags: ["Commerce"],
         summary: "Discover services marketplace",
-        description: "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
+        description: `Returns registered services across all TALOS agents with cursor pagination. Optionally exclude your own services via \`self\`.
+
+Supports \`sort\` (\`createdAt\` or \`price\`) and \`direction\` (\`asc\` or \`desc\`, default \`desc\`). When omitted, results are ordered deterministically by \`createdAt\` descending with \`id\` as a tiebreaker. Cursor pagination is only compatible with the default \`createdAt\` descending sort.`,
         operationId: "discoverServices",
         parameters: [
           {
@@ -2409,6 +2423,8 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
             schema: { type: "string" },
             description: "TALOS ID to exclude from results (your own services)",
           },
+          { $ref: "#/components/parameters/sortParam" },
+          { $ref: "#/components/parameters/directionParam" },
           { $ref: "#/components/parameters/cursorParam" },
           { $ref: "#/components/parameters/limitParam" },
           { $ref: "#/components/parameters/minScoreParam" },
@@ -2449,6 +2465,7 @@ Use this for multi-chain payment completion flows that should trigger fulfillmen
               },
             },
           },
+          "400": { description: "Invalid `sort` or `direction`, or cursor used with a non-default sort" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },
@@ -2627,7 +2644,9 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
       get: {
         tags: ["Playbooks"],
         summary: "List playbooks",
-        description: "Returns active playbooks with optional filters. Supports cursor pagination.",
+        description: `Returns active playbooks with optional filters and cursor pagination.
+
+Supports \`sort\` (\`createdAt\`, \`price\`, or \`title\`) and \`direction\` (\`asc\` or \`desc\`, default \`desc\`). When omitted, results are ordered deterministically by \`createdAt\` descending with \`id\` as a tiebreaker. Cursor pagination is only compatible with the default \`createdAt\` descending sort.`,
         operationId: "listPlaybooks",
         parameters: [
           {
@@ -2649,6 +2668,8 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
             schema: { type: "string" },
             description: "Full-text search in title, description, and tags",
           },
+          { $ref: "#/components/parameters/sortParam" },
+          { $ref: "#/components/parameters/directionParam" },
           { $ref: "#/components/parameters/cursorParam" },
           { $ref: "#/components/parameters/limitParam" },
         ],
@@ -2671,6 +2692,7 @@ For async services, poll the result via \`GET /api/talos/{id}/jobs?jobId=...\`.`
               },
             },
           },
+          "400": { description: "Invalid `sort` or `direction`, or cursor used with a non-default sort" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -2355,7 +2355,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`"
+        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort."
       },
       "limitParam": {
         "name": "limit",
@@ -2367,6 +2367,27 @@
           "default": 50
         },
         "description": "Max items per page (1–100)"
+      },
+      "sortParam": {
+        "name": "sort",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Sort field. Supported values depend on the endpoint (e.g. `createdAt`, `price`). Defaults to `createdAt`."
+      },
+      "directionParam": {
+        "name": "direction",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
+        "description": "Sort direction (`asc` or `desc`). Defaults to `desc`."
       },
       "minScoreParam": {
         "name": "minScore",
@@ -4387,7 +4408,7 @@
           "Commerce"
         ],
         "summary": "Discover services marketplace",
-        "description": "Returns all registered services across all TALOS agents with cursor pagination. Results are shuffled for diversity. Optionally exclude your own services via `self`.",
+        "description": "Returns registered services across all TALOS agents with cursor pagination. Optionally exclude your own services via `self`.\n\nSupports `sort` (`createdAt` or `price`) and `direction` (`asc` or `desc`, default `desc`). When omitted, results are ordered deterministically by `createdAt` descending with `id` as a tiebreaker. Cursor pagination is only compatible with the default `createdAt` descending sort.",
         "operationId": "discoverServices",
         "parameters": [
           {
@@ -4405,6 +4426,12 @@
               "type": "string"
             },
             "description": "TALOS ID to exclude from results (your own services)"
+          },
+          {
+            "$ref": "#/components/parameters/sortParam"
+          },
+          {
+            "$ref": "#/components/parameters/directionParam"
           },
           {
             "$ref": "#/components/parameters/cursorParam"
@@ -4477,6 +4504,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid `sort` or `direction`, or cursor used with a non-default sort"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
@@ -4792,7 +4822,7 @@
           "Playbooks"
         ],
         "summary": "List playbooks",
-        "description": "Returns active playbooks with optional filters. Supports cursor pagination.",
+        "description": "Returns active playbooks with optional filters and cursor pagination.\n\nSupports `sort` (`createdAt`, `price`, or `title`) and `direction` (`asc` or `desc`, default `desc`). When omitted, results are ordered deterministically by `createdAt` descending with `id` as a tiebreaker. Cursor pagination is only compatible with the default `createdAt` descending sort.",
         "operationId": "listPlaybooks",
         "parameters": [
           {
@@ -4833,6 +4863,12 @@
             "description": "Full-text search in title, description, and tags"
           },
           {
+            "$ref": "#/components/parameters/sortParam"
+          },
+          {
+            "$ref": "#/components/parameters/directionParam"
+          },
+          {
             "$ref": "#/components/parameters/cursorParam"
           },
           {
@@ -4864,6 +4900,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid `sort` or `direction`, or cursor used with a non-default sort"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"

--- a/web/tests/marketplace-sort.unit.test.ts
+++ b/web/tests/marketplace-sort.unit.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for marketplace sort validation (issue #437).
+ *
+ * Covers the pure `parseMarketplaceSort` parser, the cursor-compatibility
+ * guard, the deterministic orderBy builder, and route-level behaviour for
+ * valid / invalid / omitted parameters. The DB is fully mocked — no live
+ * marketplace dependency.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { asc, desc, sql } from "drizzle-orm";
+import {
+  buildMarketplaceOrderBy,
+  isDefaultMarketplaceSort,
+  parseMarketplaceSort,
+  PLAYBOOKS_SORT_FIELDS,
+  SERVICES_SORT_FIELDS,
+} from "@/lib/marketplace-sort";
+
+// ---------------------------------------------------------------------------
+// Shared DB mock — every chain method returns `this` for fluent calls.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => {
+  const chain = () => {
+    const obj: Record<string, unknown> = {};
+    const methods = [
+      "select", "from", "where", "orderBy", "limit", "leftJoin",
+      "innerJoin", "groupBy", "as",
+    ];
+    for (const m of methods) {
+      obj[m] = vi.fn(() => obj);
+    }
+    // .then() resolves with an empty array by default
+    obj.then = vi.fn((cb: (v: unknown[]) => unknown) => Promise.resolve(cb([])));
+    return obj;
+  };
+
+  return {
+    mockDb: {
+      select: vi.fn(() => chain()),
+      insert: vi.fn(),
+      update: vi.fn(),
+      transaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/db", () => ({ db: mocks.mockDb }));
+
+// Silence reputation ledger lookups — not exercised for empty result sets.
+vi.mock("@/lib/reputation-ledger", () => ({
+  fetchReputations: vi.fn().mockResolvedValue(new Map()),
+}));
+
+function req(url: string, params: Record<string, string> = {}): NextRequest {
+  const u = new URL(`http://localhost${url}`);
+  for (const [k, v] of Object.entries(params)) {
+    u.searchParams.set(k, v);
+  }
+  return new NextRequest(u.toString());
+}
+
+// ---------------------------------------------------------------------------
+// 1. parseMarketplaceSort — pure parser (no DB / network)
+// ---------------------------------------------------------------------------
+
+describe("parseMarketplaceSort", () => {
+  const servicesConfig = {
+    allowedFields: SERVICES_SORT_FIELDS,
+    fieldLabel: "createdAt, price",
+  };
+
+  describe("omitted parameters → deterministic defaults", () => {
+    it("uses createdAt desc when both params are absent", () => {
+      const result = parseMarketplaceSort(null, null, servicesConfig);
+      expect(result).toEqual({
+        ok: true,
+        sort: { field: "createdAt", direction: "desc" },
+      });
+    });
+
+    it("uses the default field when only direction is provided", () => {
+      const result = parseMarketplaceSort(null, "asc", servicesConfig);
+      expect(result).toEqual({
+        ok: true,
+        sort: { field: "createdAt", direction: "asc" },
+      });
+    });
+
+    it("uses the default direction when only sort is provided", () => {
+      const result = parseMarketplaceSort("price", null, servicesConfig);
+      expect(result).toEqual({
+        ok: true,
+        sort: { field: "price", direction: "desc" },
+      });
+    });
+  });
+
+  describe("valid parameters → documented ordering", () => {
+    const validCases: Array<[string, string, string, string]> = [
+      ["createdAt", "desc", "createdAt", "desc"],
+      ["createdAt", "asc", "createdAt", "asc"],
+      ["price", "desc", "price", "desc"],
+      ["price", "asc", "price", "asc"],
+    ];
+    it.each(validCases)(
+      'sort="%s" direction="%s" → %s %s',
+      (sort, direction, field, dir) => {
+        const result = parseMarketplaceSort(sort, direction, servicesConfig);
+        expect(result).toEqual({ ok: true, sort: { field, direction: dir } });
+      },
+    );
+
+    it("accepts every playbook sort field", () => {
+      for (const field of PLAYBOOKS_SORT_FIELDS) {
+        const result = parseMarketplaceSort(field, "asc", {
+          allowedFields: PLAYBOOKS_SORT_FIELDS,
+          fieldLabel: "createdAt, price, title",
+        });
+        expect(result.ok).toBe(true);
+      }
+    });
+  });
+
+  describe("invalid parameters → 400 and never reach the query builder", () => {
+    it.each(["bogus", "name", "id", ""])(
+      'rejects unknown sort field "%s"',
+      (field) => {
+        const result = parseMarketplaceSort(field, null, servicesConfig);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.response.status).toBe(400);
+      },
+    );
+
+    it.each(["up", "ASC", "DESC", "ascending", ""])(
+      'rejects unknown direction "%s"',
+      (direction) => {
+        const result = parseMarketplaceSort("price", direction, servicesConfig);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.response.status).toBe(400);
+      },
+    );
+
+    it("returns a human-readable error message on invalid sort", async () => {
+      const result = parseMarketplaceSort("bogus", null, servicesConfig);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const body = await result.response.json();
+        expect(body.error).toContain("Invalid sort field");
+        expect(body.error).toContain("createdAt, price");
+      }
+    });
+
+    it("returns a human-readable error message on invalid direction", async () => {
+      const result = parseMarketplaceSort("price", "sideways", servicesConfig);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const body = await result.response.json();
+        expect(body.error).toContain("Invalid sort direction");
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. isDefaultMarketplaceSort — cursor-compatibility guard
+// ---------------------------------------------------------------------------
+
+describe("isDefaultMarketplaceSort", () => {
+  it("returns true for the default createdAt desc ordering", () => {
+    expect(
+      isDefaultMarketplaceSort({ field: "createdAt", direction: "desc" }),
+    ).toBe(true);
+  });
+
+  it("returns false for every other field/direction combination", () => {
+    expect(
+      isDefaultMarketplaceSort({ field: "createdAt", direction: "asc" }),
+    ).toBe(false);
+    expect(
+      isDefaultMarketplaceSort({ field: "price", direction: "desc" }),
+    ).toBe(false);
+    expect(
+      isDefaultMarketplaceSort({ field: "price", direction: "asc" }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. buildMarketplaceOrderBy — deterministic, total ordering
+// ---------------------------------------------------------------------------
+
+describe("buildMarketplaceOrderBy", () => {
+  const createdAt = sql`created_at`;
+  const price = sql`price`;
+  const title = sql`title`;
+  const id = sql`id`;
+
+  const columns = { createdAt, price, title };
+
+  it("keeps the default createdAt desc ordering with an id tiebreaker", () => {
+    const orderBy = buildMarketplaceOrderBy(
+      { field: "createdAt", direction: "desc" },
+      columns,
+      id,
+    );
+    expect(orderBy).toHaveLength(2);
+    expect(orderBy[0].queryChunks).toEqual(desc(createdAt).queryChunks);
+    expect(orderBy[1].queryChunks).toEqual(desc(id).queryChunks);
+  });
+
+  it("orders by the requested field and direction with a stable id tiebreaker", () => {
+    const orderBy = buildMarketplaceOrderBy(
+      { field: "price", direction: "asc" },
+      columns,
+      id,
+    );
+    expect(orderBy[0].queryChunks).toEqual(asc(price).queryChunks);
+    expect(orderBy[1].queryChunks).toEqual(desc(id).queryChunks);
+
+    const descTitle = buildMarketplaceOrderBy(
+      { field: "title", direction: "desc" },
+      columns,
+      id,
+    );
+    expect(descTitle[0].queryChunks).toEqual(desc(title).queryChunks);
+    expect(descTitle[1].queryChunks).toEqual(desc(id).queryChunks);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. GET /api/services — route-level sort validation (mocked DB)
+// ---------------------------------------------------------------------------
+
+import { GET as servicesGET } from "@/app/api/services/route";
+import { GET as playbooksGET } from "@/app/api/playbooks/route";
+
+describe("GET /api/services — sort validation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 with a valid sort", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await servicesGET(req("/api/services", { sort: "price", direction: "asc" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 with the default sort when parameters are omitted", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await servicesGET(req("/api/services"));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 and never queries the DB for an invalid sort field", async () => {
+    const res = await servicesGET(req("/api/services", { sort: "bogus" }));
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and never queries the DB for an invalid direction", async () => {
+    const res = await servicesGET(req("/api/services", { sort: "price", direction: "up" }));
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when a cursor is combined with a non-default sort", async () => {
+    const res = await servicesGET(
+      req("/api/services", { sort: "price", cursor: "2026-08-01T00:00:00.000Z|svc-1" }),
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("allows a cursor with the default sort", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await servicesGET(
+      req("/api/services", { cursor: "2026-08-01T00:00:00.000Z|svc-1" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. GET /api/playbooks — route-level sort validation (mocked DB)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/playbooks — sort validation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 with a valid sort", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await playbooksGET(req("/api/playbooks", { sort: "title", direction: "asc" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 with the default sort when parameters are omitted", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await playbooksGET(req("/api/playbooks"));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 and never queries the DB for an invalid sort field", async () => {
+    const res = await playbooksGET(req("/api/playbooks", { sort: "bogus" }));
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and never queries the DB for an invalid direction", async () => {
+    const res = await playbooksGET(req("/api/playbooks", { sort: "price", direction: "sideways" }));
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when a cursor is combined with a non-default sort", async () => {
+    const res = await playbooksGET(
+      req("/api/playbooks", { sort: "price", cursor: "2026-08-01T00:00:00.000Z|pb-1" }),
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("allows a cursor with the default sort", async () => {
+    mocks.mockDb.select.mockReturnValue(buildChain([]));
+    const res = await playbooksGET(
+      req("/api/playbooks", { cursor: "2026-08-01T00:00:00.000Z|pb-1" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildChain(results: unknown[]): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  const methods = [
+    "select", "from", "where", "orderBy", "limit", "leftJoin",
+    "innerJoin", "groupBy", "as",
+  ];
+  for (const m of methods) {
+    obj[m] = vi.fn(() => obj);
+  }
+  obj.then = vi.fn((cb: (v: unknown[]) => unknown) => Promise.resolve(cb(results)));
+  return obj;
+}


### PR DESCRIPTION
## Overview

This PR validates marketplace sort fields and directions on the marketplace list endpoints while preserving deterministic default ordering. A shared parser rejects unknown `sort`/`direction` values with **400** before they ever reach the query builder, keeps the default `createdAt desc` ordering stable when parameters are omitted, and keeps cursor pagination compatible by only allowing cursors with the default sort.

## Related Issue

Closes #437

## Changes

### 🔀 Sort validation (services + playbooks)

- **[ADD]** `web/src/lib/marketplace-sort.ts`
  - `parseMarketplaceSort()` — defines supported sort fields (`services`: `createdAt`, `price`; `playbooks`: `createdAt`, `price`, `title`) and directions (`asc`/`desc`); unknown/empty values return a 400 so invalid parameters never reach the query builder; omitted parameters fall back to the deterministic `createdAt desc` default.
  - `isDefaultMarketplaceSort()` — guards cursor compatibility, since the `createdAt|id` cursor scheme is only compatible with the default ordering.
  - `buildMarketplaceOrderBy()` — builds the drizzle `orderBy` for the validated field/direction with `id` as a stable tiebreaker.
- **[MODIFY]** `web/src/app/api/services/route.ts`, `web/src/app/api/playbooks/route.ts`
  - Wire the validator in, return 400 for invalid `sort`/`direction`, and return 400 when a `cursor` is combined with a non-default sort.
  - Remove the result shuffle in `/api/services` so omitted parameters remain deterministic and `nextCursor` pagination is stable.
- **[ADD]** `web/tests/marketplace-sort.unit.test.ts`
  - Coverage for valid, invalid, and omitted parameters, plus cursor-compatibility and "never reaches the query builder" assertions (DB fully mocked — no live marketplace dependency).

### 📄 Documentation & SDK

- **[MODIFY]** `web/src/lib/openapi.ts` (+ regenerated `web/tests/fixtures/openapi.snapshot.json`) — document `sort`/`direction` query parameters, add 400 responses, and update endpoint descriptions.
- **[MODIFY]** `packages/sdk/src/types.ts`, `packages/sdk/src/client.ts`, `packages/sdk/src/generated-types.ts` — expose `sort`/`direction` on `discoverServices` and `listPlaybooks`.

## Verification Results

```
npx vitest run tests/marketplace-sort.unit.test.ts tests/openapi-snapshot.test.ts tests/marketplace-aggregates.unit.test.ts tests/service-settlement.unit.test.ts
✅ 52/52 passed

TypeScript (web + SDK): 0 errors in changed files
```

### Acceptance Criteria

| Criterion | Status |
| --- | --- |
| Valid parameters produce documented ordering | ✅ `sort=price&direction=asc` etc. validated and applied via `buildMarketplaceOrderBy` |
| Invalid parameters never reach the query builder | ✅ 400 returned before any DB query (asserted via mocked `db.select` not called) |
| Omitted parameters remain deterministic | ✅ default `createdAt desc` + `id` tiebreaker; shuffle removed from `/api/services` |
| Tests cover valid, invalid, and omitted parameters | ✅ 35 unit tests + route-level smoke tests, mocked results, no live marketplace dependency |

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [x] I have updated documentation (OpenAPI spec) for the new query parameters.
- [x] My changes generate no new warnings or errors (typecheck clean for changed files; pre-existing upstream errors unchanged).
- [x] I have added tests that prove the feature works.
- [x] New and existing unit tests pass locally with my changes.
