### PR TITLE
feat(security): validate forwarded hosts for public URL generation

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -5,6 +5,14 @@
 DATABASE_URL=postgresql://postgres.XXXX:PASSWORD@aws-0-eu-central-1.pooler.supabase.com:6543/postgres
 DIRECT_URL=postgresql://postgres.XXXX:PASSWORD@db.XXXX.supabase.co:5432/postgres
 
+# ─── Public URL Settings ──────────────────────────────────
+# Canonical base URL for your application
+APP_URL=https://talos-stellar.vercel.app
+NEXT_PUBLIC_APP_URL=https://talos-stellar.vercel.app
+
+# Comma-separated list of trusted hosts (used if APP_URL is dynamic)
+TRUSTED_HOSTS=talos-stellar.vercel.app,localhost:3000
+
 # ─── Stellar Network ──────────────────────────────────────
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/web/src/lib/__tests__/public-url.test.ts
+++ b/web/src/lib/__tests__/public-url.test.ts
@@ -1,0 +1,108 @@
+import { getPublicBaseUrl } from "../public-url";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+describe("getPublicBaseUrl", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return localhost in development if no headers provided", () => {
+    process.env.NODE_ENV = "development";
+    const headers = new Headers();
+    expect(getPublicBaseUrl(headers)).toBe("http://localhost:3000");
+  });
+
+  it("should return configured APP_URL if no headers provided in production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.APP_URL = "https://talos.example.com";
+    const headers = new Headers();
+    expect(getPublicBaseUrl(headers)).toBe("https://talos.example.com");
+  });
+
+  it("should accept explicit trusted host", () => {
+    process.env.NODE_ENV = "production";
+    process.env.TRUSTED_HOSTS = "trusted.example.com,also-trusted.com";
+    const headers = new Headers({
+      host: "trusted.example.com"
+    });
+    expect(getPublicBaseUrl(headers)).toBe("https://trusted.example.com"); // defaults to https
+  });
+
+  it("should prioritize x-forwarded-host and x-forwarded-proto", () => {
+    process.env.NODE_ENV = "production";
+    process.env.TRUSTED_HOSTS = "proxy.example.com";
+    const headers = new Headers({
+      host: "internal.local",
+      "x-forwarded-host": "proxy.example.com",
+      "x-forwarded-proto": "http"
+    });
+    expect(getPublicBaseUrl(headers)).toBe("http://proxy.example.com");
+  });
+
+  it("should fallback to APP_URL if host is untrusted", () => {
+    process.env.NODE_ENV = "production";
+    process.env.APP_URL = "https://safe.example.com";
+    const headers = new Headers({
+      host: "evil.com"
+    });
+    expect(getPublicBaseUrl(headers)).toBe("https://safe.example.com");
+  });
+
+  it("should throw if host is untrusted and no APP_URL is configured", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.TRUSTED_HOSTS = "good.com";
+    
+    const headers = new Headers({
+      host: "evil.com"
+    });
+    expect(() => getPublicBaseUrl(headers)).toThrow("Untrusted host header");
+  });
+
+  it("should accept localhost in development automatically", () => {
+    process.env.NODE_ENV = "development";
+    const headers = new Headers({
+      host: "localhost:3000"
+    });
+    expect(getPublicBaseUrl(headers)).toBe("http://localhost:3000");
+  });
+
+  it("should accept localhost in test automatically", () => {
+    process.env.NODE_ENV = "test";
+    const headers = new Headers({
+      host: "127.0.0.1:8080"
+    });
+    expect(getPublicBaseUrl(headers)).toBe("http://127.0.0.1:8080");
+  });
+
+  it("should reject ambiguous x-forwarded-host", () => {
+    process.env.NODE_ENV = "production";
+    const headers = new Headers({
+      "x-forwarded-host": "good.com, evil.com"
+    });
+    expect(() => getPublicBaseUrl(headers)).toThrow("Ambiguous X-Forwarded-Host");
+  });
+
+  it("should reject ambiguous host", () => {
+    process.env.NODE_ENV = "production";
+    const headers = new Headers({
+      "host": "good.com, evil.com"
+    });
+    expect(() => getPublicBaseUrl(headers)).toThrow("Ambiguous Host");
+  });
+
+  it("should reject malformed host with path injection", () => {
+    process.env.NODE_ENV = "production";
+    const headers = new Headers({
+      "host": "good.com/evil"
+    });
+    expect(() => getPublicBaseUrl(headers)).toThrow("Malformed host header");
+  });
+});

--- a/web/src/lib/public-url.ts
+++ b/web/src/lib/public-url.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server";
+
+export function getPublicBaseUrl(reqOrHeaders: Request | NextRequest | Headers): string {
+  const headers = reqOrHeaders instanceof Headers 
+    ? reqOrHeaders 
+    : ('headers' in reqOrHeaders ? reqOrHeaders.headers : new Headers());
+
+  const configuredUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+  
+  const forwardedHost = headers.get("x-forwarded-host");
+  const hostHeader = headers.get("host");
+  const forwardedProto = headers.get("x-forwarded-proto");
+
+  // Reject comma-separated ambiguous values
+  if (forwardedHost && forwardedHost.includes(",")) throw new Error("Ambiguous X-Forwarded-Host");
+  if (hostHeader && hostHeader.includes(",")) throw new Error("Ambiguous Host");
+  if (forwardedProto && forwardedProto.includes(",")) throw new Error("Ambiguous X-Forwarded-Proto");
+
+  // If x-forwarded-host and host both exist and we want to prevent conflicts? 
+  // Normally proxy modifies host, or keeps original in x-forwarded-host. 
+  // We'll trust x-forwarded-host if present, else host.
+  const host = forwardedHost || hostHeader;
+
+  if (!host) {
+    if (configuredUrl) return configuredUrl.replace(/\/$/, "");
+    return "http://localhost:3000";
+  }
+
+  // Basic malformed host check (e.g. injects paths)
+  if (host.includes("/") || host.includes("\\")) {
+    throw new Error("Malformed host header");
+  }
+
+  const protocol = forwardedProto === "http" ? "http" : "https";
+  let hostname = host;
+  if (host.includes(":")) {
+    // IPv6 support needs bracket handling, but for now simple split or URL parser
+    try {
+      const parsed = new URL(`http://${host}`);
+      hostname = parsed.hostname;
+    } catch {
+      throw new Error("Malformed host header");
+    }
+  }
+
+  const trustedHosts = (process.env.TRUSTED_HOSTS || "")
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+
+  if (configuredUrl) {
+    try {
+      trustedHosts.push(new URL(configuredUrl).hostname);
+    } catch (e) {}
+  }
+
+  const isLocal = process.env.NODE_ENV !== "production";
+  const isLocalHost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname.endsWith(".local");
+
+  const isTrusted = trustedHosts.includes(hostname) || (isLocal && isLocalHost);
+
+  if (!isTrusted) {
+    if (configuredUrl) {
+      return configuredUrl.replace(/\/$/, "");
+    }
+    throw new Error("Untrusted host header");
+  }
+
+  const finalProtocol = (isLocal && isLocalHost && !forwardedProto) ? "http" : protocol;
+  return `${finalProtocol}://${host}`;
+}


### PR DESCRIPTION
## Summary
This PR introduces a standardized utility for securely building public-facing URLs in the Next.js application, preventing untrusted forwarded host headers from influencing redirects, callback URLs, or generated API links.

By default, Next.js implicitly trusts `Host` and `X-Forwarded-Host` headers when constructing `req.nextUrl`, which exposes the application to Host Header Injection attacks if these URLs are later returned in callbacks or redirects. This PR solves the issue by introducing a strict allowlist-based approach for deriving the canonical public URL safely.

## Changes
- **Public URL Utility**: Created a `getPublicBaseUrl` helper to retrieve a trusted base URL from incoming requests or headers.
- **Strict Host Validation**: Explicitly rejects malformed and ambiguous (e.g., comma-separated) `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto` header combinations.
- **Environment Driven Allowlist**: Uses `APP_URL` and `NEXT_PUBLIC_APP_URL` as the canonical source of truth, and falls back to verifying against a `TRUSTED_HOSTS` allowlist if present.
- **Local Development Support**: Automatically permits `localhost`, `127.0.0.1`, `[::1]`, and `.local` domains when `NODE_ENV` is set to development or test, ensuring developer experience remains seamless.
- **Environment Configuration**: Added `APP_URL` and `TRUSTED_HOSTS` defaults to `.env.example` to document these configuration vectors for infrastructure.
- **Comprehensive Tests**: Added focused unit tests covering local development, trusted headers, conflicting headers, and malformed path-injection values.

## Testing
- Added and ran unit tests to verify safe validation behaviors: `pnpm test web/src/lib/__tests__/public-url.test.ts`.
- Confirmed the utility falls back to `APP_URL` if an attacker-controlled Host is supplied (untrusted headers are rejected safely without data leakage).
- Verified that comma-separated ambiguous host headers are strictly rejected by throwing an exception.

Closes #461
