### PR TITLE
feat: implement version registry and name-service event metadata (#403)

### DIFF
--- a/contracts/EVENTS.md
+++ b/contracts/EVENTS.md
@@ -51,6 +51,7 @@ is idempotent per cursor (see §4).
 | topics | data | meaning |
 |---|---|---|
 | (`tls_crt`, creator: Address) | (talos_id: u32, name: String, category: String) | new Talos registered |
+| (`tls_crt2`, creator: Address) | (version: u32, talos_id: u32, name: String, category: String) | new Talos registered (v2) |
 | (`pat_upd`, talos_id: u32) | (creator_addr: Address, creator_share: u32, investor_share: u32) | patron split changed |
 | (`fee_chg`,) | (old_bps: u32, new_bps: u32) | protocol fee changed |
 | (`adm_prp`,) | (current: Address, proposed: Address) | admin transfer proposed |
@@ -72,6 +73,7 @@ is idempotent per cursor (see §4).
 | topics | data |
 |---|---|
 | (`name_reg`, talos_id: u32) | (name: String, owner: Address) |
+| (`name_reg2`, talos_id: u32) | (version: u32, name: String, owner: Address) |
 | (`reg_upd`,) | (old_registry: Address, new_registry: Address) |
 | (`tl_sch`/`tl_exec`/`tl_cnl`/`tl_cfg`) | same shape as registry timelock events |
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -21,7 +21,7 @@ See [EVENTS.md](./EVENTS.md) for the full contract event indexing specification.
   - **Version negotiation** (`supports_version(maj, min, patch)`)
   - **Capability catalogue** (`interface_features()` returns `Vec<Symbol>`)
   - **Deprecation telemetry** (`dep_path` event emitted before panic when timelock is enabled)
-  - Events: `tls_crt`, `pat_upd`, `fee_chg`, `adm_prp`, `adm_acc`, `adm_cnl`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `dep_path`
+  - Events: `tls_crt`, `tls_crt2`, `pat_upd`, `fee_chg`, `adm_prp`, `adm_acc`, `adm_cnl`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `dep_path`
 
 ### 2. TalosNameService
 - **Purpose**: Human-readable name registration for Talos IDs
@@ -36,7 +36,7 @@ See [EVENTS.md](./EVENTS.md) for the full contract event indexing specification.
   - **Capability catalogue** (`interface_features()` returns `Vec<Symbol>`)
   - **Cross-contract compatibility** (`assert_registry_compatible()` cross-invokes Registry's `interface_id` + `version`)
   - **Deprecation telemetry** (`dep_path` event emitted before panic when timelock is enabled)
-  - Events: `name_reg`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `dep_path`, `compat_ok`, `compat_err`
+  - Events: `name_reg`, `name_reg2`, `tl_sch`, `tl_exec`, `tl_cnl`, `tl_cfg`, `dep_path`, `compat_ok`, `compat_err`
 
 ### 3. TalosGovernance
 - **Purpose**: Token-weighted governance for Talos Protocol
@@ -391,6 +391,7 @@ Both contracts emit typed Soroban events on every meaningful state change. Off-c
 | Event | Topics | Data | Emitted on |
 |-------|--------|------|-----------| 
 | `tls_crt` | `(symbol_short!("tls_crt"), creator: Address)` | `(talos_id: u32, name: String, category: String)` | `create_talos` success |
+| `tls_crt2` | `(symbol_short!("tls_crt2"), creator: Address)` | `(version: u32, talos_id: u32, name: String, category: String)` | `create_talos` success (v2) |
 | `pat_upd` | `(symbol_short!("pat_upd"), talos_id: u32)` | `(creator: Address, creator_share: u32, investor_share: u32)` | `update_patron` success |
 | `fee_chg` | `(symbol_short!("fee_chg"),)` | `(old_bps: u32, new_bps: u32)` | `set_protocol_fee` or timelock execution |
 | `adm_prp` | `(symbol_short!("adm_prp"),)` | `(current: Address, proposed: Address)` | `propose_admin` or timelock execution |
@@ -428,6 +429,7 @@ Both contracts emit typed Soroban events on every meaningful state change. Off-c
 | Event | Topics | Data | Emitted on |
 |-------|--------|------|-----------| 
 | `name_reg` | `(symbol_short!("name_reg"), talos_id: u32)` | `(name: String, owner: Address)` | `register_name` success |
+| `name_reg2` | `(symbol_short!("name_reg2"), talos_id: u32)` | `(version: u32, name: String, owner: Address)` | `register_name` success (v2) |
 | `reg_upd`  | `(symbol_short!("reg_upd"),)` | `(old_registry: Address, new_registry: Address)` | registry pointer update |
 | `tl_sch`   | `(symbol_short!("tl_sch"), proposal_id: u64)` | `(action: AdminAction, eta: u64, proposer: Address)` | `schedule_action` success |
 | `tl_exec`  | `(symbol_short!("tl_exec"), proposal_id: u64)` | `(action: AdminAction, executor: Address)` | `execute_action` success |

--- a/contracts/fixtures/event-query.test.ts
+++ b/contracts/fixtures/event-query.test.ts
@@ -21,6 +21,7 @@ import {
   UnboundedPageSizeError,
   MalformedEventError,
   UnknownEventError,
+  UnsupportedVersionError,
   type EventFixture,
   type FixtureSet,
 } from "./event-query";
@@ -145,8 +146,8 @@ describe("bounded querying", () => {
       toLedger: 100020,
       pageSize: 10,
     });
-    expect(result.total).toBe(3);
-    expect(result.events.map((e) => e.event).sort()).toEqual(["pat_upd", "reg_upd", "tls_crt"]);
+    expect(result.total).toBe(4);
+    expect(result.events.map((e) => e.event).sort()).toEqual(["pat_upd", "reg_upd", "tls_crt", "tls_crt2"]);
   });
 
   it("treats ledger bounds as inclusive on both ends", () => {
@@ -310,6 +311,12 @@ describe("malformed payloads", () => {
         set,
       ),
     ).toThrow(UnknownEventError);
+  });
+
+  it("rejects an unsupported version", () => {
+    const fixture = set.malformed.find((m) => m.id === "malformed.unsupported_version");
+    expect(fixture).toBeDefined();
+    expect(() => parseEventFixture(fixture!.fixture, set)).toThrow(UnsupportedVersionError);
   });
 });
 

--- a/contracts/fixtures/event-query.ts
+++ b/contracts/fixtures/event-query.ts
@@ -109,6 +109,9 @@ export class UnknownEventError extends EventQueryError {}
 /** Event payload does not match its catalog entry (topics/data shape). */
 export class MalformedEventError extends EventQueryError {}
 
+/** Event payload has an unsupported version field. */
+export class UnsupportedVersionError extends EventQueryError {}
+
 export class UnboundedRangeError extends EventQueryError {}
 export class UnboundedPageSizeError extends EventQueryError {}
 
@@ -284,6 +287,12 @@ function decodeData(set: FixtureSet, family: EventFamily, event: string, data: S
   entry.data.forEach((field, i) => {
     out[field.name ?? `data${i}`] = data[i].value;
   });
+
+  // Reject unsupported versions explicitly to prevent mis-decoding
+  if (out.version !== undefined && typeof out.version === 'number' && out.version > 1) {
+    fail(UnsupportedVersionError, `event ${event}: unsupported version ${out.version}`);
+  }
+
   return out;
 }
 

--- a/contracts/fixtures/event_fixtures.json
+++ b/contracts/fixtures/event_fixtures.json
@@ -20,6 +20,19 @@
           { "position": 1, "type": "string", "name": "name" },
           { "position": 2, "type": "string", "name": "category" }
         ]
+      },
+      "tls_crt2": {
+        "contract": "talos_registry",
+        "topics": [
+          { "position": 0, "type": "symbol", "name": "event", "description": "event type symbol" },
+          { "position": 1, "type": "address", "name": "creator", "description": "address that created the Talos" }
+        ],
+        "data": [
+          { "position": 0, "type": "u32", "name": "version" },
+          { "position": 1, "type": "u32", "name": "talos_id" },
+          { "position": 2, "type": "string", "name": "name" },
+          { "position": 3, "type": "string", "name": "category" }
+        ]
       }
     },
     "update": {
@@ -133,6 +146,32 @@
         "ledger_sequence": 100000,
         "topics": { "event": "tls_crt", "creator": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" },
         "data": { "talos_id": 1, "name": "Genesis", "category": "Marketing" }
+      }
+    },
+    {
+      "id": "creation.tls_crt2.normal",
+      "family": "creation",
+      "event": "tls_crt2",
+      "contract": "talos_registry",
+      "ledger_sequence": 100000,
+      "tx_hash": "a1b2c3d4e5f60718293a4b5c6d7e8f901112131415161718192a2b2c3d4e5f60",
+      "event_index_in_tx": 1,
+      "topics": [
+        { "type": "symbol", "value": "tls_crt2" },
+        { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" }
+      ],
+      "data": [
+        { "type": "u32", "value": 1 },
+        { "type": "u32", "value": 1 },
+        { "type": "string", "value": "Genesis" },
+        { "type": "string", "value": "Marketing" }
+      ],
+      "decoded": {
+        "event": "tls_crt2",
+        "contract": "talos_registry",
+        "ledger_sequence": 100000,
+        "topics": { "event": "tls_crt2", "creator": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" },
+        "data": { "version": 1, "talos_id": 1, "name": "Genesis", "category": "Marketing" }
       }
     },
     {
@@ -399,6 +438,27 @@
         ],
         "data": [
           { "type": "string", "value": "not-a-number" },
+          { "type": "string", "value": "Genesis" },
+          { "type": "string", "value": "Marketing" }
+        ]
+      }
+    },
+    {
+      "id": "malformed.unsupported_version",
+      "reason": "version field contains an unsupported value (> 1)",
+      "fixture": {
+        "id": "malformed.unsupported_version.fixture",
+        "family": "creation",
+        "event": "tls_crt2",
+        "contract": "talos_registry",
+        "ledger_sequence": 6,
+        "topics": [
+          { "type": "symbol", "value": "tls_crt2" },
+          { "type": "address", "value": "GDC2TFRPZ3SJJYE2GDOIVHVGU3J7RZ7WCDIGKNZC4OY4CCIY7JK5JGYZ" }
+        ],
+        "data": [
+          { "type": "u32", "value": 2 },
+          { "type": "u32", "value": 1 },
           { "type": "string", "value": "Genesis" },
           { "type": "string", "value": "Marketing" }
         ]

--- a/contracts/talos_name_service/src/lib.rs
+++ b/contracts/talos_name_service/src/lib.rs
@@ -139,7 +139,10 @@ pub enum ContractError {
 
 fn emit_name_registered(env: &Env, talos_id: u32, name: String, owner: Address) {
     let topics = (symbol_short!("name_reg"), talos_id);
-    env.events().publish(topics, (name, owner));
+    env.events().publish(topics, (name.clone(), owner.clone()));
+
+    let topics2 = (symbol_short!("name_reg2"), talos_id);
+    env.events().publish(topics2, (1u32, name, owner));
 }
 
 fn emit_registry_updated(env: &Env, old_registry: Address, new_registry: Address) {
@@ -2262,17 +2265,32 @@ mod tests {
             .iter()
             .filter(|e| e.0 == contract_id)
             .collect::<std::vec::Vec<_>>();
-        assert_eq!(events.len(), 1);
-        let (_addr, topics, data) = events.get(0).unwrap();
-        assert_eq!(topics.len() as u32, 2);
-        let t0: Symbol = TryFromVal::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
-        let t1: u32 = TryFromVal::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
-        assert_eq!(t0, symbol_short!("name_reg"));
-        assert_eq!(t1, talos_id);
-        let (got_name, got_owner): (String, Address) =
-            TryFromVal::try_from_val(&env, data).unwrap();
-        assert_eq!(got_name, name);
-        assert_eq!(got_owner, owner);
+        assert_eq!(events.len(), 2);
+        
+        // Assert name_reg
+        let (_addr1, topics1, data1) = events.get(0).unwrap();
+        assert_eq!(topics1.len() as u32, 2);
+        let t0_1: Symbol = TryFromVal::try_from_val(&env, &topics1.get(0).unwrap()).unwrap();
+        let t1_1: u32 = TryFromVal::try_from_val(&env, &topics1.get(1).unwrap()).unwrap();
+        assert_eq!(t0_1, symbol_short!("name_reg"));
+        assert_eq!(t1_1, talos_id);
+        let (got_name1, got_owner1): (String, Address) =
+            TryFromVal::try_from_val(&env, data1).unwrap();
+        assert_eq!(got_name1, name);
+        assert_eq!(got_owner1, owner);
+
+        // Assert name_reg2
+        let (_addr2, topics2, data2) = events.get(1).unwrap();
+        assert_eq!(topics2.len() as u32, 2);
+        let t0_2: Symbol = TryFromVal::try_from_val(&env, &topics2.get(0).unwrap()).unwrap();
+        let t1_2: u32 = TryFromVal::try_from_val(&env, &topics2.get(1).unwrap()).unwrap();
+        assert_eq!(t0_2, symbol_short!("name_reg2"));
+        assert_eq!(t1_2, talos_id);
+        let (got_version2, got_name2, got_owner2): (u32, String, Address) =
+            TryFromVal::try_from_val(&env, data2).unwrap();
+        assert_eq!(got_version2, 1);
+        assert_eq!(got_name2, name);
+        assert_eq!(got_owner2, owner);
     }
 
     #[test]

--- a/contracts/talos_registry/src/lib.rs
+++ b/contracts/talos_registry/src/lib.rs
@@ -178,8 +178,11 @@ pub enum DataKey {
 //                                                  Reasons callers hit a deprecated path.
 
 fn emit_talos_created(env: &Env, talos_id: u32, creator: Address, name: String, category: String) {
-    let topics = (symbol_short!("tls_crt"), creator);
-    env.events().publish(topics, (talos_id, name, category));
+    let topics = (symbol_short!("tls_crt"), creator.clone());
+    env.events().publish(topics, (talos_id, name.clone(), category.clone()));
+
+    let topics2 = (symbol_short!("tls_crt2"), creator);
+    env.events().publish(topics2, (1u32, talos_id, name, category));
 }
 
 fn emit_patron_updated(env: &Env, talos_id: u32, patron: &Patron) {
@@ -2144,19 +2147,34 @@ mod tests {
         let id = create_talos_with_auth(&env, &client, &contract_id, &creator, &protocol_wallet);
 
         let events = env.events().all();
-        assert_eq!(events.len(), 1);
-        let (addr, topics, data) = events.get(0).unwrap();
+        assert_eq!(events.len(), 2);
+        
+        // Assert tls_crt
+        let (addr1, topics1, data1) = events.get(0).unwrap();
+        assert_eq!(addr1, contract_id);
+        assert_eq!(topics1.len(), 2);
+        assert_topic_symbol(&env, &topics1, 0, symbol_short!("tls_crt"));
+        assert_topic_address(&env, &topics1, 1, &creator);
 
-        assert_eq!(addr, contract_id);
-        assert_eq!(topics.len(), 2);
-        assert_topic_symbol(&env, &topics, 0, symbol_short!("tls_crt"));
-        assert_topic_address(&env, &topics, 1, &creator);
+        let (got_id1, got_name1, got_cat1): (u32, String, String) =
+            TryFromVal::try_from_val(&env, &data1).unwrap();
+        assert_eq!(got_id1, id);
+        assert_eq!(got_name1, s(&env, "Genesis"));
+        assert_eq!(got_cat1, s(&env, "Marketing"));
 
-        let (got_id, got_name, got_cat): (u32, String, String) =
-            TryFromVal::try_from_val(&env, &data).unwrap();
-        assert_eq!(got_id, id);
-        assert_eq!(got_name, s(&env, "Genesis"));
-        assert_eq!(got_cat, s(&env, "Marketing"));
+        // Assert tls_crt2
+        let (addr2, topics2, data2) = events.get(1).unwrap();
+        assert_eq!(addr2, contract_id);
+        assert_eq!(topics2.len(), 2);
+        assert_topic_symbol(&env, &topics2, 0, symbol_short!("tls_crt2"));
+        assert_topic_address(&env, &topics2, 1, &creator);
+
+        let (got_version2, got_id2, got_name2, got_cat2): (u32, u32, String, String) =
+            TryFromVal::try_from_val(&env, &data2).unwrap();
+        assert_eq!(got_version2, 1);
+        assert_eq!(got_id2, id);
+        assert_eq!(got_name2, s(&env, "Genesis"));
+        assert_eq!(got_cat2, s(&env, "Marketing"));
     }
 
     #[test]
@@ -2188,10 +2206,10 @@ mod tests {
             }])
             .update_patron(&id, &new_patron);
 
-        // tls_crt from create_talos + pat_upd from update_patron
+        // tls_crt and tls_crt2 from create_talos + pat_upd from update_patron
         let events = env.events().all();
-        assert_eq!(events.len(), 2);
-        let (addr, topics, data) = events.get(1).unwrap();
+        assert_eq!(events.len(), 3);
+        let (addr, topics, data) = events.get(2).unwrap();
 
         assert_eq!(addr, contract_id);
         assert_eq!(topics.len(), 2);


### PR DESCRIPTION
- Dual emit `tls_crt2` and `name_reg2` events with schema version alongside old events
- Add `UnsupportedVersionError` to off-chain TypeScript parser
- Update event fixtures and tests to verify decoding and rejection of unsupported versions
- Document new events and fix `fee_chg` table formatting in `README.md`

## Summary

This PR addresses the need for the on-chain event consumers to be resilient to future contract schema changes without breaking the existing indexing infrastructure. It implements a dual-emission strategy for the `talos_registry` and `talos_name_service` contracts, where version-aware events (`tls_crt2` and `name_reg2`) are now emitted alongside the original `tls_crt` and `name_reg` events. A new `version` field (`u32`) was explicitly added to these v2 payloads. 

Furthermore, strict rejection handling (`UnsupportedVersionError`) was added to the TypeScript off-chain decoder in `event-query.ts` to ensure that it explicitly rejects any event version it doesn't recognize rather than attempting to decode it with outdated schema logic.

## Related Issues

Closes #403

## Test Plan

- [x] Automated tests run:
  - `cargo test` executed in `contracts/talos_registry` (76/76 tests passing).
  - `cargo test` executed in `contracts/talos_name_service` (42/42 tests passing).
  - `pnpm --dir contracts test:fixtures` executed (36/36 tests passing).
- [x] Manual verification steps performed:
  - 1. Hand-crafted a malformed event fixture with an unsupported version (`version: 2`) inside `event_fixtures.json`.
  - 2. Verified that the TypeScript indexer correctly throws an `UnsupportedVersionError` when iterating over the new malformed fixture.
- [x] Relevant docs updated when setup, environment variables, or workflows changed (Updated `README.md` and `EVENTS.md` with new schema properties).

## Visual Changes (if applicable)

N/A (Backend / Smart Contract event schema updates only)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [ ] I have updated `.env.example` files and documentation if I changed environment variables.
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
