### PR TITLE
 security(agent): bound diagnostic label cardinality in adapter logs

### DIFF
--- a/packages/prime-agent/docs/adapter-diagnostics.md
+++ b/packages/prime-agent/docs/adapter-diagnostics.md
@@ -1,0 +1,23 @@
+# Adapter diagnostic log schema
+
+The adapter capability sandbox emits only `adapter_sandbox_invocation`,
+`adapter_capability_denied`, and `adapter_resource_limit`. Unknown fields are
+dropped before logging.
+
+| Field | Maximum | Handling |
+| --- | ---: | --- |
+| `adapter` (provider) | 64 chars | identifier characters only |
+| `operation` | 64 chars | built-in adapter operations only |
+| `operation_id` | 128 chars | identifier characters only |
+| `outcome` (status) | 32 chars | `succeeded`, `failed`, `timed_out`, or `denied` |
+| `error_type` / `error` | 256 chars | type is an identifier; text is redacted then capped |
+| `capability` / `resource` | 32 chars | fixed allowlists |
+| `target` | 128 chars | redacted then capped |
+| `duration_ms` | 3,600,000 | locally computed finite number |
+
+Unexpected categorical values become `unknown`. Control characters are replaced
+with spaces so values cannot alter log records. Sensitive keys (tokens,
+secrets, passwords, API keys, cookies, credentials, and similar names) are
+redacted recursively in nested error metadata before truncation. The schema is
+logging-only and does not affect retry, fallback, circuit-breaker, or adapter
+execution decisions.

--- a/packages/prime-agent/src/talos_agent/adapters/capability.py
+++ b/packages/prime-agent/src/talos_agent/adapters/capability.py
@@ -22,6 +22,7 @@ from urllib.parse import unquote, urlsplit
 import httpx
 
 from talos_agent.adapters.base import BaseSocialAdapter, ChannelCapabilities, PublishResult
+from talos_agent.adapters.diagnostics import safe_adapter_diagnostic_fields
 from talos_agent.observability import log
 
 _IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
@@ -1059,10 +1060,9 @@ def _denied(adapter: str, capability: str, target: str) -> None:
     try:
         log.warning(
             "adapter_capability_denied",
-            adapter=adapter,
-            capability=capability,
-            target=target,
-            outcome="denied",
+            **safe_adapter_diagnostic_fields(
+                adapter=adapter, capability=capability, target=target, outcome="denied"
+            ),
         )
     except Exception:
         pass
@@ -1072,10 +1072,9 @@ def _resource(adapter: str, operation: str, resource: str) -> None:
     try:
         log.warning(
             "adapter_resource_limit",
-            adapter=adapter,
-            operation=operation,
-            resource=resource,
-            outcome="denied",
+            **safe_adapter_diagnostic_fields(
+                adapter=adapter, operation=operation, resource=resource, outcome="denied"
+            ),
         )
     except Exception:
         pass
@@ -1099,7 +1098,7 @@ def _invocation_log(
     if error_type is not None:
         fields["error_type"] = error_type.__name__
     try:
-        log.info("adapter_sandbox_invocation", **fields)
+        log.info("adapter_sandbox_invocation", **safe_adapter_diagnostic_fields(**fields))
     except Exception:
         pass
 

--- a/packages/prime-agent/src/talos_agent/adapters/diagnostics.py
+++ b/packages/prime-agent/src/talos_agent/adapters/diagnostics.py
@@ -47,7 +47,11 @@ def _text(value: Any, maximum: int) -> str:
 
 
 def _label(value: Any, maximum: int, allowed: frozenset[str] | None = None) -> str:
-    text = _text(_redact(value), maximum)
+    redacted = _redact(value)
+    raw_text = str(redacted)
+    if len(raw_text) > maximum:
+        return "unknown"
+    text = _text(redacted, maximum)
     return text if _SAFE_LABEL.fullmatch(text) and (allowed is None or text in allowed) else "unknown"
 
 

--- a/packages/prime-agent/src/talos_agent/adapters/diagnostics.py
+++ b/packages/prime-agent/src/talos_agent/adapters/diagnostics.py
@@ -1,0 +1,82 @@
+"""Bounded, redacted schema for adapter structured-log diagnostics."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+MAX_PROVIDER_LENGTH = 64
+MAX_OPERATION_LENGTH = 64
+MAX_STATUS_LENGTH = 32
+MAX_ERROR_LENGTH = 256
+MAX_OPERATION_ID_LENGTH = 128
+MAX_CAPABILITY_LENGTH = 32
+MAX_TARGET_LENGTH = 128
+MAX_RESOURCE_LENGTH = 32
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+_SAFE_LABEL = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]*$")
+_SENSITIVE_KEY = re.compile(r"(?:token|authorization|secret|api[_-]?key|password|cookie|signature|credential|private[_-]?key|webhook)", re.I)
+_INLINE_SECRET = re.compile(r"(Bearer\s+)[^\s,;]+", re.I)
+_VALID_OPERATIONS = frozenset({"post", "reply", "get_mentions", "search", "get_post_performance", "get_profile_stats", "network", "browser"})
+_VALID_STATUSES = frozenset({"succeeded", "failed", "timed_out", "denied"})
+_VALID_CAPABILITIES = frozenset({"secret", "network", "browser", "browser_host", "filesystem_read", "filesystem_write", "tool", "manifest", "operation"})
+_VALID_RESOURCES = frozenset({"input", "output", "request", "network_requests", "network_response", "browser_actions"})
+
+
+def _redact(value: Any, seen: set[int] | None = None) -> Any:
+    """Redact sensitive keys recursively before a value is rendered or capped."""
+    seen = set() if seen is None else seen
+    if isinstance(value, Mapping):
+        if id(value) in seen:
+            return "[CYCLE]"
+        seen.add(id(value))
+        return {str(key): "[REDACTED]" if _SENSITIVE_KEY.search(str(key)) else _redact(child, seen) for key, child in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        if id(value) in seen:
+            return "[CYCLE]"
+        seen.add(id(value))
+        return [_redact(child, seen) for child in value]
+    return _INLINE_SECRET.sub(r"\1[REDACTED]", value) if isinstance(value, str) else value
+
+
+def _text(value: Any, maximum: int) -> str:
+    """Render a redacted value as one bounded, single-line string."""
+    return _CONTROL_CHARS.sub(" ", str(value))[:maximum]
+
+
+def _label(value: Any, maximum: int, allowed: frozenset[str] | None = None) -> str:
+    text = _text(_redact(value), maximum)
+    return text if _SAFE_LABEL.fullmatch(text) and (allowed is None or text in allowed) else "unknown"
+
+
+def safe_adapter_diagnostic_fields(**fields: Any) -> dict[str, Any]:
+    """Return only documented, bounded adapter-log fields.
+
+    Unknown fields are dropped. Redaction always occurs before control-character
+    replacement and truncation.
+    """
+    result: dict[str, Any] = {}
+    if "adapter" in fields or "provider" in fields:
+        result["adapter"] = _label(fields.get("adapter", fields.get("provider")), MAX_PROVIDER_LENGTH)
+    if "operation" in fields:
+        result["operation"] = _label(fields["operation"], MAX_OPERATION_LENGTH, _VALID_OPERATIONS)
+    if fields.get("operation_id") is not None:
+        result["operation_id"] = _label(fields["operation_id"], MAX_OPERATION_ID_LENGTH)
+    if "outcome" in fields or "status" in fields:
+        result["outcome"] = _label(fields.get("outcome", fields.get("status")), MAX_STATUS_LENGTH, _VALID_STATUSES)
+    if "error_type" in fields:
+        result["error_type"] = _label(fields["error_type"], MAX_ERROR_LENGTH)
+    if "error" in fields:
+        result["error"] = _text(_redact(fields["error"]), MAX_ERROR_LENGTH)
+    if "capability" in fields:
+        result["capability"] = _label(fields["capability"], MAX_CAPABILITY_LENGTH, _VALID_CAPABILITIES)
+    if "target" in fields:
+        result["target"] = _text(_redact(fields["target"]), MAX_TARGET_LENGTH)
+    if "resource" in fields:
+        result["resource"] = _label(fields["resource"], MAX_RESOURCE_LENGTH, _VALID_RESOURCES)
+    duration = fields.get("duration_ms")
+    if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+        result["duration_ms"] = max(0, min(round(duration, 2), 3_600_000))
+    return result

--- a/packages/prime-agent/tests/test_adapter_capability_sandbox.py
+++ b/packages/prime-agent/tests/test_adapter_capability_sandbox.py
@@ -34,6 +34,11 @@ from talos_agent.adapters.capability import (
     default_manifests,
     load_manifests,
 )
+from talos_agent.adapters.diagnostics import (
+    MAX_ERROR_LENGTH,
+    MAX_PROVIDER_LENGTH,
+    safe_adapter_diagnostic_fields,
+)
 from talos_agent.adapters.registry import AdapterRegistry
 from talos_agent.adapters.telegram import TelegramAdapter, TelegramAdapterConfig
 from talos_agent.config import Settings
@@ -341,6 +346,67 @@ async def test_structured_events_never_include_payloads_or_secret_values(
         "adapter_capability_denied",
     }
     db.close()
+
+
+def test_adapter_diagnostic_schema_bounds_and_normalizes_untrusted_labels():
+    fields = safe_adapter_diagnostic_fields(
+        provider="provider-" + "x" * 500,
+        operation="post\nforged",
+        status="succeeded\r\nforged",
+        error_type="Error\x00" + "x" * 500,
+        operation_id="id\n" + "x" * 500,
+        target="target\r\n" + "x" * 500,
+        unexpected="must be dropped",
+    )
+
+    assert fields["adapter"] == "unknown"
+    assert fields["operation"] == "unknown"
+    assert fields["outcome"] == "unknown"
+    assert fields["error_type"] == "unknown"
+    assert fields["operation_id"] == "unknown"
+    assert len(fields["adapter"]) <= MAX_PROVIDER_LENGTH
+    assert "\n" not in repr(fields) and "\r" not in repr(fields)
+    assert "unexpected" not in fields
+
+
+def test_adapter_diagnostic_schema_redacts_nested_secrets_before_truncation():
+    fields = safe_adapter_diagnostic_fields(
+        adapter="telegram",
+        operation="post",
+        outcome="failed",
+        error={"context": {"api_key": "secret-value-that-must-never-appear"}, "message": "x" * 1000},
+    )
+
+    assert fields["adapter"] == "telegram"
+    assert fields["operation"] == "post"
+    assert fields["outcome"] == "failed"
+    assert "secret-value-that-must-never-appear" not in fields["error"]
+    assert "[REDACTED]" in fields["error"]
+    assert len(fields["error"]) <= MAX_ERROR_LENGTH
+
+
+def test_adapter_diagnostic_schema_preserves_normal_diagnostics():
+    assert safe_adapter_diagnostic_fields(
+        adapter="telegram",
+        operation="post",
+        operation_id="delivery-42",
+        outcome="succeeded",
+        error_type="TimeoutError",
+        capability="network",
+        resource="request",
+        target="api.telegram.org",
+        duration_ms=12.345,
+    ) == {
+        "adapter": "telegram",
+        "operation": "post",
+        "operation_id": "delivery-42",
+        "outcome": "succeeded",
+        "error_type": "TimeoutError",
+        "capability": "network",
+        "resource": "request",
+        "target": "api.telegram.org",
+        "duration_ms": 12.35,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- closes #465  

## Summary

  Hardens adapter capability-sandbox structured logs against attacker-controlled diagnostic metadata.

  - Adds an allowlisted, bounded diagnostic log schema.
  - Caps provider/adapter, operation, status/outcome, error, target, and operation ID fields.
  - Drops unknown log fields and normalizes invalid categorical values to `unknown`.
  - Replaces control characters to prevent log-record injection.
  - Applies recursive secret redaction before truncation, including nested error metadata.
  - Documents the safe adapter diagnostic schema.

  ## Tests

  Added coverage for:

  - Oversized diagnostic values
  - Control-character log injection attempts
  - Nested secret redaction
  - Normal diagnostic fields

  Retry, fallback, circuit-breaker, and adapter execution behavior are unchanged.