### PR TITLE
feat(agent): expose operational metrics for provider fallback

### DIFF
--- a/packages/prime-agent/src/talos_agent/routing/fallback.py
+++ b/packages/prime-agent/src/talos_agent/routing/fallback.py
@@ -14,8 +14,70 @@ from enum import Enum
 from typing import Any, Callable
 
 from talos_agent.circuit_breaker import CircuitBreakerOpen, cb_registry
+from talos_agent.telemetry import _is_sensitive_key
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FallbackMetricsSnapshot:
+    """A typed snapshot of fallback operational metrics for diagnostics."""
+
+    attempts: dict[str, int]
+    successes: dict[str, int]
+    skips: dict[str, int]
+    exhaustions: dict[str, int]
+
+
+class FallbackMetrics:
+    """Registry for fallback operational metrics."""
+
+    def __init__(self) -> None:
+        self._attempts: dict[str, int] = {}
+        self._successes: dict[str, int] = {}
+        self._skips: dict[str, int] = {}
+        self._exhaustions: dict[str, int] = {}
+
+    def _increment(self, counter: dict[str, int], provider: str) -> None:
+        """Increment the metric for the given provider, bounding cardinality and redacting if sensitive."""
+        # Hard limit on unique providers to prevent unbounded memory growth
+        if len(counter) >= 100 and provider not in counter:
+            provider = "OTHER_OVERFLOW"
+        elif _is_sensitive_key(provider):
+            provider = "[REDACTED]"
+        
+        counter[provider] = counter.get(provider, 0) + 1
+
+    def record_attempt(self, provider: str) -> None:
+        self._increment(self._attempts, provider)
+
+    def record_success(self, provider: str) -> None:
+        self._increment(self._successes, provider)
+
+    def record_skip(self, provider: str) -> None:
+        self._increment(self._skips, provider)
+
+    def record_exhaustion(self, provider: str) -> None:
+        self._increment(self._exhaustions, provider)
+
+    def snapshot(self) -> FallbackMetricsSnapshot:
+        """Return a typed snapshot of the current metric state."""
+        return FallbackMetricsSnapshot(
+            attempts=dict(self._attempts),
+            successes=dict(self._successes),
+            skips=dict(self._skips),
+            exhaustions=dict(self._exhaustions),
+        )
+
+    def reset(self) -> None:
+        """Clear all metric counters."""
+        self._attempts.clear()
+        self._successes.clear()
+        self._skips.clear()
+        self._exhaustions.clear()
+
+
+fallback_metrics = FallbackMetrics()
 
 
 class FallbackStrategy(str, Enum):
@@ -120,6 +182,7 @@ class FallbackChain:
                 cooldown = breaker.remaining_cooldown() or 0.0
                 msg = f"Circuit breaker OPEN (retry in {cooldown:.1f}s)"
                 attempts.append((provider_name, msg))
+                fallback_metrics.record_skip(provider_name)
                 logger.warning(
                     "Fallback skipping '%s' — %s",
                     provider_name,
@@ -127,9 +190,11 @@ class FallbackChain:
                 )
                 continue
 
+            fallback_metrics.record_attempt(provider_name)
             try:
                 result = await operation(provider_name, *args, **kwargs)
                 await breaker.record_success()
+                fallback_metrics.record_success(provider_name)
                 logger.info(
                     "Fallback succeeded with '%s' after %d attempt(s)",
                     provider_name,
@@ -162,6 +227,9 @@ class FallbackChain:
                 )
 
         # All providers exhausted
+        for p, _ in attempts:
+            fallback_metrics.record_exhaustion(p)
+
         logger.error(
             "Fallback chain exhausted after %d provider(s): %s",
             len(attempts),

--- a/packages/prime-agent/tests/test_fallback_metrics.py
+++ b/packages/prime-agent/tests/test_fallback_metrics.py
@@ -1,0 +1,131 @@
+import pytest
+from talos_agent.routing.fallback import (
+    FallbackChain,
+    fallback_metrics,
+    FallbackStrategy,
+)
+from talos_agent.circuit_breaker import cb_registry
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    fallback_metrics.reset()
+    cb_registry.reset_all()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_metrics_success_path():
+    chain = FallbackChain(["groq", "openai"])
+    
+    async def op(provider, *args):
+        if provider == "groq":
+            raise Exception("fail")
+        return "ok"
+
+    result = await chain.execute(op)
+    assert result.success is True
+    assert result.provider_name == "openai"
+
+    snap = fallback_metrics.snapshot()
+    assert snap.attempts.get("groq") == 1
+    assert snap.attempts.get("openai") == 1
+    
+    assert snap.successes.get("openai") == 1
+    assert "groq" not in snap.successes
+    
+    assert not snap.exhaustions
+    assert not snap.skips
+
+
+@pytest.mark.asyncio
+async def test_metrics_exhaustion_path():
+    chain = FallbackChain(["groq", "openai"])
+    
+    async def op(provider, *args):
+        raise Exception("fail")
+
+    result = await chain.execute(op)
+    assert result.success is False
+
+    snap = fallback_metrics.snapshot()
+    assert snap.attempts.get("groq") == 1
+    assert snap.attempts.get("openai") == 1
+    
+    assert not snap.successes
+    
+    assert snap.exhaustions.get("groq") == 1
+    assert snap.exhaustions.get("openai") == 1
+    assert not snap.skips
+
+
+@pytest.mark.asyncio
+async def test_metrics_circuit_open_skip():
+    # Force 'groq' breaker to be OPEN
+    breaker = cb_registry.get("groq")
+    for _ in range(10):
+        await breaker.record_failure()
+    assert not await breaker.allow_request()
+
+    chain = FallbackChain(["groq", "openai"])
+    
+    async def op(provider, *args):
+        return "ok"
+
+    result = await chain.execute(op)
+    assert result.success is True
+    assert result.provider_name == "openai"
+
+    snap = fallback_metrics.snapshot()
+    
+    # "groq" is skipped, so no attempt is recorded
+    assert "groq" not in snap.attempts
+    assert snap.skips.get("groq") == 1
+    
+    assert snap.attempts.get("openai") == 1
+    assert snap.successes.get("openai") == 1
+    assert not snap.exhaustions
+
+
+@pytest.mark.asyncio
+async def test_metrics_sensitive_label_redaction():
+    # Attempt to use a provider name containing sensitive substrings like "api_key"
+    chain = FallbackChain(["my_api_key_provider", "secret_groq", "openai"])
+    
+    async def op(provider, *args):
+        if provider == "my_api_key_provider":
+            raise Exception("fail")
+        return "ok"
+
+    result = await chain.execute(op)
+    assert result.success is True
+    assert result.provider_name == "secret_groq"
+
+    snap = fallback_metrics.snapshot()
+    
+    # "my_api_key_provider" and "secret_groq" should be redacted as "[REDACTED]"
+    assert snap.attempts.get("[REDACTED]") == 2
+    assert "my_api_key_provider" not in snap.attempts
+    assert "secret_groq" not in snap.attempts
+    
+    assert snap.successes.get("[REDACTED]") == 1
+    assert "openai" not in snap.attempts
+
+
+@pytest.mark.asyncio
+async def test_metrics_cardinality_bound():
+    # We bounded cardinality to 100 max unique keys
+    async def op(provider, *args):
+        return "ok"
+    
+    for i in range(105):
+        provider_name = f"provider_{i}"
+        chain = FallbackChain([provider_name])
+        await chain.execute(op)
+        
+    snap = fallback_metrics.snapshot()
+    
+    # 100 unique items + 1 OTHER_OVERFLOW
+    assert len(snap.attempts) == 101
+    assert "OTHER_OVERFLOW" in snap.attempts
+    assert snap.attempts["OTHER_OVERFLOW"] == 5


### PR DESCRIPTION
Closes #464 

## Summary

Added safe operational metrics for provider fallback without exposing sensitive request or response data.

### Changes

* Track provider attempts, successes, exhausted chains, and circuit open skips.
* Added typed in process snapshots for diagnostics and tests.
* Bounded metric labels and documented cardinality and reset behavior.
* Preserved existing retry and fallback behavior.
* Added focused tests for outcomes and sensitive value exclusion.
