### PR TITLE
feat(sdk): wire typed API error parsing into the client

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -355,15 +355,27 @@ const client = new TalosClient({
 ```
 
 **Retry semantics (deterministic & bounded):**
-- Only retries when `err.isRetryable === true` (429, 502/503/504, transport,
-  timeout).
-- Only retries when `idempotentOnly === true` (default) **and** the method is
-  `GET`/`HEAD`/`OPTIONS` — POST/PUT/PATCH/DELETE are never retried without
-  explicit opt-out via `idempotentOnly: false`.
-- `maxAttempts` is hard-capped at 8 regardless of user input.
+- Retry statuses are the transient set: `429`, `500`, `502`, `503`, `504`.
+- By default only non-POST methods (`GET`/`HEAD`/`PUT`/`DELETE`/`OPTIONS`) are
+  retried. Passing an **idempotency key** (`options.idempotencyKey`) makes a
+  request safe to retry regardless of method — the server deduplicates on the
+  key, so `POST` write paths can retry against transient failures.
+- `maxAttempts` is hard-capped at 8 regardless of user input. When not set
+  explicitly, requests carry 1 attempt (no retry) and 3 attempts when an
+  idempotency key is present.
 - Server-supplied `Retry-After` is honored (clamped to `maxRetryAfterMs`).
 - Exponential backoff `baseDelayMs * 2^(attempt-1)` capped at `maxDelayMs`.
-- Validation/auth/conflict/payment errors are **never** retried.
+- Validation/auth/conflict/payment errors are **never** retried. A 409 that
+  indicates the idempotency key was reused with a different payload surfaces
+  as `IdempotencyConflictError` instead.
+
+**Typed error parsing is wired into every request** — `TalosClient.request`
+(and every typed method) dispatches non-2xx responses through
+`errorFromResponse`, so consumers receive the typed subclasses documented
+above with `status`, `code`, `message`, `requestId`, validation `issues`, safe
+headers, and retry hints. Fetch-level failures are classified via
+`classifyTransportError` (transport vs timeout). Successful responses are
+unchanged.
 
 ### Privacy
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -35,15 +35,57 @@ import {
   type RequestSigner,
   type SigningControllerOptions,
 } from "./signing.js";
+import {
+  TalosAPIError,
+  errorFromResponse,
+  classifyTransportError,
+  parseX402Challenge,
+} from "./errors.js";
+import {
+  isPayloadConflict,
+  validateIdempotencyKey,
+  IdempotencyConflictError,
+} from "./idempotency.js";
+import type { ChaosInjector } from "./chaos.js";
+import { FaultType } from "./chaos.js";
 
-export interface RetryPolicyOptions {
+// Re-export so legacy `import { TalosAPIError } from "@talos-protocol/sdk/client"`
+// call sites keep working.
+export { TalosAPIError } from "./errors.js";
+
+/** Optional per-write request controls (idempotency + cancellation). */
+export interface WriteOptions {
+  /** Idempotency key sent as the `Idempotency-Key` header for safe retries. */
+  idempotencyKey?: string;
+  /** Abort signal forwarded to `fetch`. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Retry policy for idempotent operations. Only methods listed in
+ * `retryMethods` and status codes listed in `retryStatusCodes` are retried.
+ */
+export interface RetryOptions {
+  /** Maximum total attempts (initial + retries). Capped at 8. Default 3. */
   maxAttempts?: number;
+  /** Base delay in ms before the first retry (exponential backoff). */
   baseDelayMs?: number;
+  /** Upper bound on the delay in ms. */
   maxDelayMs?: number;
+  /** Jitter factor (0 = none, 1 = full). A boolean is accepted for brevity. */
+  jitter?: number | boolean;
+  /** Methods that may be retried. Defaults to non-POST methods. */
   retryMethods?: string[];
+  /** Status codes that are retried. Defaults to [429, 500, 502, 503, 504]. */
   retryStatusCodes?: number[];
-  jitter?: boolean;
+  /** Observer invoked before each retry. */
+  onRetry?: (info: { error: unknown; attempt: number; delayMs: number }) => void;
+  /** Random source for jitter (test seam). */
   random?: () => number;
+  /** Cap on the `Retry-After` delay honored from the server. Default 60s. */
+  maxRetryAfterMs?: number;
+  /** Reserved: only retry idempotent methods. */
+  idempotentOnly?: boolean;
 }
 
 export interface TalosClientOptions {
@@ -51,6 +93,18 @@ export interface TalosClientOptions {
   baseUrl?: string;
   /** Bearer token (TALOS API key). Adds `Authorization: Bearer <key>` header. */
   apiKey?: string;
+  /** Per-request timeout in ms. On expiry the request aborts with a `TalosTimeoutError`. */
+  timeoutMs?: number;
+  /** Retry policy (preferred name). */
+  retry?: RetryOptions;
+  /** Retry policy (legacy alias for {@link TalosClientOptions.retry}). */
+  retryPolicy?: RetryOptions;
+  /** Observer invoked once with the final error of a failed request. */
+  onError?: (event: TalosErrorEvent) => void;
+  /** Inject a custom `fetch` implementation (tests / middleware). */
+  fetchOverride?: typeof fetch;
+  /** Chaos injector for controlled fault injection. */
+  chaosInjector?: ChaosInjector;
   /** Opt-in request signer. Omitting it preserves the legacy wire format. */
   signer?: RequestSigner;
   signing?: SigningControllerOptions;
@@ -65,75 +119,94 @@ export interface TalosErrorEvent {
   durationMs: number;
 }
 
-/** Default retry bounds. Conservative — well within RFC 7231 guidance. */
-const DEFAULT_RETRY: Required<RetryOptions> = {
-  maxAttempts: 1,
-  idempotentOnly: true,
-  maxRetryAfterMs: 60_000,
-  baseDelayMs: 500,
-  maxDelayMs: 8_000,
-  jitter: 0.25,
-  onRetry: () => {
-    /* default: no-op observer */
-  },
-};
+/** Methods considered safe to retry by default. */
+const DEFAULT_RETRY_METHODS = ["GET", "HEAD", "PUT", "DELETE", "OPTIONS"];
 
-/** Methods considered safe to retry without further confirmation from the caller. */
-const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
+/** Status codes considered transient by default. */
+const DEFAULT_RETRY_STATUS_CODES = [429, 500, 502, 503, 504];
+
+/** Hard ceiling on total attempts (1 initial + 7 retries). */
+const MAX_ATTEMPTS_CAP = 8;
 
 /**
  * Sleep helper. Uses `setTimeout` so it works in both Node and the browser.
- * Returns a promise that resolves after `ms` milliseconds.
+ * Returns a promise that resolves after `ms` milliseconds, or rejects early
+ * when the abort signal fires.
  */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(new Error("Request aborted"));
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("Request aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
- * Apply jitter to a delay: `delay * (1 - jitter + jitter*random)`.
- * Bounded below by 0 and above by `delay * (1 + jitter)`.
- */
-function applyJitter(delay: number, jitter: number): number {
-  const factor = 1 - jitter + jitter * Math.random();
-  return Math.max(0, Math.round(delay * factor));
-}
-
-/**
- * Talos Protocol API client. Wraps `fetch` with typed errors, optional
- * timeout, and bounded auto-retry for idempotent operations.
+ * Talos Protocol API client. Wraps `fetch` with typed errors (see
+ * `./errors.ts`), optional per-request timeout, bounded auto-retry for
+ * idempotent operations, and an optional request signer.
  *
- * Tier list of changes from the previous version (all backward-compatible):
- *   - Errors are now typed subclasses of `TalosAPIError` (see `./errors.ts`).
- *   - `timeoutMs` enables a per-request `AbortController` timeout.
- *   - `retry.maxAttempts > 1` opt-in retries on transient failures only.
- *   - `onError` callback for centralized logging / metrics.
- *   - `fetch` injection for tests / middleware.
+ * Every failure is surfaced as a stable subclass of {@link TalosAPIError}:
+ *   - 4xx/5xx responses are parsed by {@link errorFromResponse} into the
+ *     matching typed error (validation, auth, forbidden, not-found, conflict,
+ *     payment, rate-limit, server, server-retryable).
+ *   - Transport failures (DNS, refused, reset) become {@link TalosTransportError}.
+ *   - Timeouts / aborts become {@link TalosTimeoutError}.
+ * The legacy `Talos API error <status> on <path>: <body>` message is preserved
+ * so existing catch blocks and `rejects.toThrow(...)` assertions keep working.
  */
 export class TalosClient {
   private baseUrl: string;
   private headers: Record<string, string>;
   private signer?: SigningController;
+  private timeoutMs?: number;
+  private onError?: (event: TalosErrorEvent) => void;
+  private fetchOverride?: typeof fetch;
+  private chaosInjector?: ChaosInjector;
+  private explicitMaxAttempts?: number;
+  private retry: Required<
+    Pick<
+      RetryOptions,
+      | "maxAttempts"
+      | "baseDelayMs"
+      | "maxDelayMs"
+      | "retryMethods"
+      | "retryStatusCodes"
+      | "random"
+      | "maxRetryAfterMs"
+    >
+  > & {
+    jitter: number;
+    onRetry?: (info: { error: unknown; attempt: number; delayMs: number }) => void;
+  };
 
   constructor(options: TalosClientOptions = {}) {
-    const normalizedRetryMethods = options.retryPolicy?.retryMethods?.map(
-      (method) => method.toUpperCase(),
-    );
-    this.retryPolicy = {
-      maxAttempts: options.retryPolicy?.maxAttempts ?? 3,
-      baseDelayMs: options.retryPolicy?.baseDelayMs ?? 100,
-      maxDelayMs: options.retryPolicy?.maxDelayMs ?? 1000,
-      retryMethods: normalizedRetryMethods ?? [
-        "GET",
-        "HEAD",
-        "PUT",
-        "DELETE",
-        "OPTIONS",
-      ],
-      retryStatusCodes: options.retryPolicy?.retryStatusCodes ?? [
-        429, 500, 502, 503, 504,
-      ],
-      jitter: options.retryPolicy?.jitter ?? true,
-      random: options.retryPolicy?.random ?? Math.random,
+    const retryOpts = options.retry ?? options.retryPolicy ?? {};
+    const rawJitter = retryOpts.jitter ?? true;
+    this.explicitMaxAttempts =
+      retryOpts.maxAttempts !== undefined
+        ? Math.max(1, retryOpts.maxAttempts)
+        : undefined;
+    this.retry = {
+      maxAttempts: Math.max(1, retryOpts.maxAttempts ?? 1),
+      baseDelayMs: retryOpts.baseDelayMs ?? 100,
+      maxDelayMs: retryOpts.maxDelayMs ?? 1000,
+      jitter: typeof rawJitter === "boolean" ? (rawJitter ? 1 : 0) : rawJitter,
+      retryMethods: retryOpts.retryMethods ?? DEFAULT_RETRY_METHODS,
+      retryStatusCodes: retryOpts.retryStatusCodes ?? DEFAULT_RETRY_STATUS_CODES,
+      random: retryOpts.random ?? Math.random,
+      maxRetryAfterMs: retryOpts.maxRetryAfterMs ?? 60_000,
+      onRetry: retryOpts.onRetry,
     };
     this.baseUrl = (
       options.baseUrl ?? "https://talos-stellar.vercel.app"
@@ -142,6 +215,10 @@ export class TalosClient {
     if (options.apiKey) {
       this.headers["Authorization"] = `Bearer ${options.apiKey}`;
     }
+    this.timeoutMs = options.timeoutMs;
+    this.onError = options.onError;
+    this.fetchOverride = options.fetchOverride;
+    this.chaosInjector = options.chaosInjector;
     if (options.signer) this.signer = new SigningController(options.signer, options.signing);
   }
 
@@ -150,76 +227,48 @@ export class TalosClient {
     return this.fetchOverride ?? globalThis.fetch;
   }
 
-  private shouldRetry(method: string, status: number, retryMethodsOverride?: string[]): boolean {
-    const methods = retryMethodsOverride ?? this.retryPolicy.retryMethods;
+  /** Inject configured chaos faults before a network boundary. */
+  private async maybeInjectChaos(): Promise<void> {
+    if (!this.chaosInjector) return;
+    await this.chaosInjector.maybeInjectFault(FaultType.NETWORK_DELAY);
+    await this.chaosInjector.maybeInjectFault(FaultType.NETWORK_DROP);
+    await this.chaosInjector.maybeInjectFault(FaultType.API_TIMEOUT);
+  }
+
+  private canRetry(
+    method: string,
+    status: number,
+    hasIdempotencyKey: boolean,
+  ): boolean {
+    // A caller-supplied idempotency key makes a non-idempotent method safe to
+    // retry, because the server deduplicates on the key.
     return (
-      this.retryPolicy.retryStatusCodes.includes(status) &&
-      methods.includes(method)
+      this.retry.retryStatusCodes.includes(status) &&
+      (this.retry.retryMethods.includes(method) || hasIdempotencyKey)
     );
   }
 
-  private getRetryDelay(
-    attempt: number,
-    retryAfterHeader: string | null,
-  ): number {
-    if (retryAfterHeader) {
-      const headerDelay = this.parseRetryAfter(retryAfterHeader);
-      if (headerDelay !== null) {
-        return Math.min(headerDelay, this.retryPolicy.maxDelayMs);
-      }
+  private getRetryDelay(attempt: number, retryAfterMs?: number): number {
+    if (retryAfterMs !== undefined && retryAfterMs >= 0) {
+      return Math.min(retryAfterMs, this.retry.maxRetryAfterMs);
     }
-
     const exponent = Math.pow(2, attempt - 1);
     const delay = Math.min(
-      this.retryPolicy.baseDelayMs * exponent,
-      this.retryPolicy.maxDelayMs,
+      this.retry.baseDelayMs * exponent,
+      this.retry.maxDelayMs,
     );
-    if (!this.retryPolicy.jitter) {
-      return delay;
+    if (this.retry.jitter <= 0) {
+      return Math.round(delay);
     }
-
-    return Math.floor(this.retryPolicy.random() * delay);
+    return Math.round(this.retry.random() * delay);
   }
 
-  private parseRetryAfter(header: string | null): number | null {
-    if (!header) return null;
-    const trimmed = header.trim();
-    const seconds = Number(trimmed);
-    if (!Number.isNaN(seconds)) {
-      return Math.max(0, seconds * 1000);
-    }
-
-    const parsedDate = Date.parse(trimmed);
-    if (!Number.isNaN(parsedDate)) {
-      const delta = parsedDate - Date.now();
-      return delta > 0 ? delta : 0;
-    }
-
-    return null;
-  }
-
-  private wait(delayMs: number, signal?: AbortSignal): Promise<void> {
-    if (signal?.aborted) {
-      return Promise.reject(new Error("Request aborted"));
-    }
-
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        signal?.removeEventListener("abort", onAbort);
-        resolve();
-      }, delayMs);
-
-      const onAbort = () => {
-        clearTimeout(timeout);
-        signal?.removeEventListener("abort", onAbort);
-        reject(new Error("Request aborted"));
-      };
-
-      signal?.addEventListener("abort", onAbort, { once: true });
-    });
-  }
-
-  private async request<T>(
+  /**
+   * Low-level request helper. Public so advanced callers can hit endpoints the
+   * typed methods do not expose yet, with all typed-error, retry and timeout
+   * behavior applied.
+   */
+  async request<T>(
     path: string,
     init?: RequestInit & {
       params?: Record<string, string | number | boolean>;
@@ -228,29 +277,104 @@ export class TalosClient {
   ): Promise<T> {
     let url = `${this.baseUrl}${path}`;
     const { params, signal, idempotencyKey, ...requestInit } = init ?? {};
-    const normalizedSignal = signal ?? undefined;
     if (params) {
       const filteredParams = Object.entries(params)
-        .filter(([_, value]) => value !== undefined)
-        .reduce((acc, [key, value]) => ({ ...acc, [key]: String(value) }), {} as Record<string, string>);
+        .filter(([, value]) => value !== undefined)
+        .reduce(
+          (acc, [key, value]) => ({ ...acc, [key]: String(value) }),
+          {} as Record<string, string>,
+        );
       const qs = new URLSearchParams(filteredParams).toString();
       if (qs) url += `?${qs}`;
     }
-    const headers = { ...this.headers, ...init?.headers };
+    const method = (requestInit.method ?? "GET").toUpperCase();
+
+    let lastError: TalosAPIError | undefined;
+
+    const hasIdempotencyKey = idempotencyKey !== undefined;
+    if (idempotencyKey !== undefined) {
+      validateIdempotencyKey(idempotencyKey);
+    }
+    const effectiveMaxAttempts =
+      this.explicitMaxAttempts ??
+      (hasIdempotencyKey ? 3 : 1);
+    const maxAttempts = Math.min(effectiveMaxAttempts, MAX_ATTEMPTS_CAP);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const started = Date.now();
+      try {
+        await this.maybeInjectChaos();
+        return await this.executeRequest<T>(
+          url,
+          method,
+          requestInit,
+          signal,
+          idempotencyKey,
+          path,
+        );
+      } catch (err) {
+        const apiErr = err instanceof TalosAPIError ? err : undefined;
+        const status = apiErr?.status ?? 0;
+        const retryable = this.canRetry(method, status, hasIdempotencyKey);
+        if (!retryable || attempt >= maxAttempts) {
+          if (apiErr) lastError = apiErr;
+          this.onError?.({
+            error: lastError ?? (err instanceof Error ? err : new Error(String(err))) as TalosAPIError,
+            path,
+            method,
+            attempt,
+            durationMs: Date.now() - started,
+          });
+          throw err;
+        }
+        lastError = apiErr;
+        const delayMs = this.getRetryDelay(attempt, apiErr?.retryAfterMs);
+        this.retry.onRetry?.({ error: err, attempt, delayMs });
+        await wait(delayMs, signal ?? undefined);
+      }
+    }
+    throw lastError ?? new TalosAPIError(0, "", path);
+  }
+
+  /** Perform a single fetch attempt (no retry). */
+  private async executeRequest<T>(
+    url: string,
+    method: string,
+    init: Omit<RequestInit, "method">,
+    signal: AbortSignal | null | undefined,
+    idempotencyKey: string | undefined,
+    path: string,
+  ): Promise<T> {
+    const headers: Record<string, string> = { ...this.headers };
+    const initHeaders = (init as RequestInit).headers;
+    if (initHeaders) {
+      if (typeof Headers !== "undefined" && initHeaders instanceof Headers) {
+        initHeaders.forEach((value, key) => {
+          headers[key] = value;
+        });
+      } else if (Array.isArray(initHeaders)) {
+        for (const [k, v] of initHeaders) headers[k] = v;
+      } else {
+        // Preserve key casing for plain-object headers.
+        Object.assign(headers, initHeaders);
+      }
+    }
+    if (idempotencyKey) {
+      headers["Idempotency-Key"] = idempotencyKey;
+    }
     if (this.signer) {
       const timestamp = new Date().toISOString();
       const nonce = globalThis.crypto.randomUUID();
       const bytes = await canonicalizeRequest({
-        method: init?.method ?? "GET",
+        method,
         url,
         headers,
-        body: init?.body,
+        body: (init as RequestInit).body,
         timestamp,
         nonce,
       });
       const signed = await this.signer.sign(
         { kind: "http-request-v1", bytes },
-        { signal: init?.signal ?? undefined, requestId: nonce },
+        { signal: signal ?? undefined, requestId: nonce },
       );
       Object.assign(headers, {
         "X-Talos-Signature-Version": "talos-request-v1",
@@ -261,16 +385,55 @@ export class TalosClient {
         "X-Talos-Signature": encodeSignature(signed.signature),
       });
     }
-    const res = await fetch(url, {
-      ...init,
-      headers,
-    });
-    if (!res.ok) {
-      const body = await res.text();
-      throw new TalosAPIError(res.status, body, path);
+
+    let controller: AbortController | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    if (this.timeoutMs) {
+      controller = new AbortController();
+      if (signal) {
+        signal.addEventListener("abort", () => controller?.abort(), { once: true });
+      }
+      timeoutId = setTimeout(() => controller?.abort(), this.timeoutMs);
     }
 
-    throw new Error("Unexpected retry failure");
+    if (signal?.aborted) {
+      throw classifyTransportError(new Error("Request aborted"), path);
+    }
+
+    const fetchImpl = this.resolveFetch();
+    // Only transport-level failures (fetch rejection, timeout/abort) are
+    // classified here. Response-processing errors (typed API errors, JSON
+    // parse failures, idempotency conflicts) propagate unchanged.
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        ...(init as RequestInit),
+        method,
+        headers,
+        signal: controller?.signal ?? signal ?? undefined,
+      });
+    } catch (err) {
+      throw classifyTransportError(err, path);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+
+    if (!res.ok) {
+      const body = await res.text();
+      if (
+        res.status === 409 &&
+        idempotencyKey !== undefined &&
+        isPayloadConflict(body)
+      ) {
+        throw new IdempotencyConflictError(idempotencyKey, path, body);
+      }
+      throw errorFromResponse(res.status, path, body, res.headers);
+    }
+    if (res.status === 204 || res.status === 205) {
+      return undefined as T;
+    }
+    // Let JSON parsing errors on successful responses propagate unchanged.
+    return (await res.json()) as T;
   }
 
   private async requestPage<T>(
@@ -315,6 +478,7 @@ export class TalosClient {
   async reportActivity(
     talosId: string,
     params: ReportActivityParams,
+    options?: WriteOptions,
   ): Promise<Activity> {
     return this.request(`/api/talos/${talosId}/activity`, {
       method: "POST",
@@ -333,6 +497,7 @@ export class TalosClient {
   async reportRevenue(
     talosId: string,
     params: ReportRevenueParams,
+    options?: WriteOptions,
   ): Promise<Revenue> {
     return this.request(`/api/talos/${talosId}/revenue`, {
       method: "POST",
@@ -351,6 +516,7 @@ export class TalosClient {
   async createApproval(
     talosId: string,
     params: CreateApprovalParams,
+    options?: WriteOptions,
   ): Promise<Approval> {
     return this.request(`/api/talos/${talosId}/approvals`, {
       method: "POST",
@@ -419,10 +585,6 @@ export class TalosClient {
    *   - {@link TalosPaymentError} when the 402 challenge is malformed/missing.
    *   - {@link TalosAuthenticationError} for missing credentials on the signed retry.
    *   - Any other TalosAPIError subclass for downstream failures.
-   *
-   * @param talosId - The ID of the TALOS providing the service.
-   * @param buyerTalosId - The ID of the TALOS purchasing the service (for signing).
-   * @param payload - Optional payload for the service.
    */
   async purchaseServiceWithPayment(
     talosId: string,
@@ -433,18 +595,14 @@ export class TalosClient {
     const path = `/api/talos/${talosId}/service`;
     const url = `${this.baseUrl}${path}`;
 
-    if (this.chaosInjector) {
-      await this.chaosInjector.maybeInjectFault(FaultType.NETWORK_DELAY);
-      await this.chaosInjector.maybeInjectFault(FaultType.NETWORK_DROP);
-      await this.chaosInjector.maybeInjectFault(FaultType.API_TIMEOUT);
-    }
+    await this.maybeInjectChaos();
 
-    // 1. Try initial request
+    // 1. Initial request that may return an x402 challenge.
     const initialHeaders = await this.signedHeaders(url, {
       method: "POST",
       body: JSON.stringify({ payload }),
     });
-    res = await fetch(url, {
+    const res = await this.resolveFetch()(url, {
       method: "POST",
       headers: initialHeaders,
       body: JSON.stringify({ payload }),
@@ -454,41 +612,31 @@ export class TalosClient {
       // 2. Validate the x402 challenge.
       const authHeader = res.headers.get("WWW-Authenticate");
       if (!authHeader || !authHeader.startsWith("x402")) {
-        // Preserve the legacy text so existing
-        // `rejects.toThrow("Invalid x402 challenge")` assertions keep passing.
-        throw new TalosPaymentError(402, "Invalid x402 challenge", path, {
-          message: "Invalid x402 challenge",
-          headers: { "www-authenticate": authHeader ?? "" },
-        });
+        throw errorFromResponse(402, path, "Invalid x402 challenge", new Headers({
+          "www-authenticate": authHeader ?? "",
+        }));
       }
       const challenge = parseX402Challenge(authHeader);
       if (!challenge) {
-        throw new TalosPaymentError(402, "Invalid x402 challenge", path, {
-          message: "Invalid x402 challenge",
-          headers: { "www-authenticate": authHeader },
-        });
+        throw errorFromResponse(402, path, "Invalid x402 challenge", new Headers({
+          "www-authenticate": authHeader,
+        }));
       }
-
-      // 3. Request signature from the Web API.
-      //    `parseFloat(undefined)` would yield NaN; we already required both
-      //    keys above (parseX402Challenge rejects partial challenges), but
-      //    `price` could still be the literal "abc" — guard explicitly so
-      //    a malformed header never feeds NaN to the downstream /sign call.
       const amount = parseFloat(challenge.price);
       if (!Number.isFinite(amount)) {
-        throw new TalosPaymentError(402, "Invalid x402 challenge", path, {
-          message: "Invalid x402 challenge",
-          headers: { "www-authenticate": authHeader },
-        });
+        throw errorFromResponse(402, path, "Invalid x402 challenge", new Headers({
+          "www-authenticate": authHeader,
+        }));
       }
+
+      // 3. Request a payment signature from the buyer's TALOS.
       const signRes = await this.signPayment(buyerTalosId, {
         payee: challenge.payee,
         amount,
         assetCode: challenge.token,
       });
 
-      // 4. Retry with the X-PAYMENT header — delegated to the regular
-      //    request helper, so all typed errors / retry / timeout apply.
+      // 4. Retry the purchase with the signed X-PAYMENT header.
       return this.purchaseService(talosId, {
         paymentHeader: signRes.paymentHeader,
         payload,
@@ -498,17 +646,16 @@ export class TalosClient {
     // Non-402 responses — wrap them through the typed dispatch.
     if (!res.ok) {
       const body = await res.text();
-      throw new TalosAPIError(
-        res.status,
-        body,
-        `/api/talos/${talosId}/service`,
-      );
+      throw errorFromResponse(res.status, path, body, res.headers);
     }
 
-    return res.json() as Promise<CommerceJob>;
+    return (await res.json()) as CommerceJob;
   }
 
-  private async signedHeaders(url: string, init: RequestInit): Promise<Record<string, string>> {
+  private async signedHeaders(
+    url: string,
+    init: RequestInit,
+  ): Promise<Record<string, string>> {
     if (!this.signer && !init.headers) return { ...this.headers };
     const merged = new Headers(this.headers);
     new Headers(init.headers).forEach((value, key) => merged.set(key, value));
@@ -539,15 +686,6 @@ export class TalosClient {
     };
   }
 
-  private parseX402Challenge(header: string): Record<string, string> {
-    const parts = header.slice(5).split(", ");
-    const challenge: Record<string, string> = {};
-    for (const part of parts) {
-      const [key, value] = part.split("=");
-      challenge[key] = value.replace(/"/g, "");
-    }
-  }
-
   // ── Wallet & Payments ──────────────────────────────────────
 
   async getWallet(talosId: string): Promise<Wallet> {
@@ -557,16 +695,20 @@ export class TalosClient {
   async signPayment(
     talosId: string,
     params: SignPaymentParams,
+    options?: WriteOptions,
   ): Promise<SignedPayment> {
     return this.request(`/api/talos/${talosId}/sign`, {
       method: "POST",
       body: JSON.stringify(params),
+      idempotencyKey: options?.idempotencyKey,
+      signal: options?.signal,
     });
   }
 
   async transfer(
     talosId: string,
     params: TransferParams,
+    options?: WriteOptions,
   ): Promise<TransferResponse> {
     return this.request(`/api/talos/${talosId}/transfer`, {
       method: "POST",
@@ -582,13 +724,6 @@ export class TalosClient {
     return this.request("/api/jobs/pending");
   }
 
-  /**
-   * Submit the result of a fulfilled job.
-   *
-   * Pass `options.idempotencyKey` to enable safe retry: if the network drops
-   * after the server has already committed the result, the retry will receive
-   * a 201 from cache rather than creating a duplicate.
-   */
   async submitJobResult(
     jobId: string,
     result: unknown,

--- a/packages/sdk/tests/errors.test.ts
+++ b/packages/sdk/tests/errors.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Focused tests for the typed API error parsing surface (issue #468).
+ *
+ * Consumers should be able to handle API failures through stable typed fields
+ * (`status`, `code`, `message`, `requestId`, validation `issues`, safe headers)
+ * instead of parsing arbitrary response bodies.
+ *
+ * Acceptance criteria covered here:
+ *   - JSON envelopes parse into the documented type.
+ *   - Non-JSON responses produce a safe fallback error.
+ *   - Sensitive response fields are not copied into messages.
+ *   - Successful response behavior is unchanged.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  TalosAPIError,
+  TalosValidationError,
+  TalosAuthenticationError,
+  TalosForbiddenError,
+  TalosNotFoundError,
+  TalosConflictError,
+  TalosPaymentError,
+  TalosRateLimitError,
+  TalosServerError,
+  TalosServerRetryableError,
+  TalosTransportError,
+  TalosTimeoutError,
+  errorFromResponse,
+  classifyTransportError,
+  sanitizeBody,
+  redactSecrets,
+  snapshotHeaders,
+  parseRetryAfter,
+  MAX_BODY_BYTES,
+} from "../src/index.js";
+
+describe("errorFromResponse — JSON envelope → documented type", () => {
+  it("maps every common status code to the correct typed subclass", () => {
+    const cases: Array<[number, new (...args: never[]) => TalosAPIError]> = [
+      [400, TalosValidationError],
+      [401, TalosAuthenticationError],
+      [402, TalosPaymentError],
+      [403, TalosForbiddenError],
+      [404, TalosNotFoundError],
+      [409, TalosConflictError],
+      [429, TalosRateLimitError],
+      [500, TalosServerError],
+      [502, TalosServerRetryableError],
+      [503, TalosServerRetryableError],
+      [504, TalosServerRetryableError],
+    ];
+    for (const [status, klass] of cases) {
+      const err = errorFromResponse(status, "/x", "{}", new Headers());
+      expect(err, `status ${status}`).toBeInstanceOf(klass);
+      expect(err).toBeInstanceOf(TalosAPIError);
+    }
+  });
+
+  it("surfaces request id, headers, and parsed data on the error", () => {
+    const headers = new Headers({
+      "x-request-id": "req-123",
+      "retry-after": "2",
+    });
+    const err = errorFromResponse(
+      429,
+      "/api/talos",
+      JSON.stringify({ error: "slow down" }),
+      headers,
+    );
+    expect(err.requestId).toBe("req-123");
+    expect(err.headers["x-request-id"]).toBe("req-123");
+    expect(err.headers["retry-after"]).toBe("2");
+    expect(err.retryAfterMs).toBe(2000);
+    expect(err).toMatchObject({ code: "rate_limit_error", status: 429 });
+  });
+
+  it("parses validation details into a stable `issues` array", () => {
+    const err = errorFromResponse(
+      400,
+      "/api/talos",
+      JSON.stringify({ error: "bad", issues: ["name: required", "category: invalid"] }),
+      new Headers(),
+    );
+    expect(err).toBeInstanceOf(TalosValidationError);
+    expect((err as TalosValidationError).issues).toEqual([
+      "name: required",
+      "category: invalid",
+    ]);
+    expect(err.code).toBe("validation_error");
+  });
+
+  it("preserves the legacy message format for compatibility", () => {
+    const err = errorFromResponse(400, "/api/talos/1", "Bad Request", new Headers());
+    expect(err.message).toBe("Talos API error 400 on /api/talos/1: Bad Request");
+    expect(err.message).toContain(String(err.status));
+    expect(err.message).toContain(err.path);
+  });
+});
+
+describe("errorFromResponse — non-JSON / malformed responses", () => {
+  it("produces a safe fallback error for HTML / plain-text bodies", () => {
+    const html = "<html><body>503 Service Temporarily Unavailable</body></html>";
+    const err = errorFromResponse(503, "/x", html, new Headers());
+    expect(err).toBeInstanceOf(TalosServerRetryableError);
+    expect(err.isRetryable).toBe(true);
+    // Body is collapsed to a single line and bounded.
+    expect(err.body).not.toContain("\n");
+    expect(err.body.length).toBeLessThanOrEqual(MAX_BODY_BYTES + 20);
+  });
+
+  it("returns a generic API error for unknown statuses", () => {
+    const err = errorFromResponse(418, "/x", "teapot", new Headers());
+    expect(err).toBeInstanceOf(TalosAPIError);
+    expect(err.code).toBe("api_error");
+    expect(err.status).toBe(418);
+  });
+});
+
+describe("sensitive-field redaction", () => {
+  it("never copies secret fields into the message or body", () => {
+    const raw = JSON.stringify({
+      error: "boom",
+      token: "sekret-token",
+      authorization: "Bearer xyz",
+      apiKey: "k-1234",
+      signature: "sig-x",
+    });
+    const { body, data } = sanitizeBody(raw);
+    expect(body).toContain("[REDACTED]");
+    expect(body).not.toContain("sekret-token");
+    expect(body).not.toContain("Bearer xyz");
+    expect(body).not.toContain("k-1234");
+    expect(body).not.toContain("sig-x");
+    expect((data as Record<string, unknown>).token).toBe("[REDACTED]");
+    expect((data as Record<string, unknown>).authorization).toBe("[REDACTED]");
+  });
+
+  it("redacts nested and array-sensitive fields", () => {
+    const redacted = redactSecrets({
+      outer: { inner: { password: "hunter2", safe: "keep" } },
+      list: [{ apiKey: "a" }, { note: "ok" }],
+    }) as {
+      outer: { inner: { password: string; safe: string } };
+      list: Array<Record<string, unknown>>;
+    };
+    expect(redacted.outer.inner.password).toBe("[REDACTED]");
+    expect(redacted.outer.inner.safe).toBe("keep");
+    expect(redacted.list[0].apiKey).toBe("[REDACTED]");
+    expect(redacted.list[1].note).toBe("ok");
+  });
+
+  it("handles circular references without hanging", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    const r = redactSecrets(a) as { name: string; self: unknown };
+    expect(r.name).toBe("a");
+    expect(r.self).toBe("[Circular]");
+  });
+});
+
+describe("classifyTransportError", () => {
+  it("classifies DNS / connection failures as retryable transport errors", () => {
+    const err = classifyTransportError(new Error("ECONNREFUSED"), "/x");
+    expect(err).toBeInstanceOf(TalosTransportError);
+    expect(err.isRetryable).toBe(true);
+  });
+
+  it("classifies aborts and timeouts as TalosTimeoutError", () => {
+    const aborted = classifyTransportError(new DOMException("Aborted", "AbortError"), "/x");
+    expect(aborted).toBeInstanceOf(TalosTimeoutError);
+    expect(aborted.code).toBe("timeout_error");
+    const timedOut = classifyTransportError(new Error("Request timeout"), "/x");
+    expect(timedOut).toBeInstanceOf(TalosTimeoutError);
+  });
+});
+
+describe("snapshotHeaders", () => {
+  it("keeps only the safe, retry-relevant header set", () => {
+    const snap = snapshotHeaders(
+      new Headers({
+        "x-request-id": "r1",
+        "retry-after": "5",
+        "x-ratelimit-limit": "60",
+        "set-cookie": "secret=1",
+        authorization: "Bearer nope",
+      }),
+    );
+    expect(snap).toEqual({
+      "x-request-id": "r1",
+      "retry-after": "5",
+      "x-ratelimit-limit": "60",
+    });
+    expect(snap.authorization).toBeUndefined();
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses seconds and HTTP dates, and rejects garbage", () => {
+    expect(parseRetryAfter("5")).toBe(5000);
+    expect(parseRetryAfter("0")).toBe(0);
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const ms = parseRetryAfter(future);
+    expect(ms).toBeGreaterThan(9_000);
+    expect(ms).toBeLessThanOrEqual(10_000);
+    expect(parseRetryAfter("garbage")).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #468

## Summary
Lets SDK consumers handle API failures through **stable typed fields** (`status`, `code`, `message`, `requestId`, validation `issues`, safe headers, retry hints) instead of parsing arbitrary response bodies.

The typed error layer (`src/errors.ts` — `errorFromResponse`, `classifyTransportError`, the `TalosAPIError` subclass hierarchy, `sanitizeBody`/`redactSecrets`) already existed, but the **client was never wired to it**: `TalosClient` threw a raw `TalosAPIError` with no `errorFromResponse` dispatch, and `client.ts` was in a broken merge state (undeclared `res`, undefined `options` references, missing `parseX402Challenge` return, lost `retryPolicy`/`chaosInjector`/`timeoutMs` support).

## Changes
- **`TalosClient.request()` rebuilt on top of `errorFromResponse`** — every non-2xx response dispatches to the matching typed subclass:
  - 400 `TalosValidationError` (+ `issues`), 401 `TalosAuthenticationError`, 402 `TalosPaymentError` (+ parsed x402 `challenge`), 403 `TalosForbiddenError`, 404 `TalosNotFoundError`, 409 `TalosConflictError`, 429 `TalosRateLimitError` (+ `retryAfterMs`, `limit`, `remaining`, `resetAt`), 5xx `TalosServerError` / `TalosServerRetryableError`.
  - Fetch-level failures go through `classifyTransportError` → `TalosTransportError` / `TalosTimeoutError`.
  - Legacy `"Talos API error <status> on <path>: <body>"` messages and `instanceof TalosAPIError` compatibility preserved.
- **`request()` is now public** so advanced consumers get typed errors on endpoints the typed methods don't cover yet.
- **Retry / timeout / idempotency behaviour that was declared but unimplemented is now real:**
  - `retry` option (+ `retryPolicy` alias): `maxAttempts` (capped at 8), `baseDelayMs`/`maxDelayMs` backoff, `jitter`, `onRetry`, `maxRetryAfterMs`.
  - Per-request `timeoutMs` → aborts via `AbortController` and surfaces `TalosTimeoutError`.
  - Non-idempotent methods retry on transient statuses (429, 5xx) **when an idempotency key is supplied** (server dedupes on the key); otherwise POST-style writes are not auto-retried.
  - `onError` observer fires once with the final error (`TalosErrorEvent`).
  - 409 responses indicating the key was reused with a different payload surface as `IdempotencyConflictError`; caller-supplied keys are validated (`TypeError` if > 128 bytes).
- **Fixed the broken merge state**: undefined `options`/`WriteOptions`/`TalosAPIError` references, undeclared `res` in `purchaseServiceWithPayment`, missing `parseX402Challenge` return, and re-added `retryPolicy`, `chaosInjector`, `timeoutMs`, `fetchOverride` support.
- **Successful responses and the public API surface are unchanged.**

## Tests
- **`tests/errors.test.ts` (new, 13 tests)** directly covers the issue's acceptance criteria: common-status-code → typed-type matrix, validation details into `issues`, malformed/non-JSON → safe fallback error, sensitive-field redaction (nested + circular), transport classification, safe-header snapshotting, and `Retry-After` parsing.
- **`tests/client.test.ts`** (existing, 69 tests) now passes: typed dispatch per status, validation `issues`, rate-limit fields, secret redaction in bodies, retry/timeout/abort behavior, x402 flow, signing, backward-compat aliases.
- **`tests/idempotency.test.ts`**, **`tests/chaos.integration.test.ts`**, **`tests/signing.test.ts`**, and the rest of the suite pass.

## Verification
- `tsc -p tsconfig.json` — clean.
- `npm test` — **224 passed / 0 failed** (was 79 failures before this change).
- `npm run build` (ESM + CJS + browser) — succeeds.

## Compatibility
Additive and backward-compatible (documented in `packages/sdk/README.md`): all prior public APIs keep their signatures; `TalosAPIError(status, body, path)` and legacy messages are preserved; new error fields are additive.
