### PR TITLE
ci: add Python and Web/SDK CI workflows, fix ruff errors

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,48 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/prime-agent/**'
+      - '.github/workflows/python-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/prime-agent/**'
+      - '.github/workflows/python-ci.yml'
+
+jobs:
+  lint-and-test:
+    name: Ruff Lint & Pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/prime-agent
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: packages/prime-agent/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Ruff lint
+        run: uv run ruff check src/
+
+      - name: Ruff format check
+        run: uv run ruff format --check src/
+
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/web-sdk-ci.yml
+++ b/.github/workflows/web-sdk-ci.yml
@@ -1,0 +1,77 @@
+name: Web & SDK CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/sdk/**'
+      - 'web/**'
+      - '.github/workflows/web-sdk-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/sdk/**'
+      - 'web/**'
+      - '.github/workflows/web-sdk-ci.yml'
+
+jobs:
+  sdk:
+    name: SDK – Type-check, Lint & Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/sdk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          pnpm-cache: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: TypeScript type-check (ESM)
+        run: pnpm build:esm
+
+      - name: Run tests
+        run: pnpm test
+
+  web:
+    name: Web – Type-check, Lint & Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          pnpm-cache: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: TypeScript type-check
+        run: pnpm tsc --noEmit
+
+      - name: ESLint
+        run: pnpm lint
+
+      - name: Run unit tests
+        run: pnpm test:unit

--- a/packages/prime-agent/src/talos_agent/agent/loop.py
+++ b/packages/prime-agent/src/talos_agent/agent/loop.py
@@ -31,7 +31,6 @@ from talos_agent.agent.prompt import build_system_prompt
 from talos_agent.http import call_with_retry
 from talos_agent.routing import (
     FallbackChain,
-    ProviderRegistry,
     RoutingConstraints,
     RoutingPolicy,
     UsageTracker,
@@ -232,8 +231,6 @@ async def _routed_agent_loop(
             f"[dim]Router: {decision.provider_name}/{decision.model} "
             f"(score={decision.score:.2f})[/dim]"
         )
-
-        provider = registry.get(decision.provider_name)
 
         # Define the completion operation for fallback
         async def _complete(

--- a/packages/prime-agent/src/talos_agent/routing/policy.py
+++ b/packages/prime-agent/src/talos_agent/routing/policy.py
@@ -25,18 +25,13 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 from talos_agent.routing.provider import (
     ProviderCapabilities,
     ProviderMetadata,
     ProviderRegistry,
-    ProviderStatus,
     TaskType,
 )
-
-if TYPE_CHECKING:
-    from talos_agent.routing.provider import LLMProvider
 
 logger = logging.getLogger(__name__)
 

--- a/packages/prime-agent/src/talos_agent/routing/provider.py
+++ b/packages/prime-agent/src/talos_agent/routing/provider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Any

--- a/packages/prime-agent/src/talos_agent/routing/usage.py
+++ b/packages/prime-agent/src/talos_agent/routing/usage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Callable
 


### PR DESCRIPTION
## Summary
Add CI workflows for Python and Web/SDK packages to catch regressions before deployment.

## What was implemented

### Python CI ()
- Runs on pushes to  and PRs affecting 
- Uses  for dependency management with caching
- **Ruff lint**: Checks Python code style and catches common errors
- **Ruff format**: Verifies code formatting
- **Pytest**: Runs unit tests with verbose output

### Web/SDK CI ()
- Runs on pushes to  and PRs affecting  or 
- Uses Version 11.8.0
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

These are common pnpm commands used in various situations, use 'pnpm help -a' to list all commands

Manage your dependencies:
      add                  Installs a package and any packages that it depends
                           on. By default, any new package is installed as a
                           prod dependency
   i, install              Install all dependencies for a project
  ln, link                 Connect the local project to another one
  rm, remove               Removes packages from node_modules and from the
                           project's package.json
      unlink               Unlinks a package. Like yarn unlink but pnpm
                           re-installs the dependency after removing the
                           external link
  up, update               Updates packages to their latest version based on the
                           specified range

Review your dependencies:
      audit                Checks for known security issues with the installed
                           packages
  ls, list                 Print all the versions of packages that are
                           installed, as well as their dependencies, in a
                           tree-structure
      outdated             Check for outdated packages
      why                  Shows all packages that depend on the specified
                           package

Run your scripts:
      create               Create a project from a "create-*" or "@foo/create-*"
                           starter kit
      dlx                  Fetches a package from the registry without
                           installing it as a dependency, hot loads it, and runs
                           whatever default command binary it exposes
      exec                 Executes a shell command in scope of a project
      run                  Runs a defined package script

Other:
   c, config               Manage the pnpm configuration files
      init                 Create a package.json file
      publish              Publishes a package to the registry
      stage                Stage packages for publishing

Options:
  -r, --recursive          Run the command for each project in the workspace. with dependency caching

**SDK job:**
- TypeScript type-check via Scope: all 4 workspace projects
? Verifying lockfile against supply-chain policies (1342 entries)...
Lockfile is up to date, resolution step is skipped
Already up to date

   ╭───────────────────────────────────────────────╮
   │                                               │
   │      Update available! 11.8.0 → 11.25.0.      │
   │     Changelog: https://pnpm.io/v/11.25.0      │
   │   To update, run: corepack use pnpm@11.25.0   │
   │                                               │
   ╰───────────────────────────────────────────────╯

## Acceptance Criteria
- [x] Jobs run on pull requests and pushes to main
- [x] No production secrets required
- [x] Documented local commands match CI gates
- [x] SDK type-check is a real required failure (no )
- [x] Ruff checks pass with green output
- [x] Path filters ensure fast CI for unrelated changes

## Local Commands
```bash
# Python (prime-agent)
cd packages/prime-agent
uv sync --dev
uv run ruff check src/
uv run ruff format --check src/
uv run pytest tests/ -v

# SDK
cd packages/sdk
pnpm install
pnpm build:esm  # type-check
pnpm test

# Web
cd web
pnpm install
pnpm tsc --noEmit  # type-check
pnpm lint
pnpm test:unit
```

Closes #402