### PR TITLE
docs(web): document the public pagination response contract

### DIFF
--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -1056,7 +1056,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         name: "cursor",
         in: "query",
         schema: { type: "string" },
-        description: "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected or lead to undefined pagination behavior. Only compatible with the default `createdAt` descending sort.",
+        description: "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected with a 400 validation error. Only compatible with the default `createdAt` descending sort.",
       },
       limitParam: {
         name: "limit",

--- a/web/src/lib/openapi.ts
+++ b/web/src/lib/openapi.ts
@@ -910,11 +910,12 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
       },
       CursorPage: {
         type: "object",
+        required: ["nextCursor"],
         properties: {
           nextCursor: {
             type: "string",
             nullable: true,
-            description: "Opaque cursor for the next page. Pass as `cursor` query param.",
+            description: "Opaque cursor for the next page. Pass as `cursor` query param. Will be null if there are no more pages (final page).",
           },
         },
       },
@@ -1055,7 +1056,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
         name: "cursor",
         in: "query",
         schema: { type: "string" },
-        description: "Opaque pagination cursor returned from the previous page's `nextCursor`",
+        description: "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected or lead to undefined pagination behavior.",
       },
       limitParam: {
         name: "limit",
@@ -1199,6 +1200,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
                     { $ref: "#/components/schemas/CursorPage" },
                     {
                       type: "object",
+                      required: ["data"],
                       properties: {
                         data: {
                           type: "array",
@@ -1211,6 +1213,7 @@ Inter-agent commerce uses the Stellar x402 payment protocol:
               },
             },
           },
+          "400": { $ref: "#/components/responses/ValidationError" },
           "500": { $ref: "#/components/responses/InternalError" },
         },
       },

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -2062,11 +2062,14 @@
       },
       "CursorPage": {
         "type": "object",
+        "required": [
+          "nextCursor"
+        ],
         "properties": {
           "nextCursor": {
             "type": "string",
             "nullable": true,
-            "description": "Opaque cursor for the next page. Pass as `cursor` query param."
+            "description": "Opaque cursor for the next page. Pass as `cursor` query param. Will be null if there are no more pages (final page)."
           }
         }
       },
@@ -2355,7 +2358,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`"
+        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected or lead to undefined pagination behavior."
       },
       "limitParam": {
         "name": "limit",
@@ -2582,6 +2585,9 @@
                     },
                     {
                       "type": "object",
+                      "required": [
+                        "data"
+                      ],
                       "properties": {
                         "data": {
                           "type": "array",
@@ -2595,6 +2601,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"

--- a/web/tests/fixtures/openapi.snapshot.json
+++ b/web/tests/fixtures/openapi.snapshot.json
@@ -2358,11 +2358,7 @@
         "schema": {
           "type": "string"
         },
-<<<<<<< HEAD
-        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected or lead to undefined pagination behavior."
-=======
-        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`. Only compatible with the default `createdAt` descending sort."
->>>>>>> upstream/main
+        "description": "Opaque pagination cursor returned from the previous page's `nextCursor`. Malformed cursors are rejected with a 400 validation error. Only compatible with the default `createdAt` descending sort."
       },
       "limitParam": {
         "name": "limit",

--- a/web/tests/pagination-envelope.test.ts
+++ b/web/tests/pagination-envelope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { openApiSpec } from "../src/lib/openapi";
+
+describe("Pagination Contract", () => {
+    it("defines CursorPage correctly with explicit final-page behavior", () => {
+        const cursorPage = (openApiSpec.components.schemas as any).CursorPage;
+
+        // Explicitly require nextCursor in the envelope
+        expect(cursorPage.required).toContain("nextCursor");
+
+        const nextCursor = cursorPage.properties.nextCursor;
+        // The cursor is nullable for the final page
+        expect(nextCursor.nullable).toBe(true);
+
+        // Description explicitly addresses final-page behavior
+        expect(nextCursor.description).toMatch(/null.*no more pages|null.*final page/i);
+    });
+
+    it("defines cursor query parameter with explicit malformed behavior", () => {
+        const cursorParam = (openApiSpec.components.parameters as any).cursorParam;
+
+        expect(cursorParam.name).toBe("cursor");
+        expect(cursorParam.in).toBe("query");
+
+        // Description makes malformed behavior explicit
+        expect(cursorParam.description).toMatch(/malformed cursors/i);
+    });
+
+    it("adds 400 validation error responses to endpoints", () => {
+        const talosGet = (openApiSpec.paths as any)["/api/talos"].get;
+
+        expect(talosGet.responses["400"]).toBeDefined();
+        expect(talosGet.responses["400"].$ref).toBe("#/components/responses/ValidationError");
+    });
+});


### PR DESCRIPTION
Closes #444 

## Summary

Provide a brief description of the changes, background context, and what these changes accomplish.

## Related Issues

Closes #N (Replace N with the issue number, e.g. Closes #1)

## Test Plan

Detail the steps you took to test these changes.
- [ ] Automated tests run (e.g. `cargo test`, `uv run pytest`, `pnpm test:e2e`)
- [ ] Manual verification steps performed:
  - 1. ...
  - 2. ...
- [ ] Relevant docs updated when setup, environment variables, or workflows changed

## Visual Changes (if applicable)

For any user interface changes, please add screenshots or screen recordings showing:
- Before
- After

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [ ] My code follows the style guidelines of this project.
- [ ] I have updated `.env.example` files and documentation if I changed environment variables.
- [ ] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.


Title:
docs(web): document the public pagination response contract

Description
This PR formally documents the pagination metadata contract for public web API endpoints, specifically targeting cursor-based pagination envelopes. It ensures our OpenAPI specification accurately tracks the properties returned to clients, and introduces a dedicated contract snapshot test to prevent undocumented structural drift.

No runtime behavior was modified in this contribution.

Changes
web/src/lib/openapi.ts
:
Formally required nextCursor in the CursorPage components schema, explicitly describing returning null when a client hits the final page.
Added documentation to the cursor (cursorParam) query parameter detailing the behavior for malformed requests (e.g. results in HTTP 400).
Expanded the GET /api/talos OpenAPI response specification to declare HTTP 400 Validation Errors, mapping to our limit parsing configurations.
web/tests/pagination-envelope.test.ts
:
Introduced a contract test for the CursorPage definition that validates envelope attributes and structural requirements natively, failing if the documentation definition diverges.
web/tests/fixtures/openapi.snapshot.json
:
Generated and synced the OpenAPI JSON snapshot to account for the new property descriptions.
Acceptance Criteria
 OpenAPI accurately describes the pagination response and client errors.
 A contract test exists to fail when the documented envelope drifts.
 Existing endpoint behaviors remain unchanged (documentation-only).
 Malformed cursor and final-page behaviors are explicit in descriptions.
 The local verification command is documented.
Local Verification
To run the focused isolation contract test for this PR locally, run:

bash:
cd web
pnpm vitest run tests/pagination-envelope.test.ts Tests/openapi-snapshot.test.ts
